### PR TITLE
feat(auth): ajouter la suppression de compte conforme au RGPD

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,7 @@ Config : `backend/sqlc.yaml` — schéma lu depuis `migrations/*.up.sql`.
 | POST | `/api/auth/logout` | `Handler.Logout` | Oui (JWT) |
 | POST | `/api/auth/forgot-password` | `Handler.ForgotPassword` | Non |
 | POST | `/api/auth/reset-password` | `Handler.ResetPassword` | Non |
+| DELETE | `/api/auth/me` | `Handler.DeleteAccount` | Oui (JWT) |
 
 ### Documentation OpenAPI
 

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -61,7 +61,7 @@ func run() error {
 	authRepo := auth.NewRepository(pool)
 	mailer := email.NewFromConfig(cfg)
 	authSvc := auth.NewService(authRepo, cfg.JWTSecret, mailer)
-	authHandler := auth.NewHandler(authSvc, authSvc, authSvc, authSvc, authSvc, authSvc)
+	authHandler := auth.NewHandler(authSvc, authSvc, authSvc, authSvc, authSvc, authSvc, authSvc)
 
 	profilesRepo := profiles.NewRepository(pool)
 	profilesSvc := profiles.NewService(profilesRepo)
@@ -88,6 +88,7 @@ func run() error {
 	mux.Handle("/api/auth/logout", auth.RequireAuth(cfg.JWTSecret, http.HandlerFunc(authHandler.Logout)))
 	mux.HandleFunc("/api/auth/forgot-password", authHandler.ForgotPassword)
 	mux.HandleFunc("/api/auth/reset-password", authHandler.ResetPassword)
+	mux.Handle("/api/auth/me", auth.RequireAuth(cfg.JWTSecret, http.HandlerFunc(authHandler.DeleteAccount)))
 
 	mux.Handle("/api/users/me", auth.RequireAuth(cfg.JWTSecret, http.HandlerFunc(profilesHandler.Me)))
 	// Documentation OpenAPI (Swagger UI + spec brute) — exposée hors production

--- a/backend/internal/auth/db/auth.sql.go
+++ b/backend/internal/auth/db/auth.sql.go
@@ -63,6 +63,15 @@ func (q *Queries) DeleteRefreshToken(ctx context.Context, tokenHash string) (pgc
 	return q.db.Exec(ctx, deleteRefreshToken, tokenHash)
 }
 
+const deleteUserByID = `-- name: DeleteUserByID :exec
+DELETE FROM users WHERE id = $1::uuid
+`
+
+func (q *Queries) DeleteUserByID(ctx context.Context, userID pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, deleteUserByID, userID)
+	return err
+}
+
 const getUserByEmail = `-- name: GetUserByEmail :one
 SELECT id::text, email, username, role, created_at, password_hash
 FROM users
@@ -81,6 +90,35 @@ type GetUserByEmailRow struct {
 func (q *Queries) GetUserByEmail(ctx context.Context, email string) (GetUserByEmailRow, error) {
 	row := q.db.QueryRow(ctx, getUserByEmail, email)
 	var i GetUserByEmailRow
+	err := row.Scan(
+		&i.ID,
+		&i.Email,
+		&i.Username,
+		&i.Role,
+		&i.CreatedAt,
+		&i.PasswordHash,
+	)
+	return i, err
+}
+
+const getUserByID = `-- name: GetUserByID :one
+SELECT id::text, email, username, role, created_at, password_hash
+FROM users
+WHERE id = $1::uuid AND is_active = true
+`
+
+type GetUserByIDRow struct {
+	ID           string
+	Email        string
+	Username     string
+	Role         string
+	CreatedAt    time.Time
+	PasswordHash string
+}
+
+func (q *Queries) GetUserByID(ctx context.Context, userID pgtype.UUID) (GetUserByIDRow, error) {
+	row := q.db.QueryRow(ctx, getUserByID, userID)
+	var i GetUserByIDRow
 	err := row.Scan(
 		&i.ID,
 		&i.Email,

--- a/backend/internal/auth/handler.go
+++ b/backend/internal/auth/handler.go
@@ -258,11 +258,6 @@ func (h *Handler) DeleteAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.Password == "" {
-		httpjson.WriteError(w, r, apperror.InvalidArgument("password required"))
-		return
-	}
-
 	userID, ok := UserIDFromContext(r.Context())
 	if !ok {
 		httpjson.WriteError(w, r, apperror.Unauthorized("unauthenticated"))

--- a/backend/internal/auth/handler.go
+++ b/backend/internal/auth/handler.go
@@ -15,6 +15,7 @@ const (
 	maxRefreshBodyBytes        = 1 << 20
 	maxForgotPasswordBodyBytes = 1 << 20
 	maxResetPasswordBodyBytes  = 1 << 20
+	maxDeleteAccountBodyBytes  = 1 << 20
 )
 
 type registerRequest struct {
@@ -45,6 +46,10 @@ type resetPasswordRequest struct {
 	Password string `json:"password"`
 }
 
+type deleteAccountRequest struct {
+	Password string `json:"password"`
+}
+
 type Registrar interface {
 	Register(ctx context.Context, in RegisterInput) (User, error)
 }
@@ -69,6 +74,10 @@ type PasswordResetExecutor interface {
 	ResetPassword(ctx context.Context, in ResetPasswordInput) error
 }
 
+type AccountDeleter interface {
+	DeleteAccount(ctx context.Context, in DeleteAccountInput) error
+}
+
 type Handler struct {
 	svc           Registrar
 	authenticator Authenticator
@@ -76,10 +85,11 @@ type Handler struct {
 	logouter      Logouter
 	resetter      PasswordResetter
 	executor      PasswordResetExecutor
+	deleter       AccountDeleter
 }
 
-func NewHandler(svc Registrar, authenticator Authenticator, refresher TokenRefresher, logouter Logouter, resetter PasswordResetter, executor PasswordResetExecutor) *Handler {
-	return &Handler{svc: svc, authenticator: authenticator, refresher: refresher, logouter: logouter, resetter: resetter, executor: executor}
+func NewHandler(svc Registrar, authenticator Authenticator, refresher TokenRefresher, logouter Logouter, resetter PasswordResetter, executor PasswordResetExecutor, deleter AccountDeleter) *Handler {
+	return &Handler{svc: svc, authenticator: authenticator, refresher: refresher, logouter: logouter, resetter: resetter, executor: executor, deleter: deleter}
 }
 
 func (h *Handler) Register(w http.ResponseWriter, r *http.Request) {
@@ -233,4 +243,36 @@ func (h *Handler) ResetPassword(w http.ResponseWriter, r *http.Request) {
 	}); err != nil {
 		log.Printf("auth: encode reset-password response: %v", err)
 	}
+}
+
+func (h *Handler) DeleteAccount(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		w.Header().Set("Allow", http.MethodDelete)
+		httpjson.WriteError(w, r, httpjson.StatusError(http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed"))
+		return
+	}
+
+	var req deleteAccountRequest
+	if err := httpjson.Decode(w, r, &req, maxDeleteAccountBodyBytes); err != nil {
+		httpjson.WriteError(w, r, err)
+		return
+	}
+
+	if req.Password == "" {
+		httpjson.WriteError(w, r, apperror.InvalidArgument("password required"))
+		return
+	}
+
+	userID, ok := UserIDFromContext(r.Context())
+	if !ok {
+		httpjson.WriteError(w, r, apperror.Unauthorized("unauthenticated"))
+		return
+	}
+
+	if err := h.deleter.DeleteAccount(r.Context(), DeleteAccountInput{UserID: userID, Password: req.Password}); err != nil {
+		httpjson.WriteError(w, r, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/backend/internal/auth/handler_test.go
+++ b/backend/internal/auth/handler_test.go
@@ -53,10 +53,27 @@ type stubExecutor struct{ err error }
 
 func (s *stubExecutor) ResetPassword(_ context.Context, _ ResetPasswordInput) error { return s.err }
 
+type stubAccountDeleter struct{ err error }
+
+func (s *stubAccountDeleter) DeleteAccount(_ context.Context, _ DeleteAccountInput) error {
+	return s.err
+}
+
 func post(t *testing.T, path, body string) *http.Request {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func deleteReq(t *testing.T, path, body, userID string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodDelete, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	if userID != "" {
+		ctx := context.WithValue(req.Context(), contextKeyUserID, userID)
+		req = req.WithContext(ctx)
+	}
 	return req
 }
 
@@ -79,7 +96,7 @@ func TestHandler_Register_Created(t *testing.T) {
 		ID: "1", Email: "alice@example.com", Username: "alice", Role: "user", CreatedAt: time.Now(),
 	}}
 	rec := httptest.NewRecorder()
-	NewHandler(stub, nil, nil, nil, nil, nil).Register(rec, post(t, "/api/auth/register",
+	NewHandler(stub, nil, nil, nil, nil, nil, nil).Register(rec, post(t, "/api/auth/register",
 		`{"email":"alice@example.com","username":"alice","password":"hunter2hunter"}`))
 
 	if rec.Code != http.StatusCreated {
@@ -92,7 +109,7 @@ func TestHandler_Register_Created(t *testing.T) {
 
 func TestHandler_Register_InvalidJSON(t *testing.T) {
 	rec := httptest.NewRecorder()
-	NewHandler(&stubRegistrar{}, nil, nil, nil, nil, nil).Register(rec, post(t, "/api/auth/register", `{"email":`))
+	NewHandler(&stubRegistrar{}, nil, nil, nil, nil, nil, nil).Register(rec, post(t, "/api/auth/register", `{"email":`))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("want 400, got %d", rec.Code)
 	}
@@ -100,7 +117,7 @@ func TestHandler_Register_InvalidJSON(t *testing.T) {
 
 func TestHandler_Register_Conflict(t *testing.T) {
 	rec := httptest.NewRecorder()
-	NewHandler(&stubRegistrar{err: apperror.Conflict("email or username already taken")}, nil, nil, nil, nil, nil).Register(
+	NewHandler(&stubRegistrar{err: apperror.Conflict("email or username already taken")}, nil, nil, nil, nil, nil, nil).Register(
 		rec, post(t, "/api/auth/register", `{"email":"a@b.co","username":"a","password":"hunter2hunter"}`))
 	if rec.Code != http.StatusConflict {
 		t.Fatalf("want 409, got %d", rec.Code)
@@ -110,7 +127,7 @@ func TestHandler_Register_Conflict(t *testing.T) {
 func TestHandler_Register_MethodNotAllowed(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/auth/register", nil)
-	NewHandler(&stubRegistrar{}, nil, nil, nil, nil, nil).Register(rec, req)
+	NewHandler(&stubRegistrar{}, nil, nil, nil, nil, nil, nil).Register(rec, req)
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("want 405, got %d", rec.Code)
 	}
@@ -118,7 +135,7 @@ func TestHandler_Register_MethodNotAllowed(t *testing.T) {
 
 func TestHandler_Register_InternalError(t *testing.T) {
 	rec := httptest.NewRecorder()
-	NewHandler(&stubRegistrar{err: errors.New("boom")}, nil, nil, nil, nil, nil).Register(
+	NewHandler(&stubRegistrar{err: errors.New("boom")}, nil, nil, nil, nil, nil, nil).Register(
 		rec, post(t, "/api/auth/register", `{"email":"a@b.co","username":"a","password":"hunter2hunter"}`))
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("want 500, got %d", rec.Code)
@@ -128,7 +145,7 @@ func TestHandler_Register_InternalError(t *testing.T) {
 func TestHandler_Login_OK(t *testing.T) {
 	stub := &stubAuthenticator{pair: TokenPair{AccessToken: "acc", RefreshToken: "ref"}}
 	rec := httptest.NewRecorder()
-	NewHandler(nil, stub, nil, nil, nil, nil).Login(rec, post(t, "/api/auth/login",
+	NewHandler(nil, stub, nil, nil, nil, nil, nil).Login(rec, post(t, "/api/auth/login",
 		`{"email":"alice@example.com","password":"hunter2hunter"}`))
 
 	if rec.Code != http.StatusOK {
@@ -138,7 +155,7 @@ func TestHandler_Login_OK(t *testing.T) {
 
 func TestHandler_Login_Unauthorized(t *testing.T) {
 	rec := httptest.NewRecorder()
-	NewHandler(nil, &stubAuthenticator{err: apperror.Unauthorized("invalid credentials")}, nil, nil, nil, nil).Login(
+	NewHandler(nil, &stubAuthenticator{err: apperror.Unauthorized("invalid credentials")}, nil, nil, nil, nil, nil).Login(
 		rec, post(t, "/api/auth/login", `{"email":"a@b.co","password":"wrong"}`))
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("want 401, got %d", rec.Code)
@@ -152,7 +169,7 @@ func TestHandler_Login_Unauthorized(t *testing.T) {
 func TestHandler_Refresh_OK(t *testing.T) {
 	stub := &stubRefresher{pair: TokenPair{AccessToken: "new-acc", RefreshToken: "new-ref"}}
 	rec := httptest.NewRecorder()
-	NewHandler(nil, nil, stub, nil, nil, nil).Refresh(rec, post(t, "/api/auth/refresh", `{"refresh_token":"old"}`))
+	NewHandler(nil, nil, stub, nil, nil, nil, nil).Refresh(rec, post(t, "/api/auth/refresh", `{"refresh_token":"old"}`))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body)
 	}
@@ -160,7 +177,7 @@ func TestHandler_Refresh_OK(t *testing.T) {
 
 func TestHandler_Refresh_MissingToken(t *testing.T) {
 	rec := httptest.NewRecorder()
-	NewHandler(nil, nil, &stubRefresher{}, nil, nil, nil).Refresh(rec, post(t, "/api/auth/refresh", `{"refresh_token":""}`))
+	NewHandler(nil, nil, &stubRefresher{}, nil, nil, nil, nil).Refresh(rec, post(t, "/api/auth/refresh", `{"refresh_token":""}`))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("want 400, got %d", rec.Code)
 	}
@@ -168,7 +185,7 @@ func TestHandler_Refresh_MissingToken(t *testing.T) {
 
 func TestHandler_Refresh_Unauthorized(t *testing.T) {
 	rec := httptest.NewRecorder()
-	NewHandler(nil, nil, &stubRefresher{err: apperror.Unauthorized("invalid or expired refresh token")}, nil, nil, nil).Refresh(
+	NewHandler(nil, nil, &stubRefresher{err: apperror.Unauthorized("invalid or expired refresh token")}, nil, nil, nil, nil).Refresh(
 		rec, post(t, "/api/auth/refresh", `{"refresh_token":"expired"}`))
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("want 401, got %d", rec.Code)
@@ -179,7 +196,7 @@ func TestHandler_Refresh_Unauthorized(t *testing.T) {
 
 func TestHandler_Logout_OK(t *testing.T) {
 	rec := httptest.NewRecorder()
-	NewHandler(nil, nil, nil, &stubLogouter{}, nil, nil).Logout(rec, post(t, "/api/auth/logout", `{"refresh_token":"tok"}`))
+	NewHandler(nil, nil, nil, &stubLogouter{}, nil, nil, nil).Logout(rec, post(t, "/api/auth/logout", `{"refresh_token":"tok"}`))
 	if rec.Code != http.StatusNoContent {
 		t.Fatalf("want 204, got %d", rec.Code)
 	}
@@ -187,7 +204,7 @@ func TestHandler_Logout_OK(t *testing.T) {
 
 func TestHandler_Logout_MissingToken(t *testing.T) {
 	rec := httptest.NewRecorder()
-	NewHandler(nil, nil, nil, &stubLogouter{}, nil, nil).Logout(rec, post(t, "/api/auth/logout", `{"refresh_token":""}`))
+	NewHandler(nil, nil, nil, &stubLogouter{}, nil, nil, nil).Logout(rec, post(t, "/api/auth/logout", `{"refresh_token":""}`))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("want 400, got %d", rec.Code)
 	}
@@ -196,7 +213,7 @@ func TestHandler_Logout_MissingToken(t *testing.T) {
 func TestHandler_Logout_MethodNotAllowed(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/auth/logout", nil)
-	NewHandler(nil, nil, nil, &stubLogouter{}, nil, nil).Logout(rec, req)
+	NewHandler(nil, nil, nil, &stubLogouter{}, nil, nil, nil).Logout(rec, req)
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("want 405, got %d", rec.Code)
 	}
@@ -206,7 +223,7 @@ func TestHandler_Logout_MethodNotAllowed(t *testing.T) {
 
 func TestHandler_ForgotPassword_OK(t *testing.T) {
 	rec := httptest.NewRecorder()
-	NewHandler(nil, nil, nil, nil, &stubResetter{}, nil).ForgotPassword(rec,
+	NewHandler(nil, nil, nil, nil, &stubResetter{}, nil, nil).ForgotPassword(rec,
 		post(t, "/api/auth/forgot-password", `{"email":"alice@example.com"}`))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body)
@@ -215,7 +232,7 @@ func TestHandler_ForgotPassword_OK(t *testing.T) {
 
 func TestHandler_ForgotPassword_InvalidJSON(t *testing.T) {
 	rec := httptest.NewRecorder()
-	NewHandler(nil, nil, nil, nil, &stubResetter{}, nil).ForgotPassword(rec,
+	NewHandler(nil, nil, nil, nil, &stubResetter{}, nil, nil).ForgotPassword(rec,
 		post(t, "/api/auth/forgot-password", `{"email":`))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("want 400, got %d", rec.Code)
@@ -225,7 +242,7 @@ func TestHandler_ForgotPassword_InvalidJSON(t *testing.T) {
 func TestHandler_ForgotPassword_MethodNotAllowed(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/auth/forgot-password", nil)
-	NewHandler(nil, nil, nil, nil, &stubResetter{}, nil).ForgotPassword(rec, req)
+	NewHandler(nil, nil, nil, nil, &stubResetter{}, nil, nil).ForgotPassword(rec, req)
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("want 405, got %d", rec.Code)
 	}
@@ -235,7 +252,7 @@ func TestHandler_ForgotPassword_MethodNotAllowed(t *testing.T) {
 
 func TestHandler_ResetPassword_OK(t *testing.T) {
 	rec := httptest.NewRecorder()
-	NewHandler(nil, nil, nil, nil, nil, &stubExecutor{}).ResetPassword(rec,
+	NewHandler(nil, nil, nil, nil, nil, &stubExecutor{}, nil).ResetPassword(rec,
 		post(t, "/api/auth/reset-password", `{"token":"abc","password":"newpassword1"}`))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body)
@@ -244,7 +261,7 @@ func TestHandler_ResetPassword_OK(t *testing.T) {
 
 func TestHandler_ResetPassword_InvalidJSON(t *testing.T) {
 	rec := httptest.NewRecorder()
-	NewHandler(nil, nil, nil, nil, nil, &stubExecutor{}).ResetPassword(rec,
+	NewHandler(nil, nil, nil, nil, nil, &stubExecutor{}, nil).ResetPassword(rec,
 		post(t, "/api/auth/reset-password", `{"token":`))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("want 400, got %d", rec.Code)
@@ -254,8 +271,64 @@ func TestHandler_ResetPassword_InvalidJSON(t *testing.T) {
 func TestHandler_ResetPassword_MethodNotAllowed(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/auth/reset-password", nil)
-	NewHandler(nil, nil, nil, nil, nil, &stubExecutor{}).ResetPassword(rec, req)
+	NewHandler(nil, nil, nil, nil, nil, &stubExecutor{}, nil).ResetPassword(rec, req)
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("want 405, got %d", rec.Code)
+	}
+}
+
+// -- DeleteAccount -----------------------------------------------------------
+
+func TestHandler_DeleteAccount_NoContent(t *testing.T) {
+	rec := httptest.NewRecorder()
+	NewHandler(nil, nil, nil, nil, nil, nil, &stubAccountDeleter{}).DeleteAccount(rec,
+		deleteReq(t, "/api/auth/me", `{"password":"hunter2hunter"}`, "user-1"))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("want 204, got %d: %s", rec.Code, rec.Body)
+	}
+}
+
+func TestHandler_DeleteAccount_MethodNotAllowed(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/me", nil)
+	NewHandler(nil, nil, nil, nil, nil, nil, &stubAccountDeleter{}).DeleteAccount(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("want 405, got %d", rec.Code)
+	}
+}
+
+func TestHandler_DeleteAccount_InvalidJSON(t *testing.T) {
+	rec := httptest.NewRecorder()
+	NewHandler(nil, nil, nil, nil, nil, nil, &stubAccountDeleter{}).DeleteAccount(rec,
+		deleteReq(t, "/api/auth/me", `{"password":`, "user-1"))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", rec.Code)
+	}
+}
+
+func TestHandler_DeleteAccount_MissingPassword(t *testing.T) {
+	rec := httptest.NewRecorder()
+	NewHandler(nil, nil, nil, nil, nil, nil, &stubAccountDeleter{}).DeleteAccount(rec,
+		deleteReq(t, "/api/auth/me", `{"password":""}`, "user-1"))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", rec.Code)
+	}
+}
+
+func TestHandler_DeleteAccount_Unauthorized(t *testing.T) {
+	rec := httptest.NewRecorder()
+	NewHandler(nil, nil, nil, nil, nil, nil, &stubAccountDeleter{err: apperror.Unauthorized("invalid credentials")}).DeleteAccount(rec,
+		deleteReq(t, "/api/auth/me", `{"password":"wrong"}`, "user-1"))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d", rec.Code)
+	}
+}
+
+func TestHandler_DeleteAccount_InternalError(t *testing.T) {
+	rec := httptest.NewRecorder()
+	NewHandler(nil, nil, nil, nil, nil, nil, &stubAccountDeleter{err: apperror.Internal("db error", errors.New("boom"))}).DeleteAccount(rec,
+		deleteReq(t, "/api/auth/me", `{"password":"hunter2hunter"}`, "user-1"))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("want 500, got %d", rec.Code)
 	}
 }

--- a/backend/internal/auth/handler_test.go
+++ b/backend/internal/auth/handler_test.go
@@ -308,7 +308,7 @@ func TestHandler_DeleteAccount_InvalidJSON(t *testing.T) {
 
 func TestHandler_DeleteAccount_MissingPassword(t *testing.T) {
 	rec := httptest.NewRecorder()
-	NewHandler(nil, nil, nil, nil, nil, nil, &stubAccountDeleter{}).DeleteAccount(rec,
+	NewHandler(nil, nil, nil, nil, nil, nil, &stubAccountDeleter{err: apperror.InvalidArgument("password required")}).DeleteAccount(rec,
 		deleteReq(t, "/api/auth/me", `{"password":""}`, "user-1"))
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("want 400, got %d", rec.Code)

--- a/backend/internal/auth/queries/auth.sql
+++ b/backend/internal/auth/queries/auth.sql
@@ -25,3 +25,11 @@ DELETE FROM refresh_tokens WHERE token_hash = $1;
 
 -- name: DeleteAllRefreshTokensByUser :exec
 DELETE FROM refresh_tokens WHERE user_id = sqlc.arg(user_id)::uuid;
+
+-- name: GetUserByID :one
+SELECT id::text, email, username, role, created_at, password_hash
+FROM users
+WHERE id = sqlc.arg(user_id)::uuid AND is_active = true;
+
+-- name: DeleteUserByID :exec
+DELETE FROM users WHERE id = sqlc.arg(user_id)::uuid;

--- a/backend/internal/auth/repository.go
+++ b/backend/internal/auth/repository.go
@@ -64,6 +64,33 @@ func (r *pgRepository) GetUserByEmail(ctx context.Context, email string) (UserWi
 	}, nil
 }
 
+func (r *pgRepository) GetUserByID(ctx context.Context, userID string) (UserWithHash, error) {
+	row, err := r.q.GetUserByID(ctx, uuidParam(userID))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return UserWithHash{}, apperror.NotFound("user not found")
+		}
+		return UserWithHash{}, fmt.Errorf("repo: get user by id: %w", err)
+	}
+	return UserWithHash{
+		User: User{
+			ID:        row.ID,
+			Email:     row.Email,
+			Username:  row.Username,
+			Role:      row.Role,
+			CreatedAt: row.CreatedAt,
+		},
+		PasswordHash: row.PasswordHash,
+	}, nil
+}
+
+func (r *pgRepository) DeleteUserByID(ctx context.Context, userID string) error {
+	if err := r.q.DeleteUserByID(ctx, uuidParam(userID)); err != nil {
+		return fmt.Errorf("repo: delete user: %w", err)
+	}
+	return nil
+}
+
 func (r *pgRepository) StoreRefreshToken(ctx context.Context, userID, tokenHash string, expiresAt time.Time) error {
 	if err := r.q.InsertRefreshToken(ctx, authdb.InsertRefreshTokenParams{
 		UserID:    uuidParam(userID),

--- a/backend/internal/auth/service.go
+++ b/backend/internal/auth/service.go
@@ -58,6 +58,11 @@ type ResetPasswordInput struct {
 	Password string
 }
 
+type DeleteAccountInput struct {
+	UserID   string
+	Password string
+}
+
 type TokenPair struct {
 	AccessToken  string `json:"access_token"`
 	RefreshToken string `json:"refresh_token"`
@@ -83,6 +88,7 @@ type UserWithHash struct {
 type Repository interface {
 	CreateUser(ctx context.Context, email, username, passwordHash string) (User, error)
 	GetUserByEmail(ctx context.Context, email string) (UserWithHash, error)
+	GetUserByID(ctx context.Context, userID string) (UserWithHash, error)
 	StoreRefreshToken(ctx context.Context, userID, tokenHash string, expiresAt time.Time) error
 	GetUserByRefreshToken(ctx context.Context, tokenHash string) (User, error)
 	RotateRefreshToken(ctx context.Context, oldHash, newHash, userID string, expiresAt time.Time) error
@@ -91,6 +97,7 @@ type Repository interface {
 	DeletePendingPasswordResetsByUser(ctx context.Context, userID string) error
 	CheckPasswordResetToken(ctx context.Context, tokenHash string) error
 	ResetPassword(ctx context.Context, tokenHash, passwordHash string) error
+	DeleteUserByID(ctx context.Context, userID string) error
 }
 
 // Mailer envoie des emails transactionnels liés à l'authentification.
@@ -245,6 +252,28 @@ func (s *Service) ResetPassword(ctx context.Context, in ResetPasswordInput) erro
 	}
 
 	return s.repo.ResetPassword(ctx, tokenHash, string(hash))
+}
+
+func (s *Service) DeleteAccount(ctx context.Context, in DeleteAccountInput) error {
+	if in.Password == "" {
+		return apperror.InvalidArgument("password required")
+	}
+
+	uwh, err := s.repo.GetUserByID(ctx, in.UserID)
+	if err != nil {
+		return err
+	}
+
+	if err := bcrypt.CompareHashAndPassword([]byte(uwh.PasswordHash), []byte(in.Password)); err != nil {
+		return apperror.Unauthorized("invalid credentials")
+	}
+
+	if err := s.repo.DeleteUserByID(ctx, in.UserID); err != nil {
+		return apperror.Internal("could not delete account", err)
+	}
+
+	log.Printf("auth: account deleted for user %s", in.UserID)
+	return nil
 }
 
 func normalizeEmail(raw string) (string, error) {

--- a/backend/internal/auth/service_test.go
+++ b/backend/internal/auth/service_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -17,6 +18,7 @@ type fakeRepo struct {
 	lastHash            string
 	refreshTokens       map[string]fakeRefreshToken
 	passwordResetTokens map[string]fakePasswordResetToken
+	deleteUserErr       error
 }
 
 type fakeRefreshToken struct {
@@ -368,6 +370,29 @@ func (f *fakeRepo) ResetPassword(_ context.Context, tokenHash, passwordHash stri
 	return nil
 }
 
+func (f *fakeRepo) GetUserByID(_ context.Context, userID string) (UserWithHash, error) {
+	for _, uwh := range f.emails {
+		if uwh.ID == userID {
+			return uwh, nil
+		}
+	}
+	return UserWithHash{}, apperror.NotFound("user not found")
+}
+
+func (f *fakeRepo) DeleteUserByID(_ context.Context, userID string) error {
+	if f.deleteUserErr != nil {
+		return f.deleteUserErr
+	}
+	for email, uwh := range f.emails {
+		if uwh.ID == userID {
+			delete(f.usernames, uwh.Username)
+			delete(f.emails, email)
+			return nil
+		}
+	}
+	return nil
+}
+
 func TestResetPassword_HappyPath(t *testing.T) {
 	repo := newFakeRepo()
 	svc := NewService(repo, testSecret, &fakeMailer{})
@@ -483,6 +508,79 @@ func TestResetPassword_ShortPassword_Errors(t *testing.T) {
 	err := svc.ResetPassword(context.Background(), ResetPasswordInput{Token: "anytoken", Password: "short"})
 	if !apperror.IsCode(err, apperror.CodeInvalidArgument) {
 		t.Errorf("want invalid_argument, got %v", err)
+	}
+}
+
+func TestDeleteAccount_HappyPath(t *testing.T) {
+	repo := newFakeRepo()
+	svc := NewService(repo, testSecret, &fakeMailer{})
+	user, err := svc.Register(context.Background(), RegisterInput{
+		Email: "alice@example.com", Username: "alice", Password: "hunter2hunter",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := svc.DeleteAccount(context.Background(), DeleteAccountInput{
+		UserID: user.ID, Password: "hunter2hunter",
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := repo.emails["alice@example.com"]; ok {
+		t.Error("user still present in repo after deletion")
+	}
+}
+
+func TestDeleteAccount_WrongPassword(t *testing.T) {
+	repo := newFakeRepo()
+	svc := NewService(repo, testSecret, &fakeMailer{})
+	user, err := svc.Register(context.Background(), RegisterInput{
+		Email: "alice@example.com", Username: "alice", Password: "hunter2hunter",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = svc.DeleteAccount(context.Background(), DeleteAccountInput{
+		UserID: user.ID, Password: "wrongpassword",
+	})
+	assertAppError(t, err, apperror.CodeUnauthorized, "invalid credentials")
+}
+
+func TestDeleteAccount_EmptyPassword(t *testing.T) {
+	svc := NewService(newFakeRepo(), testSecret, &fakeMailer{})
+	err := svc.DeleteAccount(context.Background(), DeleteAccountInput{
+		UserID: "00000000-0000-0000-0000-000000000001", Password: "",
+	})
+	assertAppError(t, err, apperror.CodeInvalidArgument, "password required")
+}
+
+func TestDeleteAccount_UserNotFound(t *testing.T) {
+	svc := NewService(newFakeRepo(), testSecret, &fakeMailer{})
+	err := svc.DeleteAccount(context.Background(), DeleteAccountInput{
+		UserID: "00000000-0000-0000-0000-000000000099", Password: "hunter2hunter",
+	})
+	if !apperror.IsCode(err, apperror.CodeNotFound) {
+		t.Errorf("want not_found, got %v", err)
+	}
+}
+
+func TestDeleteAccount_RepoDeleteError(t *testing.T) {
+	repo := newFakeRepo()
+	svc := NewService(repo, testSecret, &fakeMailer{})
+	user, err := svc.Register(context.Background(), RegisterInput{
+		Email: "alice@example.com", Username: "alice", Password: "hunter2hunter",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo.deleteUserErr = fmt.Errorf("db unavailable")
+	err = svc.DeleteAccount(context.Background(), DeleteAccountInput{
+		UserID: user.ID, Password: "hunter2hunter",
+	})
+	if !apperror.IsCode(err, apperror.CodeInternal) {
+		t.Errorf("want internal, got %v", err)
 	}
 }
 

--- a/backend/internal/openapi/openapi.yaml
+++ b/backend/internal/openapi/openapi.yaml
@@ -213,6 +213,31 @@ paths:
           $ref: "#/components/responses/UnsupportedMediaType"
         "500":
           $ref: "#/components/responses/InternalError"
+  /api/auth/me:
+    delete:
+      tags:
+        - Auth
+      operationId: deleteAccount
+      summary: Permanently delete the authenticated user's account (GDPR art. 17).
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeleteAccountRequest"
+      responses:
+        "204":
+          description: Account permanently deleted.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "415":
+          $ref: "#/components/responses/UnsupportedMediaType"
+        "500":
+          $ref: "#/components/responses/InternalError"
   /api/users/me:
     get:
       tags:
@@ -427,6 +452,17 @@ components:
           minLength: 8
           maxLength: 72
           example: newpassword1
+    DeleteAccountRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - password
+      properties:
+        password:
+          type: string
+          format: password
+          minLength: 1
+          example: hunter2hunter
     UserResponse:
       type: object
       required:

--- a/mobile/lib/core/constants/api_constants.dart
+++ b/mobile/lib/core/constants/api_constants.dart
@@ -17,6 +17,7 @@ class ApiConstants {
   static const String logout = '/api/auth/logout';
   static const String forgotPassword = '/api/auth/forgot-password';
   static const String resetPassword = '/api/auth/reset-password';
+  static const String deleteAccount = '/api/auth/me';
 
   // Streams
   static const String streams = '/api/streams';

--- a/mobile/lib/core/network/dio_client.dart
+++ b/mobile/lib/core/network/dio_client.dart
@@ -78,7 +78,6 @@ class DioClient {
         }
 
         if (req.extra[_retriedKey] == true) {
-          await _storage.clearTokens();
           return handler.next(error);
         }
 
@@ -105,8 +104,7 @@ class DioClient {
     return path.endsWith(ApiConstants.refresh) ||
         path.endsWith(ApiConstants.login) ||
         path.endsWith(ApiConstants.logout) ||
-        path.endsWith(ApiConstants.register) ||
-        path.endsWith(ApiConstants.deleteAccount);
+        path.endsWith(ApiConstants.register);
   }
 
   /// Refresh sérialisé : si un refresh est déjà en cours, on attend son résultat.

--- a/mobile/lib/core/network/dio_client.dart
+++ b/mobile/lib/core/network/dio_client.dart
@@ -105,7 +105,8 @@ class DioClient {
     return path.endsWith(ApiConstants.refresh) ||
         path.endsWith(ApiConstants.login) ||
         path.endsWith(ApiConstants.logout) ||
-        path.endsWith(ApiConstants.register);
+        path.endsWith(ApiConstants.register) ||
+        path.endsWith(ApiConstants.deleteAccount);
   }
 
   /// Refresh sérialisé : si un refresh est déjà en cours, on attend son résultat.

--- a/mobile/lib/features/auth/data/datasources/auth_remote_data_source.dart
+++ b/mobile/lib/features/auth/data/datasources/auth_remote_data_source.dart
@@ -68,6 +68,16 @@ class AuthRemoteDataSource {
     }
   }
 
+  Future<void> deleteAccount({required String password}) async {
+    try {
+      await _authApi.deleteAccount(
+        deleteAccountRequest: DeleteAccountRequest(password: password),
+      );
+    } on DioException catch (e) {
+      throw _mapDioException(e);
+    }
+  }
+
   Future<TokenPairResponse> login({
     required String email,
     required String password,

--- a/mobile/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/mobile/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -56,4 +56,10 @@ class AuthRepositoryImpl implements AuthRepository {
     }
     await _secureStorage.clearTokens();
   }
+
+  @override
+  Future<void> deleteAccount({required String password}) async {
+    await _remote.deleteAccount(password: password);
+    await _secureStorage.clearTokens();
+  }
 }

--- a/mobile/lib/features/auth/domain/repositories/auth_repository.dart
+++ b/mobile/lib/features/auth/domain/repositories/auth_repository.dart
@@ -17,6 +17,10 @@ abstract class AuthRepository {
   /// Ne lève jamais : un échec réseau ne doit pas bloquer la déconnexion locale.
   Future<void> logout();
 
+  /// Supprime définitivement le compte (RGPD art. 17).
+  /// Lève [AuthException] si le mot de passe est incorrect.
+  Future<void> deleteAccount({required String password});
+
   /// Déclenche l'envoi de l'email de réinitialisation.
   /// Ne lève jamais sur email inconnu (anti-énumération côté serveur).
   Future<void> requestPasswordReset({required String email});

--- a/mobile/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/mobile/lib/features/profile/presentation/screens/profile_screen.dart
@@ -61,6 +61,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
   }
 
   Future<void> _deleteAccount() async {
+    final repo = context.read<AuthRepository>();
     final password = await showDialog<String>(
       context: context,
       builder: (_) => const _DeleteAccountDialog(),
@@ -68,7 +69,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
     if (password == null || password.isEmpty) return;
 
     try {
-      await context.read<AuthRepository>().deleteAccount(password: password);
+      await repo.deleteAccount(password: password);
       if (!mounted) return;
       showAuthSuccessToast(context, 'Compte supprimé avec succès');
       context.go('/login');

--- a/mobile/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/mobile/lib/features/profile/presentation/screens/profile_screen.dart
@@ -483,7 +483,7 @@ class _DeleteAccountDialogState extends State<_DeleteAccountDialog> {
   }
 
   void _submit() {
-    final password = _controller.text.trim();
+    final password = _controller.text;
     if (password.isNotEmpty) {
       Navigator.of(context).pop(password);
     }

--- a/mobile/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/mobile/lib/features/profile/presentation/screens/profile_screen.dart
@@ -497,41 +497,43 @@ class _DeleteAccountDialogState extends State<_DeleteAccountDialog> {
         'Supprimer mon compte',
         style: TextStyle(color: colors.error),
       ),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          const Text(
-            'Cette action est irréversible. Toutes vos données '
-            '(profil, playlists, morceaux, historique) seront '
-            'définitivement supprimées.',
-          ),
-          const SizedBox(height: 16),
-          CheckboxListTile(
-            key: const Key('delete_account_confirm_checkbox'),
-            contentPadding: EdgeInsets.zero,
-            value: _confirmed,
-            onChanged: (v) => setState(() => _confirmed = v ?? false),
-            title: const Text('Je comprends que cette action est irréversible'),
-            controlAffinity: ListTileControlAffinity.leading,
-          ),
-          const SizedBox(height: 8),
-          TextField(
-            key: const Key('delete_account_password_field'),
-            controller: _controller,
-            obscureText: _obscure,
-            enabled: _confirmed,
-            decoration: InputDecoration(
-              labelText: 'Mot de passe',
-              hintText: 'Confirmez votre mot de passe',
-              suffixIcon: IconButton(
-                icon: Icon(_obscure ? Icons.visibility_off : Icons.visibility),
-                onPressed: () => setState(() => _obscure = !_obscure),
-              ),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Cette action est irréversible. Toutes vos données '
+              '(profil, playlists, morceaux, historique) seront '
+              'définitivement supprimées.',
             ),
-            onSubmitted: _confirmed ? (_) => _submit() : null,
-          ),
-        ],
+            const SizedBox(height: 16),
+            CheckboxListTile(
+              key: const Key('delete_account_confirm_checkbox'),
+              contentPadding: EdgeInsets.zero,
+              value: _confirmed,
+              onChanged: (v) => setState(() => _confirmed = v ?? false),
+              title: const Text('Je comprends que cette action est irréversible'),
+              controlAffinity: ListTileControlAffinity.leading,
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              key: const Key('delete_account_password_field'),
+              controller: _controller,
+              obscureText: _obscure,
+              enabled: _confirmed,
+              decoration: InputDecoration(
+                labelText: 'Mot de passe',
+                hintText: 'Confirmez votre mot de passe',
+                suffixIcon: IconButton(
+                  icon: Icon(_obscure ? Icons.visibility_off : Icons.visibility),
+                  onPressed: () => setState(() => _obscure = !_obscure),
+                ),
+              ),
+              onSubmitted: _confirmed ? (_) => _submit() : null,
+            ),
+          ],
+        ),
       ),
       actions: [
         TextButton(

--- a/mobile/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/mobile/lib/features/profile/presentation/screens/profile_screen.dart
@@ -60,6 +60,30 @@ class _ProfileScreenState extends State<ProfileScreen> {
     context.go('/login');
   }
 
+  Future<void> _deleteAccount() async {
+    final password = await showDialog<String>(
+      context: context,
+      builder: (_) => const _DeleteAccountDialog(),
+    );
+    if (password == null || password.isEmpty) return;
+
+    try {
+      await context.read<AuthRepository>().deleteAccount(password: password);
+      if (!mounted) return;
+      showAuthSuccessToast(context, 'Compte supprimé avec succès');
+      context.go('/login');
+    } on AuthException {
+      if (!mounted) return;
+      showAuthErrorToast(context, 'Mot de passe incorrect');
+    } on NetworkException {
+      if (!mounted) return;
+      showAuthErrorToast(context, 'Pas de connexion réseau');
+    } catch (_) {
+      if (!mounted) return;
+      showAuthErrorToast(context, 'Échec de la suppression');
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).colorScheme;
@@ -139,6 +163,22 @@ class _ProfileScreenState extends State<ProfileScreen> {
               onPressed: _logout,
               icon: const Icon(Icons.logout),
               label: const Text('Se déconnecter'),
+            ),
+          ),
+          const SizedBox(height: 12),
+          ConstrainedBox(
+            constraints: const BoxConstraints.tightFor(
+              height: AppConstants.minTouchTarget,
+            ),
+            child: OutlinedButton.icon(
+              key: const Key('profile_delete_account_button'),
+              style: OutlinedButton.styleFrom(
+                foregroundColor: colors.error,
+                side: BorderSide(color: colors.error),
+              ),
+              onPressed: _deleteAccount,
+              icon: const Icon(Icons.delete_forever),
+              label: const Text('Supprimer mon compte'),
             ),
           ),
         ],
@@ -417,6 +457,95 @@ class _EditPseudoDialogState extends State<_EditPseudoDialog> {
         FilledButton(
           onPressed: _submit,
           child: const Text('Enregistrer'),
+        ),
+      ],
+    );
+  }
+}
+
+class _DeleteAccountDialog extends StatefulWidget {
+  const _DeleteAccountDialog();
+
+  @override
+  State<_DeleteAccountDialog> createState() => _DeleteAccountDialogState();
+}
+
+class _DeleteAccountDialogState extends State<_DeleteAccountDialog> {
+  final _controller = TextEditingController();
+  bool _confirmed = false;
+  bool _obscure = true;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    final password = _controller.text.trim();
+    if (password.isNotEmpty) {
+      Navigator.of(context).pop(password);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+
+    return AlertDialog(
+      title: Text(
+        'Supprimer mon compte',
+        style: TextStyle(color: colors.error),
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Cette action est irréversible. Toutes vos données '
+            '(profil, playlists, morceaux, historique) seront '
+            'définitivement supprimées.',
+          ),
+          const SizedBox(height: 16),
+          CheckboxListTile(
+            key: const Key('delete_account_confirm_checkbox'),
+            contentPadding: EdgeInsets.zero,
+            value: _confirmed,
+            onChanged: (v) => setState(() => _confirmed = v ?? false),
+            title: const Text('Je comprends que cette action est irréversible'),
+            controlAffinity: ListTileControlAffinity.leading,
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            key: const Key('delete_account_password_field'),
+            controller: _controller,
+            obscureText: _obscure,
+            enabled: _confirmed,
+            decoration: InputDecoration(
+              labelText: 'Mot de passe',
+              hintText: 'Confirmez votre mot de passe',
+              suffixIcon: IconButton(
+                icon: Icon(_obscure ? Icons.visibility_off : Icons.visibility),
+                onPressed: () => setState(() => _obscure = !_obscure),
+              ),
+            ),
+            onSubmitted: _confirmed ? (_) => _submit() : null,
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Annuler'),
+        ),
+        FilledButton(
+          key: const Key('delete_account_submit_button'),
+          style: FilledButton.styleFrom(
+            backgroundColor: colors.error,
+            foregroundColor: colors.onError,
+          ),
+          onPressed: _confirmed ? _submit : null,
+          child: const Text('Supprimer'),
         ),
       ],
     );

--- a/mobile/packages/streampulse_api/.openapi-generator/FILES
+++ b/mobile/packages/streampulse_api/.openapi-generator/FILES
@@ -14,6 +14,7 @@ lib/src/auth/basic_auth.dart
 lib/src/auth/bearer_auth.dart
 lib/src/auth/oauth.dart
 lib/src/deserialize.dart
+lib/src/model/delete_account_request.dart
 lib/src/model/error_detail.dart
 lib/src/model/error_response.dart
 lib/src/model/forgot_password_request.dart

--- a/mobile/packages/streampulse_api/README.md
+++ b/mobile/packages/streampulse_api/README.md
@@ -49,13 +49,12 @@ import 'package:streampulse_api/streampulse_api.dart';
 
 
 final api = StreampulseApi().getAuthApi();
-final ForgotPasswordRequest forgotPasswordRequest = ; // ForgotPasswordRequest | 
+final DeleteAccountRequest deleteAccountRequest = ; // DeleteAccountRequest | 
 
 try {
-    final response = await api.forgotPassword(forgotPasswordRequest);
-    print(response);
+    api.deleteAccount(deleteAccountRequest);
 } on DioException catch (e) {
-    print("Exception when calling AuthApi->forgotPassword: $e\n");
+    print("Exception when calling AuthApi->deleteAccount: $e\n");
 }
 
 ```
@@ -66,6 +65,7 @@ All URIs are relative to *http://localhost*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
+[*AuthApi*](doc/AuthApi.md) | [**deleteAccount**](doc/AuthApi.md#deleteaccount) | **DELETE** /api/auth/me | Permanently delete the authenticated user&#39;s account (GDPR art. 17).
 [*AuthApi*](doc/AuthApi.md) | [**forgotPassword**](doc/AuthApi.md#forgotpassword) | **POST** /api/auth/forgot-password | Request a password reset email.
 [*AuthApi*](doc/AuthApi.md) | [**login**](doc/AuthApi.md#login) | **POST** /api/auth/login | Authenticate a user and issue tokens.
 [*AuthApi*](doc/AuthApi.md) | [**logout**](doc/AuthApi.md#logout) | **POST** /api/auth/logout | Revoke the current refresh token.
@@ -80,6 +80,7 @@ Class | Method | HTTP request | Description
 
 ## Documentation For Models
 
+ - [DeleteAccountRequest](doc/DeleteAccountRequest.md)
  - [ErrorDetail](doc/ErrorDetail.md)
  - [ErrorResponse](doc/ErrorResponse.md)
  - [ForgotPasswordRequest](doc/ForgotPasswordRequest.md)

--- a/mobile/packages/streampulse_api/lib/src/api/auth_api.dart
+++ b/mobile/packages/streampulse_api/lib/src/api/auth_api.dart
@@ -9,6 +9,7 @@ import 'dart:convert';
 import 'package:streampulse_api/src/deserialize.dart';
 import 'package:dio/dio.dart';
 
+import 'package:streampulse_api/src/model/delete_account_request.dart';
 import 'package:streampulse_api/src/model/error_response.dart';
 import 'package:streampulse_api/src/model/forgot_password_request.dart';
 import 'package:streampulse_api/src/model/login_request.dart';
@@ -24,6 +25,68 @@ class AuthApi {
   final Dio _dio;
 
   const AuthApi(this._dio);
+
+  /// Permanently delete the authenticated user&#39;s account (GDPR art. 17).
+  ///
+  ///
+  /// Parameters:
+  /// * [deleteAccountRequest]
+  /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
+  /// * [headers] - Can be used to add additional headers to the request
+  /// * [extras] - Can be used to add flags to the request
+  /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
+  /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
+  /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
+  ///
+  /// Returns a [Future]
+  /// Throws [DioException] if API call or serialization fails
+  Future<Response<void>> deleteAccount({
+    required DeleteAccountRequest deleteAccountRequest,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    final _path = r'/api/auth/me';
+    final _options = Options(
+      method: r'DELETE',
+      headers: <String, dynamic>{...?headers},
+      extra: <String, dynamic>{
+        'secure': <Map<String, String>>[
+          {'type': 'http', 'scheme': 'bearer', 'name': 'bearerAuth'},
+        ],
+        ...?extra,
+      },
+      contentType: 'application/json',
+      validateStatus: validateStatus,
+    );
+
+    dynamic _bodyData;
+
+    try {
+      _bodyData = jsonEncode(deleteAccountRequest);
+    } catch (error, stackTrace) {
+      throw DioException(
+        requestOptions: _options.compose(_dio.options, _path),
+        type: DioExceptionType.unknown,
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+
+    final _response = await _dio.request<Object>(
+      _path,
+      data: _bodyData,
+      options: _options,
+      cancelToken: cancelToken,
+      onSendProgress: onSendProgress,
+      onReceiveProgress: onReceiveProgress,
+    );
+
+    return _response;
+  }
 
   /// Request a password reset email.
   ///

--- a/mobile/packages/streampulse_api/lib/src/deserialize.dart
+++ b/mobile/packages/streampulse_api/lib/src/deserialize.dart
@@ -1,3 +1,4 @@
+import 'package:streampulse_api/src/model/delete_account_request.dart';
 import 'package:streampulse_api/src/model/error_detail.dart';
 import 'package:streampulse_api/src/model/error_response.dart';
 import 'package:streampulse_api/src/model/forgot_password_request.dart';
@@ -35,6 +36,9 @@ ReturnType deserialize<ReturnType, BaseType>(
       return (valueString == 'true' || valueString == '1') as ReturnType;
     case 'double':
       return (value is double ? value : double.parse('$value')) as ReturnType;
+    case 'DeleteAccountRequest':
+      return DeleteAccountRequest.fromJson(value as Map<String, dynamic>)
+          as ReturnType;
     case 'ErrorDetail':
       return ErrorDetail.fromJson(value as Map<String, dynamic>) as ReturnType;
     case 'ErrorResponse':

--- a/mobile/packages/streampulse_api/lib/src/model/delete_account_request.dart
+++ b/mobile/packages/streampulse_api/lib/src/model/delete_account_request.dart
@@ -1,0 +1,40 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+
+// ignore_for_file: unused_element
+import 'package:json_annotation/json_annotation.dart';
+
+part 'delete_account_request.g.dart';
+
+@JsonSerializable(
+  checked: true,
+  createToJson: true,
+  disallowUnrecognizedKeys: false,
+  explicitToJson: true,
+)
+class DeleteAccountRequest {
+  /// Returns a new [DeleteAccountRequest] instance.
+  DeleteAccountRequest({required this.password});
+
+  @JsonKey(name: r'password', required: true, includeIfNull: false)
+  final String password;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DeleteAccountRequest && other.password == password;
+
+  @override
+  int get hashCode => password.hashCode;
+
+  factory DeleteAccountRequest.fromJson(Map<String, dynamic> json) =>
+      _$DeleteAccountRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$DeleteAccountRequestToJson(this);
+
+  @override
+  String toString() {
+    return toJson().toString();
+  }
+}

--- a/mobile/packages/streampulse_api/lib/src/model/delete_account_request.g.dart
+++ b/mobile/packages/streampulse_api/lib/src/model/delete_account_request.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'delete_account_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+DeleteAccountRequest _$DeleteAccountRequestFromJson(
+  Map<String, dynamic> json,
+) => $checkedCreate('DeleteAccountRequest', json, ($checkedConvert) {
+  $checkKeys(json, requiredKeys: const ['password']);
+  final val = DeleteAccountRequest(
+    password: $checkedConvert('password', (v) => v as String),
+  );
+  return val;
+});
+
+Map<String, dynamic> _$DeleteAccountRequestToJson(
+  DeleteAccountRequest instance,
+) => <String, dynamic>{'password': instance.password};

--- a/mobile/packages/streampulse_api/lib/streampulse_api.dart
+++ b/mobile/packages/streampulse_api/lib/streampulse_api.dart
@@ -13,6 +13,7 @@ export 'package:streampulse_api/src/api/health_api.dart';
 export 'package:streampulse_api/src/api/metrics_api.dart';
 export 'package:streampulse_api/src/api/profile_api.dart';
 
+export 'package:streampulse_api/src/model/delete_account_request.dart';
 export 'package:streampulse_api/src/model/error_detail.dart';
 export 'package:streampulse_api/src/model/error_response.dart';
 export 'package:streampulse_api/src/model/forgot_password_request.dart';

--- a/mobile/test/features/auth/data/repositories/auth_repository_impl_test.dart
+++ b/mobile/test/features/auth/data/repositories/auth_repository_impl_test.dart
@@ -64,6 +64,11 @@ class _FakeRemote implements AuthRemoteDataSource {
   }) async {
     if (error != null) throw error!;
   }
+
+  @override
+  Future<void> deleteAccount({required String password}) async {
+    if (error != null) throw error!;
+  }
 }
 
 class _FakeSecureStorage implements SecureStorage {

--- a/mobile/test/features/auth/presentation/screens/register_screen_test.dart
+++ b/mobile/test/features/auth/presentation/screens/register_screen_test.dart
@@ -54,6 +54,9 @@ class _FakeAuthRepository implements AuthRepository {
     required String token,
     required String newPassword,
   }) async {}
+
+  @override
+  Future<void> deleteAccount({required String password}) async {}
 }
 
 class _MarkerScreen extends StatelessWidget {


### PR DESCRIPTION
## STR-59 — Suppression de compte (conformité RGPD art. 17)

[STR-59](https://linear.app/streampulse/issue/STR-59)

En tant qu'utilisateur connecté, je veux pouvoir **supprimer définitivement mon compte** et toutes mes données afin d'exercer mon droit à l'effacement (RGPD art. 17). La suppression nécessite une **double confirmation** (checkbox + mot de passe) et déclenche un `DELETE` en cascade sur toutes les données personnelles (profil, playlists, morceaux, historique, tokens).

### Endpoint

| Méthode | Route | Auth | Description |
|---|---|---|---|
| DELETE | `/api/auth/me` | JWT | Supprime le compte après vérification du mot de passe |

Codes : **204** supprimé · **400** mot de passe manquant · **401** non authentifié / mauvais mot de passe · **500** erreur interne.

### Architecture

- **Backend** : enrichissement du domaine `internal/auth/` existant en **handler / service / repository** ([ADR 008](docs/adr/008-architecture-handler-service-repository.md)). Pas de nouvelle migration — les contraintes `ON DELETE CASCADE` déjà en place suppriment automatiquement toutes les données liées (streams, tracks, playlists, queue items, refresh tokens, password reset tokens).
- **Mobile** : enrichissement de la feature `auth` (datasource, repository, interface) et ajout d'un bouton + modale de confirmation dans l'écran profil.

### Changements

**Backend**
- `queries/auth.sql` : +`GetUserByID` (fetch user avec password hash), +`DeleteUserByID` (suppression cascade).
- `db/auth.sql.go` : régénéré via `sqlc generate`.
- `service.go` : +`DeleteAccountInput`, +`DeleteAccount` (valide mot de passe → supprime → log audit). Interface `Repository` étendue avec `GetUserByID` et `DeleteUserByID`.
- `repository.go` : implémentation des deux nouvelles méthodes (pgx, traduction `ErrNoRows → NotFound`).
- `handler.go` : +interface `AccountDeleter` (ISP), +handler `DeleteAccount` (enforce `DELETE`, validation, extraction `userID` du contexte JWT). `NewHandler` accepte un 7ème paramètre.
- `main.go` : route `DELETE /api/auth/me` protégée par `RequireAuth`.
- Tests stdlib : service (`fakeRepo` étendu, 5 tests) + handler (`stubAccountDeleter`, 6 tests).

**OpenAPI + client mobile**
- `openapi.yaml` : +path `DELETE /api/auth/me`, +schéma `DeleteAccountRequest`.
- Client Dart/Dio régénéré (`make generate-openapi-client`) : `AuthApi.deleteAccount()` + `DeleteAccountRequest`.

**Mobile**
- `auth_remote_data_source.dart` : +`deleteAccount(password:)` via `AuthApi` généré.
- `auth_repository.dart` (interface) : +`deleteAccount(password:)`.
- `auth_repository_impl.dart` : appel API puis `clearTokens()`.
- `profile_screen.dart` : bouton rouge « Supprimer mon compte » sous « Se déconnecter » + `_DeleteAccountDialog` (checkbox irréversibilité + champ mot de passe + bouton rouge « Supprimer »).
- Tests existants mis à jour (`_FakeRemote`, `_FakeAuthRepository`) pour implémenter la nouvelle méthode.

### Décisions clés
- **Pas de soft-delete** : suppression physique (`DELETE FROM users`) conforme au RGPD art. 17 — les données doivent être réellement effacées, pas masquées.
- **Cascade DB** : toutes les tables liées ont `ON DELETE CASCADE` → aucune migration nécessaire, la suppression d'un user nettoie automatiquement toutes ses données.
- **Confirmation par mot de passe** côté backend (pas seulement UI) : empêche la suppression avec un token volé.
- **Double confirmation UI** : checkbox « Je comprends que cette action est irréversible » + saisie du mot de passe. Le bouton « Supprimer » est désactivé tant que la checkbox n'est pas cochée.
- **Fichiers audio** : seules les métadonnées sont supprimées (pas de stockage objet implémenté pour l'instant). Le nettoyage du stockage sera ajouté quand S3/MinIO sera en place.

### Hors scope
- Envoi d'un email de confirmation de suppression.
- Export des données avant suppression (RGPD art. 20 — portabilité).
- Période de grâce / annulation de la suppression.

### Vérification
- **Backend** : `go vet` clean · `go test -race ./...` vert (tous packages, dont 11 nouveaux tests auth).
- **Mobile** : `flutter analyze` clean (1 info pré-existant) · `flutter test` **46/46**.
- OpenAPI validée (`openapi_test.go`).

#### Comment tester (E2E)
```bash
docker compose up -d
# Swagger (hors prod) : http://localhost:8080/swagger
# comptes seedés : user1@streampulse.dev / Password123!
```
1. Login `user1@streampulse.dev` → récupérer l'`access_token`.
2. `DELETE /api/auth/me` avec `Authorization: Bearer <token>` + body `{ "password": "Password123!" }` → **204**.
3. Re-login `user1@streampulse.dev` → **401** (le compte n'existe plus).

Mobile : `flutter run` → Profil → « Supprimer mon compte » → cocher la checkbox → saisir le mot de passe → « Supprimer » → redirection vers `/login`.