### PR TITLE
feat(api): moteur HLS — segmentation et génération du manifeste

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
         working-directory: ./backend
         run: go mod download
 
+      - name: Install ffmpeg (segmentation HLS — cf. ADR 015)
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
       - name: Run tests
         working-directory: ./backend
         run: go test -v -race -coverprofile=coverage.txt ./...

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,7 +197,11 @@ Domaine `internal/streaming/` (handler/service/repository). Détails dans [ADR 0
 | PATCH | `/api/streams/{id}/start` | `Handler.Start` | Oui — rôle `broadcaster`, owner ; `idle→live` (409 si pas idle ou déjà un live) |
 | PATCH | `/api/streams/{id}/stop` | `Handler.Stop` | Oui — rôle `broadcaster`, owner ; `live→ended` (409 si pas live) |
 | GET | `/api/streams/{id}/events` | `Handler.Events` | Oui (JWT) — flux **SSE**, event `ended` à l'arrêt (STR-77) |
+| POST | `/api/streams/ingest/{stream_key}` | `Handler.Ingest` | **Non (JWT)** — auth par `stream_key` dans le path ; push audio AAC segmenté en HLS (STR-70/71) |
+| GET | `/api/streams/{id}/playlist.m3u8` | `Handler.Playlist` | Oui (JWT) — manifeste HLS du direct (409 si pas live) (STR-70) |
+| GET | `/api/streams/{id}/segments/{segment}` | `Handler.Segment` | Oui (JWT) — segment `.ts` (nom validé anti-traversal) (STR-70) |
 
+- Moteur HLS (STR-70) : le diffuseur pousse de l'AAC sur `ingest/{stream_key}` (auth par clé, 100 % mémoire) ; **ffmpeg** (`-c:a copy`) segmente en `.ts` de ~10 s + manifeste `.m3u8` glissant servi aux auditeurs. Un segmenteur par session live, tué + répertoire nettoyé à l'arrêt. Détails [ADR 015](docs/adr/015-moteur-hls-segmentation-ffmpeg.md).
 - Cycle de vie du direct (STR-77) : `start`/`stop` = endpoints dédiés (le PUT ne touche pas au statut) ; **un seul flux live par diffuseur** ; goroutines gérées par `LiveSessions` (context + mutex). Détails [ADR 013](docs/adr/013-domaine-streaming.md) §7.
 - Titre **non unique** (contrainte retirée en `000015`) : pas de 409 sur le titre.
 - `stream_key` (32 octets base64url, en clair) jamais exposé à un tiers ; URL source = `{STREAM_INGEST_BASE_URL}/api/streams/ingest/{stream_key}`.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,7 +19,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
 
 FROM alpine:3 AS runner
 
-RUN apk add --no-cache ca-certificates tzdata
+RUN apk add --no-cache ca-certificates tzdata ffmpeg
 
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -146,6 +146,15 @@ func run() error {
 	// Événements SSE du direct (STR-85) : notif d'arrêt aux auditeurs authentifiés.
 	mux.Handle("GET /api/streams/{id}/events", auth.RequireAuth(cfg.JWTSecret,
 		http.HandlerFunc(streamingHandler.Events)))
+	// Ingest du flux audio par le diffuseur (STR-70/71) : auth par stream_key dans
+	// le path (pas de JWT), le corps est un push audio continu segmenté en HLS.
+	mux.Handle("POST /api/streams/ingest/{stream_key}", http.HandlerFunc(streamingHandler.Ingest))
+	// Lecture HLS par l'auditeur (STR-70) : manifeste + segments, auth JWT. La
+	// visibilité (flux privé/absent → 404) est vérifiée dans le handler.
+	mux.Handle("GET /api/streams/{id}/playlist.m3u8", auth.RequireAuth(cfg.JWTSecret,
+		http.HandlerFunc(streamingHandler.Playlist)))
+	mux.Handle("GET /api/streams/{id}/segments/{segment}", auth.RequireAuth(cfg.JWTSecret,
+		http.HandlerFunc(streamingHandler.Segment)))
 	// Documentation OpenAPI (Swagger UI + spec brute) — exposée hors production
 	// uniquement, pour ne pas publier la surface de l'API sur l'environnement public.
 	if !cfg.IsProd() {

--- a/backend/internal/openapi/openapi.yaml
+++ b/backend/internal/openapi/openapi.yaml
@@ -740,6 +740,15 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "415":
+          description: >-
+            Content-Type present but not audio/* (a non-audio push would spin the
+            HLS demuxer without producing segments). An absent Content-Type is
+            accepted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "500":
           $ref: "#/components/responses/InternalError"
   /api/streams/{id}/playlist.m3u8:
@@ -773,7 +782,9 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
         "409":
-          description: The stream is not live.
+          description: >-
+            The stream is not live, or its manifest is not ready yet (window
+            between start and the first segment).
           content:
             application/json:
               schema:

--- a/backend/internal/openapi/openapi.yaml
+++ b/backend/internal/openapi/openapi.yaml
@@ -700,6 +700,121 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "500":
           $ref: "#/components/responses/InternalError"
+  /api/streams/ingest/{stream_key}:
+    parameters:
+      - name: stream_key
+        in: path
+        required: true
+        description: The broadcaster's secret stream key (from stream_source_url).
+        schema:
+          type: string
+    post:
+      tags:
+        - Streaming
+      operationId: ingestStream
+      summary: Push a live audio stream (broadcaster ingest).
+      description: >-
+        Continuous AAC audio ingest for a live stream, authenticated by the
+        `stream_key` in the path (no JWT). The request body is a continuous audio
+        stream segmented into HLS by the backend (cf. ADR 015). The stream must be
+        live (started) for the push to be accepted.
+      requestBody:
+        required: true
+        content:
+          audio/aac:
+            schema:
+              type: string
+              format: binary
+      responses:
+        "204":
+          description: Ingest completed (broadcaster disconnected).
+        "404":
+          description: No live stream for this key.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: An ingest is already in progress for this stream.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+  /api/streams/{id}/playlist.m3u8:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Streaming
+      operationId: streamPlaylist
+      summary: Get the live HLS media playlist (manifest).
+      description: >-
+        Returns the continuously-updated HLS media playlist (`.m3u8`) of a live
+        stream. Segment URIs are relative (`segments/…`). Requires the stream to
+        be live.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: HLS media playlist.
+          content:
+            application/vnd.apple.mpegurl:
+              schema:
+                type: string
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: The stream is not live.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/streams/{id}/segments/{segment}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: segment
+        in: path
+        required: true
+        description: Segment file name (e.g. seg_00001.ts).
+        schema:
+          type: string
+          pattern: '^seg_\d+\.ts$'
+    get:
+      tags:
+        - Streaming
+      operationId: streamSegment
+      summary: Get an HLS media segment (.ts).
+      description: >-
+        Returns an MPEG-TS audio segment referenced by the live playlist. Requires
+        the stream to be live.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: MPEG-TS segment.
+          content:
+            video/mp2t:
+              schema:
+                type: string
+                format: binary
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
 components:
   securitySchemes:
     bearerAuth:

--- a/backend/internal/streaming/handler.go
+++ b/backend/internal/streaming/handler.go
@@ -446,8 +446,12 @@ func (h *Handler) Ingest(w http.ResponseWriter, r *http.Request) {
 	// ferme PAS l'entrée du segmenteur : la session reste live (fenêtre de
 	// segments disponible) jusqu'au stop explicite.
 	if _, err := io.Copy(writer, r.Body); err != nil {
-		// Ne jamais logger le stream_key (secret) : on ne trace que l'erreur.
+		// Push interrompu par une erreur : refléter l'échec plutôt qu'un 204
+		// trompeur (un broadcast avorté ≠ déconnexion propre). Ne jamais logger le
+		// stream_key (secret). Si le client est déjà parti, l'écriture est un no-op.
 		log.Printf("streaming: ingest interrompu: %v", err)
+		httpjson.WriteError(w, r, apperror.Internal("ingest interrupted", err))
+		return
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -465,35 +469,27 @@ func ingestError(err error) error {
 }
 
 // Playlist gère GET /api/streams/{id}/playlist.m3u8 : sert le manifeste HLS à un
-// auditeur authentifié. Visibilité alignée sur GetStream (404 si absent/privé).
+// auditeur authentifié. 409 si le flux n'est pas en direct.
 func (h *Handler) Playlist(w http.ResponseWriter, r *http.Request) {
-	requesterID, ok := auth.UserIDFromContext(r.Context())
-	if !ok {
-		httpjson.WriteError(w, r, apperror.Unauthorized("unauthenticated"))
-		return
-	}
-	id := r.PathValue("id")
-
-	if _, _, err := h.svc.GetStream(r.Context(), id, requesterID); err != nil {
-		httpjson.WriteError(w, r, err)
-		return
-	}
-
-	path, ok := h.sessions.Playlist(id)
-	if !ok {
-		httpjson.WriteError(w, r, apperror.Conflict("stream is not live"))
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/vnd.apple.mpegurl")
-	w.Header().Set("Cache-Control", "no-cache")
-	http.ServeFile(w, r, path)
+	h.serveHLSFile(w, r, "application/vnd.apple.mpegurl",
+		func(id string) (string, bool) { return h.sessions.Playlist(id) },
+		apperror.Conflict("stream is not live"))
 }
 
 // Segment gère GET /api/streams/{id}/segments/{segment} : sert un segment .ts à un
 // auditeur authentifié. Le nom du segment est validé (anti path-traversal) dans
-// la couche session.
+// la couche session ; nom invalide ou segment absent -> 404.
 func (h *Handler) Segment(w http.ResponseWriter, r *http.Request) {
+	h.serveHLSFile(w, r, "video/mp2t",
+		func(id string) (string, bool) { return h.sessions.Segment(id, r.PathValue("segment")) },
+		apperror.NotFound("segment not found"))
+}
+
+// serveHLSFile factorise le service d'un fichier HLS (manifeste ou segment) à un
+// auditeur authentifié : contrôle de visibilité (GetStream, 404 si absent/privé),
+// lookup de la session (unavailable si le flux n'est pas en direct), en-têtes puis
+// ServeFile. lookup renvoie le chemin disque et sa validité.
+func (h *Handler) serveHLSFile(w http.ResponseWriter, r *http.Request, contentType string, lookup func(id string) (string, bool), unavailable error) {
 	requesterID, ok := auth.UserIDFromContext(r.Context())
 	if !ok {
 		httpjson.WriteError(w, r, apperror.Unauthorized("unauthenticated"))
@@ -506,13 +502,13 @@ func (h *Handler) Segment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	path, ok := h.sessions.Segment(id, r.PathValue("segment"))
+	path, ok := lookup(id)
 	if !ok {
-		httpjson.WriteError(w, r, apperror.NotFound("segment not found"))
+		httpjson.WriteError(w, r, unavailable)
 		return
 	}
 
-	w.Header().Set("Content-Type", "video/mp2t")
+	w.Header().Set("Content-Type", contentType)
 	w.Header().Set("Cache-Control", "no-cache")
 	http.ServeFile(w, r, path)
 }

--- a/backend/internal/streaming/handler.go
+++ b/backend/internal/streaming/handler.go
@@ -446,7 +446,8 @@ func (h *Handler) Ingest(w http.ResponseWriter, r *http.Request) {
 	// ferme PAS l'entrée du segmenteur : la session reste live (fenêtre de
 	// segments disponible) jusqu'au stop explicite.
 	if _, err := io.Copy(writer, r.Body); err != nil {
-		log.Printf("streaming: ingest copy (key tronquée %.8s…): %v", key, err)
+		// Ne jamais logger le stream_key (secret) : on ne trace que l'erreur.
+		log.Printf("streaming: ingest interrompu: %v", err)
 	}
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/backend/internal/streaming/handler.go
+++ b/backend/internal/streaming/handler.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"mime"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -436,6 +438,20 @@ func (h *Handler) Ingest(w http.ResponseWriter, r *http.Request) {
 	}
 	defer release()
 
+	// Validation légère du Content-Type (après résolution de la clé pour préserver
+	// le 404 sur clé inconnue, avant io.Copy pour qu'aucun octet n'atteigne ffmpeg).
+	// Si présent, il doit être audio/* : coupe tôt un push manifestement non-audio
+	// (ex. curl --data-binary → application/x-www-form-urlencoded) qui ferait tourner
+	// ffmpeg dans le vide (le demuxer ADTS cherche des sync words sans jamais mourir).
+	// Un Content-Type absent reste accepté (clients bruts, cf. ADR 015).
+	if ct := r.Header.Get("Content-Type"); ct != "" {
+		if mt, _, perr := mime.ParseMediaType(ct); perr != nil || !strings.HasPrefix(mt, "audio/") {
+			httpjson.WriteError(w, r, httpjson.StatusError(
+				http.StatusUnsupportedMediaType, "unsupported_media_type", "content-type must be audio/aac"))
+			return
+		}
+	}
+
 	// Push long : neutraliser les deadlines read/write posées par http.Server
 	// (ReadTimeout/WriteTimeout couperaient une diffusion de plusieurs minutes).
 	rc := http.NewResponseController(w)
@@ -504,6 +520,15 @@ func (h *Handler) serveHLSFile(w http.ResponseWriter, r *http.Request, contentTy
 
 	path, ok := lookup(id)
 	if !ok {
+		httpjson.WriteError(w, r, unavailable)
+		return
+	}
+
+	// Le fichier peut ne pas exister encore (fenêtre entre le start et le premier
+	// segment, ou push dont ffmpeg n'a encore rien produit) ou avoir été retiré
+	// (fenêtre glissante) : renvoyer l'erreur JSON documentée plutôt que le
+	// `404 page not found` text/plain brut de http.ServeFile (hors contrat).
+	if _, err := os.Stat(path); err != nil {
 		httpjson.WriteError(w, r, unavailable)
 		return
 	}

--- a/backend/internal/streaming/handler.go
+++ b/backend/internal/streaming/handler.go
@@ -2,7 +2,9 @@ package streaming
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"strconv"
@@ -35,10 +37,14 @@ type StreamService interface {
 	StopStream(ctx context.Context, id, requesterID string) (Stream, error)
 }
 
-// StreamEvents fournit l'abonnement SSE aux événements d'un flux (implémenté par
-// *LiveSessions).
-type StreamEvents interface {
+// StreamSessions expose au handler les opérations sur les sessions live :
+// abonnement SSE (STR-85), ingest audio et service des fichiers HLS (STR-70).
+// *LiveSessions l'implémente. Le handler utilise l'ensemble de ces méthodes.
+type StreamSessions interface {
 	Subscribe(streamID string) (<-chan SessionEvent, func())
+	AttachIngest(streamKey string) (io.Writer, func(), error)
+	Playlist(streamID string) (string, bool)
+	Segment(streamID, name string) (string, bool)
 }
 
 // Handler expose le domaine streaming en HTTP. ingestBaseURL sert à construire
@@ -46,11 +52,11 @@ type StreamEvents interface {
 type Handler struct {
 	svc           StreamService
 	ingestBaseURL string
-	events        StreamEvents
+	sessions      StreamSessions
 }
 
-func NewHandler(svc StreamService, ingestBaseURL string, events StreamEvents) *Handler {
-	return &Handler{svc: svc, ingestBaseURL: strings.TrimRight(ingestBaseURL, "/"), events: events}
+func NewHandler(svc StreamService, ingestBaseURL string, sessions StreamSessions) *Handler {
+	return &Handler{svc: svc, ingestBaseURL: strings.TrimRight(ingestBaseURL, "/"), sessions: sessions}
 }
 
 // createStreamRequest : pointeurs pour distinguer « champ absent » de zéro.
@@ -363,7 +369,7 @@ func (h *Handler) Events(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ch, unsub := h.events.Subscribe(id)
+	ch, unsub := h.sessions.Subscribe(id)
 	if ch == nil {
 		httpjson.WriteError(w, r, apperror.Conflict("stream is not live"))
 		return
@@ -415,4 +421,97 @@ func (h *Handler) Events(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+}
+
+// Ingest gère POST /api/streams/ingest/{stream_key} : réception du flux audio du
+// diffuseur (STR-71). L'authentification se fait par le stream_key du path (pas de
+// JWT) ; le corps est un flux continu copié dans le segmenteur HLS de la session.
+func (h *Handler) Ingest(w http.ResponseWriter, r *http.Request) {
+	key := r.PathValue("stream_key")
+
+	writer, release, err := h.sessions.AttachIngest(key)
+	if err != nil {
+		httpjson.WriteError(w, r, ingestError(err))
+		return
+	}
+	defer release()
+
+	// Push long : neutraliser les deadlines read/write posées par http.Server
+	// (ReadTimeout/WriteTimeout couperaient une diffusion de plusieurs minutes).
+	rc := http.NewResponseController(w)
+	_ = rc.SetReadDeadline(time.Time{})
+	_ = rc.SetWriteDeadline(time.Time{})
+
+	// Copie bloquante jusqu'à la fin du push (EOF = diffuseur déconnecté). On ne
+	// ferme PAS l'entrée du segmenteur : la session reste live (fenêtre de
+	// segments disponible) jusqu'au stop explicite.
+	if _, err := io.Copy(writer, r.Body); err != nil {
+		log.Printf("streaming: ingest copy (key tronquée %.8s…): %v", key, err)
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ingestError mappe les erreurs d'ingest vers un status HTTP.
+func ingestError(err error) error {
+	switch {
+	case errors.Is(err, errIngestInProgress):
+		return apperror.Conflict("ingest already in progress")
+	case errors.Is(err, errSegmenterUnavailable):
+		return apperror.Internal("hls segmenter unavailable", err)
+	default: // errNotLive : clé inconnue ou flux pas en direct (on ne divulgue pas la différence)
+		return apperror.NotFound("no live stream for this key")
+	}
+}
+
+// Playlist gère GET /api/streams/{id}/playlist.m3u8 : sert le manifeste HLS à un
+// auditeur authentifié. Visibilité alignée sur GetStream (404 si absent/privé).
+func (h *Handler) Playlist(w http.ResponseWriter, r *http.Request) {
+	requesterID, ok := auth.UserIDFromContext(r.Context())
+	if !ok {
+		httpjson.WriteError(w, r, apperror.Unauthorized("unauthenticated"))
+		return
+	}
+	id := r.PathValue("id")
+
+	if _, _, err := h.svc.GetStream(r.Context(), id, requesterID); err != nil {
+		httpjson.WriteError(w, r, err)
+		return
+	}
+
+	path, ok := h.sessions.Playlist(id)
+	if !ok {
+		httpjson.WriteError(w, r, apperror.Conflict("stream is not live"))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/vnd.apple.mpegurl")
+	w.Header().Set("Cache-Control", "no-cache")
+	http.ServeFile(w, r, path)
+}
+
+// Segment gère GET /api/streams/{id}/segments/{segment} : sert un segment .ts à un
+// auditeur authentifié. Le nom du segment est validé (anti path-traversal) dans
+// la couche session.
+func (h *Handler) Segment(w http.ResponseWriter, r *http.Request) {
+	requesterID, ok := auth.UserIDFromContext(r.Context())
+	if !ok {
+		httpjson.WriteError(w, r, apperror.Unauthorized("unauthenticated"))
+		return
+	}
+	id := r.PathValue("id")
+
+	if _, _, err := h.svc.GetStream(r.Context(), id, requesterID); err != nil {
+		httpjson.WriteError(w, r, err)
+		return
+	}
+
+	path, ok := h.sessions.Segment(id, r.PathValue("segment"))
+	if !ok {
+		httpjson.WriteError(w, r, apperror.NotFound("segment not found"))
+		return
+	}
+
+	w.Header().Set("Content-Type", "video/mp2t")
+	w.Header().Set("Cache-Control", "no-cache")
+	http.ServeFile(w, r, path)
 }

--- a/backend/internal/streaming/handler_test.go
+++ b/backend/internal/streaming/handler_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -576,5 +578,75 @@ func TestHandler_Events_StreamsEndedThenCloses(t *testing.T) {
 	}
 	if !strings.Contains(sw.Body.String(), "event: ended") {
 		t.Errorf("le flux SSE doit contenir l'event ended: %s", sw.Body.String())
+	}
+}
+
+func TestHandler_Ingest_RejectsNonAudioContentType(t *testing.T) {
+	ls := sessionsWithFakeSeg(t)
+	ls.Start("sid-415", "KEY415")
+	defer ls.StopAll()
+	h := NewHandler(&stubService{}, testIngestURL, ls)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/streams/ingest/KEY415", strings.NewReader("garbage"))
+	req.SetPathValue("stream_key", "KEY415")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	h.Ingest(rec, req)
+
+	if rec.Code != http.StatusUnsupportedMediaType {
+		t.Fatalf("want 415 pour un content-type non-audio, got %d: %s", rec.Code, rec.Body)
+	}
+}
+
+func TestHandler_Ingest_AllowsAbsentContentType(t *testing.T) {
+	ls := sessionsWithFakeSeg(t)
+	ls.Start("sid-noct", "KEYNOCT")
+	defer ls.StopAll()
+	h := NewHandler(&stubService{}, testIngestURL, ls)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/streams/ingest/KEYNOCT", strings.NewReader(""))
+	req.SetPathValue("stream_key", "KEYNOCT")
+	req.Header.Del("Content-Type") // absent -> accepté (lenient, cf. ADR 015)
+	rec := httptest.NewRecorder()
+
+	h.Ingest(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("want 204 (content-type absent accepté), got %d: %s", rec.Code, rec.Body)
+	}
+}
+
+// TestHandler_Playlist_NotReadyReturnsJSON409 : session vivante mais manifeste pas
+// encore écrit sur disque -> 409 JSON (contrat) et non un 404 text/plain brut.
+func TestHandler_Playlist_NotReadyReturnsJSON409(t *testing.T) {
+	seg := fakeSegmenter(t)
+	if err := os.Remove(filepath.Join(seg.dir, hlsPlaylistName)); err != nil {
+		t.Fatalf("remove playlist: %v", err)
+	}
+	ls := NewLiveSessions(context.Background())
+	ls.newSeg = func() (*hlsSegmenter, error) { return seg, nil }
+	ls.Start("sid-nr", "KEYNR")
+	defer ls.StopAll()
+
+	stub := &stubService{getRet: Stream{ID: "sid-nr", UserID: testUserID, IsPublic: true}}
+	h := NewHandler(stub, testIngestURL, ls)
+
+	token, err := auth.GenerateAccessToken(testUserID, "user", testSecret, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/streams/sid-nr/playlist.m3u8", nil)
+	req.SetPathValue("id", "sid-nr")
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	auth.RequireAuth(testSecret, http.HandlerFunc(h.Playlist)).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("want 409 (manifeste pas encore écrit), got %d: %s", rec.Code, rec.Body)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Fatalf("l'erreur doit rester JSON, content-type=%q", ct)
 	}
 }

--- a/backend/internal/streaming/handler_test.go
+++ b/backend/internal/streaming/handler_test.go
@@ -537,8 +537,8 @@ func (f *flushSignalRecorder) Flush() {
 }
 
 func TestHandler_Events_StreamsEndedThenCloses(t *testing.T) {
-	sessions := NewLiveSessions(context.Background())
-	sessions.Start("s1")
+	sessions := newTestSessions(context.Background())
+	sessions.Start("s1", "")
 	stub := &stubService{getOwner: true, getRet: Stream{ID: "s1", UserID: testUserID, IsPublic: true}}
 	h := NewHandler(stub, testIngestURL, sessions)
 

--- a/backend/internal/streaming/hls.go
+++ b/backend/internal/streaming/hls.go
@@ -92,7 +92,7 @@ func (s *hlsSegmenter) input() io.Writer { return s.stdin }
 func (s *hlsSegmenter) playlistPath() string { return filepath.Join(s.dir, hlsPlaylistName) }
 
 // segmentPath retourne le chemin disque d'un segment après validation stricte du
-// nom (anti-traversal). (\"\", false) si le nom ne correspond pas au motif attendu.
+// nom (anti-traversal). ("", false) si le nom ne correspond pas au motif attendu.
 func (s *hlsSegmenter) segmentPath(name string) (string, bool) {
 	if !segmentNamePattern.MatchString(name) {
 		return "", false

--- a/backend/internal/streaming/hls.go
+++ b/backend/internal/streaming/hls.go
@@ -1,0 +1,117 @@
+package streaming
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+// Paramètres de segmentation HLS (cf. ADR 015).
+const (
+	hlsSegmentSeconds = 10 // durée cible d'un segment .ts
+	hlsListSize       = 6  // fenêtre glissante du manifeste (~1 min)
+	hlsPlaylistName   = "playlist.m3u8"
+	hlsSegmentPattern = "seg_%05d.ts" // nom de fichier des segments (sur disque)
+	hlsSegmentPrefix  = "segments/"   // préfixe des URI de segments dans le manifeste
+	hlsShutdownGrace  = 5 * time.Second
+)
+
+// Erreurs d'ingest, mappées vers un status HTTP par le handler.
+var (
+	errNotLive              = errors.New("streaming: no live session for this key")
+	errSegmenterUnavailable = errors.New("streaming: hls segmenter unavailable")
+	errIngestInProgress     = errors.New("streaming: ingest already in progress")
+)
+
+// segmentNamePattern valide le nom d'un segment demandé par un auditeur
+// (anti path-traversal) : exactement seg_<chiffres>.ts, rien d'autre.
+var segmentNamePattern = regexp.MustCompile(`^seg_\d+\.ts$`)
+
+// hlsSegmenter pilote un process ffmpeg qui lit de l'AAC sur stdin et écrit un
+// manifeste HLS + des segments MPEG-TS dans un répertoire temporaire dédié.
+// L'audio est remuxé sans ré-encodage (-c:a copy).
+type hlsSegmenter struct {
+	dir   string         // répertoire de travail (manifeste + segments)
+	cmd   *exec.Cmd      // nil dans les tests (segmenteur simulé)
+	stdin io.WriteCloser // entrée où copier l'audio du diffuseur
+	done  chan struct{}  // fermé quand le process ffmpeg a terminé
+}
+
+// newHLSSegmenter crée le répertoire de travail et démarre ffmpeg. En cas
+// d'échec (ffmpeg absent, etc.) le répertoire est nettoyé et l'erreur remontée.
+func newHLSSegmenter() (*hlsSegmenter, error) {
+	dir, err := os.MkdirTemp("", "streampulse-hls-")
+	if err != nil {
+		return nil, fmt.Errorf("hls: create work dir: %w", err)
+	}
+
+	cmd := exec.Command("ffmpeg",
+		"-hide_banner", "-loglevel", "warning",
+		"-i", "pipe:0", // audio lu sur stdin
+		"-c:a", "copy", // remux AAC -> TS, pas de transcodage
+		"-f", "hls",
+		"-hls_time", strconv.Itoa(hlsSegmentSeconds),
+		"-hls_list_size", strconv.Itoa(hlsListSize),
+		"-hls_flags", "delete_segments+append_list+omit_endlist",
+		"-hls_segment_type", "mpegts",
+		"-hls_base_url", hlsSegmentPrefix, // les URI du manifeste pointent vers segments/…
+		"-hls_segment_filename", filepath.Join(dir, hlsSegmentPattern),
+		filepath.Join(dir, hlsPlaylistName),
+	)
+	cmd.Stderr = os.Stderr // warnings/erreurs ffmpeg vers les logs du conteneur
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		return nil, fmt.Errorf("hls: stdin pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
+		_ = os.RemoveAll(dir)
+		return nil, fmt.Errorf("hls: start ffmpeg: %w", err)
+	}
+
+	s := &hlsSegmenter{dir: dir, cmd: cmd, stdin: stdin, done: make(chan struct{})}
+	go func() {
+		_ = cmd.Wait()
+		close(s.done)
+	}()
+	return s, nil
+}
+
+// input expose l'entrée stdin de ffmpeg : le handler d'ingest y copie l'audio.
+func (s *hlsSegmenter) input() io.Writer { return s.stdin }
+
+// playlistPath retourne le chemin disque du manifeste .m3u8.
+func (s *hlsSegmenter) playlistPath() string { return filepath.Join(s.dir, hlsPlaylistName) }
+
+// segmentPath retourne le chemin disque d'un segment après validation stricte du
+// nom (anti-traversal). (\"\", false) si le nom ne correspond pas au motif attendu.
+func (s *hlsSegmenter) segmentPath(name string) (string, bool) {
+	if !segmentNamePattern.MatchString(name) {
+		return "", false
+	}
+	return filepath.Join(s.dir, name), true
+}
+
+// close ferme stdin (ffmpeg finalise le dernier segment et s'arrête), attend sa
+// terminaison (bornée par hlsShutdownGrace, sinon kill) puis supprime le
+// répertoire de travail. Idempotence non requise : appelé une fois par session.
+func (s *hlsSegmenter) close() {
+	_ = s.stdin.Close()
+	if s.cmd != nil {
+		select {
+		case <-s.done:
+		case <-time.After(hlsShutdownGrace):
+			_ = s.cmd.Process.Kill()
+			<-s.done
+		}
+	}
+	_ = os.RemoveAll(s.dir)
+}

--- a/backend/internal/streaming/hls_test.go
+++ b/backend/internal/streaming/hls_test.go
@@ -1,0 +1,205 @@
+package streaming
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// nopWriteCloser adapte un io.Writer en io.WriteCloser (Close no-op).
+type nopWriteCloser struct{ io.Writer }
+
+func (nopWriteCloser) Close() error { return nil }
+
+// fakeSegmenter construit un segmenteur simulé (sans ffmpeg) : répertoire réel
+// avec un manifeste + un segment, entrée branchée sur io.Discard, cmd nil (close
+// n'attend aucun process). done reste ouvert : la session vit jusqu'au cancel.
+func fakeSegmenter(t *testing.T) *hlsSegmenter {
+	t.Helper()
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, hlsPlaylistName), "#EXTM3U\n")
+	mustWrite(t, filepath.Join(dir, "seg_00000.ts"), "fake-ts")
+	return &hlsSegmenter{dir: dir, stdin: nopWriteCloser{io.Discard}, done: make(chan struct{})}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// sessionsWithFakeSeg construit un registre dont le segmenteur est simulé.
+func sessionsWithFakeSeg(t *testing.T) *LiveSessions {
+	t.Helper()
+	ls := NewLiveSessions(context.Background())
+	ls.newSeg = func() (*hlsSegmenter, error) { return fakeSegmenter(t), nil }
+	return ls
+}
+
+func TestSegmentPath_RejectsTraversal(t *testing.T) {
+	s := fakeSegmenter(t)
+	valid := []string{"seg_00000.ts", "seg_1.ts", "seg_99999.ts"}
+	for _, name := range valid {
+		if _, ok := s.segmentPath(name); !ok {
+			t.Errorf("nom valide refusé: %q", name)
+		}
+	}
+	invalid := []string{
+		"../etc/passwd", "seg_.ts", "seg_1.mp3", "..", "seg_1.ts/../x",
+		"/abs/seg_1.ts", "seg_1.TS", "", "playlist.m3u8",
+	}
+	for _, name := range invalid {
+		if _, ok := s.segmentPath(name); ok {
+			t.Errorf("nom invalide accepté (traversal possible): %q", name)
+		}
+	}
+}
+
+func TestAttachIngest_RoutesByKeyAndGuards(t *testing.T) {
+	ls := sessionsWithFakeSeg(t)
+	ls.Start("s1", "KEY1")
+	defer ls.StopAll()
+
+	if _, _, err := ls.AttachIngest("inconnue"); !errors.Is(err, errNotLive) {
+		t.Fatalf("clé inconnue: want errNotLive, got %v", err)
+	}
+
+	w, release, err := ls.AttachIngest("KEY1")
+	if err != nil || w == nil {
+		t.Fatalf("attach valide: want (writer, nil), got (%v, %v)", w, err)
+	}
+
+	if _, _, err := ls.AttachIngest("KEY1"); !errors.Is(err, errIngestInProgress) {
+		t.Fatalf("double push: want errIngestInProgress, got %v", err)
+	}
+
+	release()
+	_, release2, err := ls.AttachIngest("KEY1")
+	if err != nil {
+		t.Fatalf("ré-attach après release: %v", err)
+	}
+	release2()
+}
+
+func TestAttachIngest_AfterStop(t *testing.T) {
+	ls := sessionsWithFakeSeg(t)
+	ls.Start("s1", "KEY1")
+	ls.Stop("s1")
+
+	if _, _, err := ls.AttachIngest("KEY1"); !errors.Is(err, errNotLive) {
+		t.Fatalf("après stop: want errNotLive, got %v", err)
+	}
+}
+
+func TestAttachIngest_SegmenterUnavailable(t *testing.T) {
+	ls := NewLiveSessions(context.Background())
+	ls.newSeg = func() (*hlsSegmenter, error) { return nil, errors.New("ffmpeg absent") }
+	ls.Start("s1", "KEY1")
+	defer ls.StopAll()
+
+	if _, _, err := ls.AttachIngest("KEY1"); !errors.Is(err, errSegmenterUnavailable) {
+		t.Fatalf("segmenteur indisponible: want errSegmenterUnavailable, got %v", err)
+	}
+}
+
+func TestPlaylistAndSegmentLookup(t *testing.T) {
+	ls := sessionsWithFakeSeg(t)
+	ls.Start("s1", "KEY1")
+	defer ls.StopAll()
+
+	if p, ok := ls.Playlist("s1"); !ok || filepath.Base(p) != hlsPlaylistName {
+		t.Fatalf("playlist: want (…/%s, true), got (%q, %v)", hlsPlaylistName, p, ok)
+	}
+	if _, ok := ls.Playlist("inconnu"); ok {
+		t.Fatal(`playlist d'un flux inconnu doit être ("", false)`)
+	}
+
+	if p, ok := ls.Segment("s1", "seg_00000.ts"); !ok || filepath.Base(p) != "seg_00000.ts" {
+		t.Fatalf("segment valide: got (%q, %v)", p, ok)
+	}
+	if _, ok := ls.Segment("s1", "../secret"); ok {
+		t.Fatal("segment traversal accepté")
+	}
+	if _, ok := ls.Segment("inconnu", "seg_00000.ts"); ok {
+		t.Fatal(`segment d'un flux inconnu doit être ("", false)`)
+	}
+}
+
+// TestHLSSegmenter_Integration exerce le vrai pipeline ffmpeg de bout en bout :
+// on génère ~25 s d'AAC, on les segmente, et on vérifie le manifeste + les
+// segments produits. Ignoré si ffmpeg n'est pas installé (dev sans ffmpeg) ;
+// exécuté en CI/Docker où ffmpeg est présent (cf. ADR 015).
+func TestHLSSegmenter_Integration(t *testing.T) {
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg absent du PATH : test d'intégration HLS ignoré")
+	}
+
+	aac := generateTestAAC(t, 25)
+
+	seg, err := newHLSSegmenter()
+	if err != nil {
+		t.Fatalf("newHLSSegmenter: %v", err)
+	}
+	defer seg.close()
+
+	if _, err := io.Copy(seg.input(), bytes.NewReader(aac)); err != nil {
+		t.Fatalf("copie de l'audio vers ffmpeg: %v", err)
+	}
+	// Fin du push : fermer l'entrée pour que ffmpeg finalise le dernier segment.
+	if err := seg.stdin.Close(); err != nil {
+		t.Fatalf("close stdin: %v", err)
+	}
+	select {
+	case <-seg.done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("ffmpeg n'a pas terminé après la fin de l'entrée")
+	}
+
+	data, err := os.ReadFile(seg.playlistPath())
+	if err != nil {
+		t.Fatalf("lecture du manifeste: %v", err)
+	}
+	manifest := string(data)
+	if !strings.Contains(manifest, "#EXTM3U") {
+		t.Fatalf("manifeste sans en-tête #EXTM3U:\n%s", manifest)
+	}
+	if n := strings.Count(manifest, ".ts"); n < 2 {
+		t.Fatalf("attendu >= 2 segments pour 25 s, obtenu %d:\n%s", n, manifest)
+	}
+	// hls_base_url : les URI de segments sont préfixées par segments/ (route auditeur).
+	if !strings.Contains(manifest, hlsSegmentPrefix+"seg_") {
+		t.Fatalf("manifeste sans préfixe %q:\n%s", hlsSegmentPrefix, manifest)
+	}
+	// Le fichier du premier segment existe sur disque (nom attendu par segmentPath).
+	if _, err := os.Stat(filepath.Join(seg.dir, "seg_00000.ts")); err != nil {
+		t.Fatalf("premier segment absent du disque: %v", err)
+	}
+}
+
+// generateTestAAC synthétise `seconds` secondes d'AAC (conteneur ADTS) via
+// ffmpeg, pour alimenter le segmenteur sans fichier de test binaire.
+func generateTestAAC(t *testing.T, seconds int) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	cmd := exec.Command("ffmpeg", "-hide_banner", "-loglevel", "error",
+		"-f", "lavfi", "-i", fmt.Sprintf("sine=frequency=440:duration=%d", seconds),
+		"-c:a", "aac", "-b:a", "64k", "-f", "adts", "pipe:1")
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("génération de l'AAC de test: %v", err)
+	}
+	if buf.Len() == 0 {
+		t.Fatal("AAC de test vide")
+	}
+	return buf.Bytes()
+}

--- a/backend/internal/streaming/hls_test.go
+++ b/backend/internal/streaming/hls_test.go
@@ -90,6 +90,60 @@ func TestAttachIngest_RoutesByKeyAndGuards(t *testing.T) {
 	release2()
 }
 
+// waitFor sonde une condition jusqu'à timeout (pour les transitions asynchrones
+// pilotées par la goroutine de session, ex. le reap).
+func waitFor(cond func() bool, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return cond()
+}
+
+// TestSegmenterDeath_ReapsSession vérifie qu'à la mort spontanée de ffmpeg, la
+// session est retirée du registre et les abonnés SSE notifiés (fin de flux) — plus
+// de session « zombie » servant des 404 jusqu'au stop.
+func TestSegmenterDeath_ReapsSession(t *testing.T) {
+	ls := NewLiveSessions(context.Background())
+	seg := fakeSegmenter(t)
+	ls.newSeg = func() (*hlsSegmenter, error) { return seg, nil }
+	ls.Start("s1", "KEY1")
+
+	if _, ok := ls.Playlist("s1"); !ok {
+		t.Fatal("le flux devrait être servi tant que le segmenteur est vivant")
+	}
+
+	ch, unsub := ls.Subscribe("s1")
+	if ch == nil {
+		t.Fatal("Subscribe devrait fonctionner tant que le flux est live")
+	}
+	defer unsub()
+
+	close(seg.done) // simule l'arrêt spontané de ffmpeg
+
+	select {
+	case ev, ok := <-ch:
+		if ok && ev.Type != "ended" {
+			t.Fatalf("event attendu ended, obtenu %+v", ev)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("aucun événement SSE après la mort du segmenteur")
+	}
+
+	if !waitFor(func() bool { return !ls.IsLive("s1") }, 2*time.Second) {
+		t.Fatal("session non récoltée (toujours live) après la mort du segmenteur")
+	}
+	if _, ok := ls.Playlist("s1"); ok {
+		t.Fatal("Playlist devrait échouer après reap")
+	}
+	if _, _, err := ls.AttachIngest("KEY1"); !errors.Is(err, errNotLive) {
+		t.Fatalf("AttachIngest après reap: want errNotLive, got %v", err)
+	}
+}
+
 func TestAttachIngest_AfterStop(t *testing.T) {
 	ls := sessionsWithFakeSeg(t)
 	ls.Start("s1", "KEY1")

--- a/backend/internal/streaming/service.go
+++ b/backend/internal/streaming/service.go
@@ -172,9 +172,10 @@ type KeyGenerator interface {
 }
 
 // Sessions gère le cycle de vie des goroutines de diffusion (implémenté par
-// *LiveSessions). Le service enregistre/annule la session au start/stop.
+// *LiveSessions). Le service enregistre/annule la session au start/stop. La clé
+// de flux est fournie au start pour router l'ingest audio (cf. ADR 015).
 type Sessions interface {
-	Start(streamID string)
+	Start(streamID, streamKey string)
 	Stop(streamID string)
 }
 
@@ -276,7 +277,7 @@ func (s *Service) StartStream(ctx context.Context, id, requesterID string) (Stre
 		}
 		return Stream{}, err
 	}
-	s.sessions.Start(stream.ID)
+	s.sessions.Start(stream.ID, stream.StreamKey)
 	return stream, nil
 }
 

--- a/backend/internal/streaming/service_test.go
+++ b/backend/internal/streaming/service_test.go
@@ -208,12 +208,16 @@ type fakeKeys struct {
 func (f fakeKeys) NewStreamKey() (string, error) { return f.key, f.err }
 
 type fakeSessions struct {
-	started []string
-	stopped []string
+	started     []string
+	startedKeys []string
+	stopped     []string
 }
 
-func (f *fakeSessions) Start(id string) { f.started = append(f.started, id) }
-func (f *fakeSessions) Stop(id string)  { f.stopped = append(f.stopped, id) }
+func (f *fakeSessions) Start(id, key string) {
+	f.started = append(f.started, id)
+	f.startedKeys = append(f.startedKeys, key)
+}
+func (f *fakeSessions) Stop(id string) { f.stopped = append(f.stopped, id) }
 
 func TestService_CreateStream_Success(t *testing.T) {
 	repo := &fakeRepo{ret: Stream{ID: "s1", Title: "Mon flux"}}

--- a/backend/internal/streaming/session.go
+++ b/backend/internal/streaming/session.go
@@ -17,12 +17,24 @@ type SessionEvent struct {
 type session struct {
 	streamKey string // secret de push (index d'ingest) ; "" si non routable
 	cancel    context.CancelFunc
-	hls       *hlsSegmenter // nil si le segmenteur n'a pas pu démarrer
 
 	mu          sync.Mutex
 	closed      bool
-	ingesting   bool // un seul push audio à la fois
+	dead        bool          // ffmpeg s'est arrêté seul : segmenteur inexploitable
+	ingesting   bool          // un seul push audio à la fois
+	hls         *hlsSegmenter // publié après le spawn ; protégé par mu
 	subscribers map[chan SessionEvent]struct{}
+}
+
+// segmenter retourne le segmenteur si la session est exploitable (segmenteur
+// présent et process vivant), nil sinon. Sérialise l'accès à s.hls / s.dead.
+func (s *session) segmenter() *hlsSegmenter {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.dead {
+		return nil
+	}
+	return s.hls
 }
 
 // LiveSessions est le registre in-memory des flux en direct (une session par
@@ -50,29 +62,21 @@ func NewLiveSessions(base context.Context) *LiveSessions {
 }
 
 // Start enregistre une session pour streamID (indexée aussi par streamKey pour
-// l'ingest) et lance sa goroutine, après avoir démarré le segmenteur HLS.
-// Idempotent : si une session existe déjà, rien n'est fait.
+// l'ingest) puis démarre son segmenteur HLS et lance sa goroutine. Idempotent :
+// si une session existe déjà, rien n'est fait. Le spawn ffmpeg (MkdirTemp + fork,
+// potentiellement lents) se fait HORS du verrou du registre pour ne pas bloquer
+// les autres sessions ; le segmenteur est publié ensuite sous le verrou de session.
 func (ls *LiveSessions) Start(streamID, streamKey string) {
+	// Phase 1 — réserver l'entrée dans le registre sous verrou (aucune I/O).
 	ls.mu.Lock()
-	defer ls.mu.Unlock()
 	if _, ok := ls.byID[streamID]; ok {
+		ls.mu.Unlock()
 		return
 	}
 	ctx, cancel := context.WithCancel(ls.base)
-
-	seg, err := ls.newSeg()
-	if err != nil {
-		// Le flux est déjà 'live' en base : on enregistre quand même la session
-		// (stop/SSE fonctionnent) mais sans audio. En pratique ffmpeg est présent
-		// dans l'image (ADR 015) ; ce chemin couvre son absence en dev.
-		log.Printf("streaming: segmenteur HLS indisponible pour %s: %v", streamID, err)
-		seg = nil
-	}
-
 	s := &session{
 		streamKey:   streamKey,
 		cancel:      cancel,
-		hls:         seg,
 		subscribers: make(map[chan SessionEvent]struct{}),
 	}
 	ls.byID[streamID] = s
@@ -80,25 +84,71 @@ func (ls *LiveSessions) Start(streamID, streamKey string) {
 		ls.byKey[streamKey] = s
 	}
 	ls.wg.Add(1)
+	ls.mu.Unlock()
+
+	// Phase 2 — spawn du segmenteur HORS verrou (le flux est déjà 'live' en base ;
+	// en cas d'échec ffmpeg, la session reste enregistrée mais sans audio — stop/SSE
+	// fonctionnent. En pratique ffmpeg est présent dans l'image, ADR 015).
+	seg, err := ls.newSeg()
+	if err != nil {
+		log.Printf("streaming: segmenteur HLS indisponible pour %s: %v", streamID, err)
+		seg = nil
+	}
+
+	// Phase 3 — publier le segmenteur puis lancer la goroutine de session.
+	s.mu.Lock()
+	s.hls = seg
+	s.mu.Unlock()
+
 	go func() {
 		defer ls.wg.Done()
-		s.run(ctx)
+		if s.run(ctx) {
+			// ffmpeg est mort seul : on récolte la session (retrait + notif).
+			ls.reap(streamID, s)
+		}
 	}()
 }
 
 // run est la goroutine de session : elle vit jusqu'à l'annulation du context
 // (stop diffuseur ou shutdown) ou l'arrêt spontané de ffmpeg (entrée terminée /
-// erreur), puis libère le segmenteur (process + répertoire de travail).
-func (s *session) run(ctx context.Context) {
-	if s.hls == nil {
+// erreur), puis libère le segmenteur (process + répertoire de travail). Retourne
+// true si ffmpeg s'est arrêté seul (la session doit alors être récoltée).
+func (s *session) run(ctx context.Context) bool {
+	seg := s.segmenter()
+	if seg == nil {
 		<-ctx.Done()
-		return
+		return false
 	}
 	select {
 	case <-ctx.Done():
-	case <-s.hls.done:
+		seg.close()
+		return false
+	case <-seg.done:
+		// Marquer la session inexploitable AVANT le nettoyage pour que
+		// Playlist/Segment/AttachIngest cessent immédiatement de servir un flux mort.
+		s.mu.Lock()
+		s.dead = true
+		s.mu.Unlock()
+		seg.close()
+		return true
 	}
-	s.hls.close()
+}
+
+// reap retire du registre une session dont le segmenteur est mort seul et notifie
+// ses abonnés SSE (fin de flux). La ligne DB reste 'live' jusqu'au stop du
+// diffuseur (réconciliée au boot, cf. ADR 013 §7). No-op si la session a déjà été
+// remplacée/retirée entre-temps.
+func (ls *LiveSessions) reap(streamID string, s *session) {
+	ls.mu.Lock()
+	if ls.byID[streamID] == s {
+		delete(ls.byID, streamID)
+		if s.streamKey != "" {
+			delete(ls.byKey, s.streamKey)
+		}
+	}
+	ls.mu.Unlock()
+	s.publish(SessionEvent{Type: "ended"})
+	s.closeSubscribers()
 }
 
 // Stop retire la session, publie l'événement "ended" (best-effort) à ses abonnés,
@@ -124,8 +174,8 @@ func (ls *LiveSessions) Stop(streamID string) {
 
 // AttachIngest réserve la session live identifiée par streamKey pour un unique
 // push audio, et retourne l'entrée où copier le flux + une fonction de
-// détachement. Erreurs : errNotLive (clé inconnue / flux pas en direct),
-// errSegmenterUnavailable, errIngestInProgress (un push est déjà en cours).
+// détachement. Erreurs : errNotLive (clé inconnue / flux pas en direct / segmenteur
+// mort), errSegmenterUnavailable, errIngestInProgress (un push est déjà en cours).
 func (ls *LiveSessions) AttachIngest(streamKey string) (io.Writer, func(), error) {
 	ls.mu.Lock()
 	s, ok := ls.byKey[streamKey]
@@ -136,8 +186,8 @@ func (ls *LiveSessions) AttachIngest(streamKey string) (io.Writer, func(), error
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.closed {
-		// La session a été arrêtée entre la lecture de la map et ici.
+	if s.closed || s.dead {
+		// Session arrêtée (entre la lecture de la map et ici) ou segmenteur mort.
 		return nil, nil, errNotLive
 	}
 	if s.hls == nil {
@@ -157,15 +207,19 @@ func (ls *LiveSessions) AttachIngest(streamKey string) (io.Writer, func(), error
 
 // Playlist retourne le chemin disque du manifeste .m3u8 du flux en direct
 // (identifié par son id public). ("", false) si le flux n'est pas en direct ou
-// n'a pas de segmenteur.
+// n'a pas de segmenteur exploitable.
 func (ls *LiveSessions) Playlist(streamID string) (string, bool) {
 	ls.mu.Lock()
 	s, ok := ls.byID[streamID]
 	ls.mu.Unlock()
-	if !ok || s.hls == nil {
+	if !ok {
 		return "", false
 	}
-	return s.hls.playlistPath(), true
+	seg := s.segmenter()
+	if seg == nil {
+		return "", false
+	}
+	return seg.playlistPath(), true
 }
 
 // Segment retourne le chemin disque d'un segment .ts du flux en direct, après
@@ -174,10 +228,14 @@ func (ls *LiveSessions) Segment(streamID, name string) (string, bool) {
 	ls.mu.Lock()
 	s, ok := ls.byID[streamID]
 	ls.mu.Unlock()
-	if !ok || s.hls == nil {
+	if !ok {
 		return "", false
 	}
-	return s.hls.segmentPath(name)
+	seg := s.segmenter()
+	if seg == nil {
+		return "", false
+	}
+	return seg.segmentPath(name)
 }
 
 // Subscribe abonne un client SSE aux événements du flux. Retourne le canal de

--- a/backend/internal/streaming/session.go
+++ b/backend/internal/streaming/session.go
@@ -2,6 +2,8 @@ package streaming
 
 import (
 	"context"
+	"io"
+	"log"
 	"sync"
 )
 
@@ -11,43 +13,72 @@ type SessionEvent struct {
 }
 
 // session représente une diffusion en cours : le context d'annulation de sa
-// goroutine et l'ensemble des abonnés SSE.
+// goroutine, son segmenteur HLS (STR-70), et l'ensemble des abonnés SSE (STR-85).
 type session struct {
-	cancel context.CancelFunc
+	streamKey string // secret de push (index d'ingest) ; "" si non routable
+	cancel    context.CancelFunc
+	hls       *hlsSegmenter // nil si le segmenteur n'a pas pu démarrer
 
 	mu          sync.Mutex
 	closed      bool
+	ingesting   bool // un seul push audio à la fois
 	subscribers map[chan SessionEvent]struct{}
 }
 
 // LiveSessions est le registre in-memory des flux en direct (une session par
 // flux live). Protégé par mutex. Chaque session porte l'annulation de sa
-// goroutine (STR-84) et ses abonnés SSE (STR-85).
+// goroutine (STR-84), son segmenteur HLS (STR-70) et ses abonnés SSE (STR-85).
 type LiveSessions struct {
-	base context.Context
+	base   context.Context
+	newSeg func() (*hlsSegmenter, error) // injectable (tests sans ffmpeg)
 
-	mu   sync.Mutex
-	byID map[string]*session
-	wg   sync.WaitGroup
+	mu    sync.Mutex
+	byID  map[string]*session // id public -> session (SSE, lecture HLS, stop)
+	byKey map[string]*session // stream_key secret -> session (ingest)
+	wg    sync.WaitGroup
 }
 
 // NewLiveSessions construit le registre. base est le context de cycle de vie du
 // serveur : son annulation (shutdown) propage l'arrêt à toutes les sessions.
 func NewLiveSessions(base context.Context) *LiveSessions {
-	return &LiveSessions{base: base, byID: make(map[string]*session)}
+	return &LiveSessions{
+		base:   base,
+		newSeg: newHLSSegmenter,
+		byID:   make(map[string]*session),
+		byKey:  make(map[string]*session),
+	}
 }
 
-// Start enregistre une session pour streamID et lance sa goroutine. Idempotent :
-// si une session existe déjà, rien n'est fait.
-func (ls *LiveSessions) Start(streamID string) {
+// Start enregistre une session pour streamID (indexée aussi par streamKey pour
+// l'ingest) et lance sa goroutine, après avoir démarré le segmenteur HLS.
+// Idempotent : si une session existe déjà, rien n'est fait.
+func (ls *LiveSessions) Start(streamID, streamKey string) {
 	ls.mu.Lock()
 	defer ls.mu.Unlock()
 	if _, ok := ls.byID[streamID]; ok {
 		return
 	}
 	ctx, cancel := context.WithCancel(ls.base)
-	s := &session{cancel: cancel, subscribers: make(map[chan SessionEvent]struct{})}
+
+	seg, err := ls.newSeg()
+	if err != nil {
+		// Le flux est déjà 'live' en base : on enregistre quand même la session
+		// (stop/SSE fonctionnent) mais sans audio. En pratique ffmpeg est présent
+		// dans l'image (ADR 015) ; ce chemin couvre son absence en dev.
+		log.Printf("streaming: segmenteur HLS indisponible pour %s: %v", streamID, err)
+		seg = nil
+	}
+
+	s := &session{
+		streamKey:   streamKey,
+		cancel:      cancel,
+		hls:         seg,
+		subscribers: make(map[chan SessionEvent]struct{}),
+	}
 	ls.byID[streamID] = s
+	if streamKey != "" {
+		ls.byKey[streamKey] = s
+	}
 	ls.wg.Add(1)
 	go func() {
 		defer ls.wg.Done()
@@ -55,20 +86,32 @@ func (ls *LiveSessions) Start(streamID string) {
 	}()
 }
 
-// run est la goroutine de session. Placeholder : elle vit jusqu'à l'annulation
-// du context (stop ou shutdown). STR-70/71 y brancheront la segmentation HLS.
+// run est la goroutine de session : elle vit jusqu'à l'annulation du context
+// (stop diffuseur ou shutdown) ou l'arrêt spontané de ffmpeg (entrée terminée /
+// erreur), puis libère le segmenteur (process + répertoire de travail).
 func (s *session) run(ctx context.Context) {
-	<-ctx.Done()
+	if s.hls == nil {
+		<-ctx.Done()
+		return
+	}
+	select {
+	case <-ctx.Done():
+	case <-s.hls.done:
+	}
+	s.hls.close()
 }
 
 // Stop retire la session, publie l'événement "ended" (best-effort) à ses abonnés,
 // PUIS ferme leurs canaux (signal de fin de flux faisant autorité) et annule la
-// goroutine. No-op si aucune session active.
+// goroutine (qui libère le segmenteur). No-op si aucune session active.
 func (ls *LiveSessions) Stop(streamID string) {
 	ls.mu.Lock()
 	s, ok := ls.byID[streamID]
 	if ok {
 		delete(ls.byID, streamID)
+		if s.streamKey != "" {
+			delete(ls.byKey, s.streamKey)
+		}
 	}
 	ls.mu.Unlock()
 	if !ok {
@@ -77,6 +120,64 @@ func (ls *LiveSessions) Stop(streamID string) {
 	s.publish(SessionEvent{Type: "ended"})
 	s.closeSubscribers()
 	s.cancel()
+}
+
+// AttachIngest réserve la session live identifiée par streamKey pour un unique
+// push audio, et retourne l'entrée où copier le flux + une fonction de
+// détachement. Erreurs : errNotLive (clé inconnue / flux pas en direct),
+// errSegmenterUnavailable, errIngestInProgress (un push est déjà en cours).
+func (ls *LiveSessions) AttachIngest(streamKey string) (io.Writer, func(), error) {
+	ls.mu.Lock()
+	s, ok := ls.byKey[streamKey]
+	ls.mu.Unlock()
+	if !ok {
+		return nil, nil, errNotLive
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		// La session a été arrêtée entre la lecture de la map et ici.
+		return nil, nil, errNotLive
+	}
+	if s.hls == nil {
+		return nil, nil, errSegmenterUnavailable
+	}
+	if s.ingesting {
+		return nil, nil, errIngestInProgress
+	}
+	s.ingesting = true
+	release := func() {
+		s.mu.Lock()
+		s.ingesting = false
+		s.mu.Unlock()
+	}
+	return s.hls.input(), release, nil
+}
+
+// Playlist retourne le chemin disque du manifeste .m3u8 du flux en direct
+// (identifié par son id public). ("", false) si le flux n'est pas en direct ou
+// n'a pas de segmenteur.
+func (ls *LiveSessions) Playlist(streamID string) (string, bool) {
+	ls.mu.Lock()
+	s, ok := ls.byID[streamID]
+	ls.mu.Unlock()
+	if !ok || s.hls == nil {
+		return "", false
+	}
+	return s.hls.playlistPath(), true
+}
+
+// Segment retourne le chemin disque d'un segment .ts du flux en direct, après
+// validation stricte du nom (anti path-traversal, cf. hlsSegmenter.segmentPath).
+func (ls *LiveSessions) Segment(streamID, name string) (string, bool) {
+	ls.mu.Lock()
+	s, ok := ls.byID[streamID]
+	ls.mu.Unlock()
+	if !ok || s.hls == nil {
+		return "", false
+	}
+	return s.hls.segmentPath(name)
 }
 
 // Subscribe abonne un client SSE aux événements du flux. Retourne le canal de
@@ -120,11 +221,13 @@ func (ls *LiveSessions) IsLive(streamID string) bool {
 	return ok
 }
 
-// StopAll annule toutes les sessions (arrêt serveur) et libère les goroutines.
+// StopAll annule toutes les sessions (arrêt serveur) et libère les goroutines
+// (qui libèrent chacune leur segmenteur).
 func (ls *LiveSessions) StopAll() {
 	ls.mu.Lock()
 	sessions := ls.byID
 	ls.byID = make(map[string]*session)
+	ls.byKey = make(map[string]*session)
 	ls.mu.Unlock()
 
 	for _, s := range sessions {

--- a/backend/internal/streaming/session_pprof_test.go
+++ b/backend/internal/streaming/session_pprof_test.go
@@ -26,10 +26,10 @@ func waitDrained(t *testing.T, ls *LiveSessions) {
 // TestLiveSessions_NoGoroutineLeak_OnStop vérifie qu'un Stop libère la goroutine
 // de session (STR-86).
 func TestLiveSessions_NoGoroutineLeak_OnStop(t *testing.T) {
-	ls := NewLiveSessions(context.Background())
+	ls := newTestSessions(context.Background())
 	const n = 20
 	for i := 0; i < n; i++ {
-		ls.Start(fmt.Sprintf("s%d", i))
+		ls.Start(fmt.Sprintf("s%d", i), "")
 	}
 	for i := 0; i < n; i++ {
 		ls.Stop(fmt.Sprintf("s%d", i))
@@ -40,10 +40,10 @@ func TestLiveSessions_NoGoroutineLeak_OnStop(t *testing.T) {
 // TestLiveSessions_NoGoroutineLeak_OnStopAll vérifie que StopAll (arrêt serveur)
 // libère toutes les goroutines de session.
 func TestLiveSessions_NoGoroutineLeak_OnStopAll(t *testing.T) {
-	ls := NewLiveSessions(context.Background())
+	ls := newTestSessions(context.Background())
 	const n = 20
 	for i := 0; i < n; i++ {
-		ls.Start(fmt.Sprintf("s%d", i))
+		ls.Start(fmt.Sprintf("s%d", i), "")
 	}
 	ls.StopAll()
 	waitDrained(t, ls)
@@ -53,9 +53,9 @@ func TestLiveSessions_NoGoroutineLeak_OnStopAll(t *testing.T) {
 // context de base (shutdown serveur) termine les goroutines de session (STR-84).
 func TestLiveSessions_NoGoroutineLeak_OnContextCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	ls := NewLiveSessions(ctx)
+	ls := newTestSessions(ctx)
 	for i := 0; i < 20; i++ {
-		ls.Start(fmt.Sprintf("s%d", i))
+		ls.Start(fmt.Sprintf("s%d", i), "")
 	}
 	cancel() // annule le context de base -> toutes les goroutines run() retournent
 	waitDrained(t, ls)

--- a/backend/internal/streaming/session_test.go
+++ b/backend/internal/streaming/session_test.go
@@ -7,13 +7,21 @@ import (
 	"time"
 )
 
+// newTestSessions construit un registre dont le segmenteur HLS est désactivé :
+// les tests de cycle de vie (SSE, goroutines) n'exercent pas ffmpeg.
+func newTestSessions(ctx context.Context) *LiveSessions {
+	ls := NewLiveSessions(ctx)
+	ls.newSeg = func() (*hlsSegmenter, error) { return nil, nil }
+	return ls
+}
+
 func TestLiveSessions_StartRegisters_StopRemoves(t *testing.T) {
-	ls := NewLiveSessions(context.Background())
+	ls := newTestSessions(context.Background())
 
 	if ls.IsLive("s1") {
 		t.Fatal("aucune session ne devrait être active au départ")
 	}
-	ls.Start("s1")
+	ls.Start("s1", "")
 	if !ls.IsLive("s1") {
 		t.Fatal("s1 devrait être live après Start")
 	}
@@ -24,9 +32,9 @@ func TestLiveSessions_StartRegisters_StopRemoves(t *testing.T) {
 }
 
 func TestLiveSessions_StartIdempotent(t *testing.T) {
-	ls := NewLiveSessions(context.Background())
-	ls.Start("s1")
-	ls.Start("s1") // ne doit pas créer de doublon ni paniquer
+	ls := newTestSessions(context.Background())
+	ls.Start("s1", "")
+	ls.Start("s1", "") // ne doit pas créer de doublon ni paniquer
 	if !ls.IsLive("s1") {
 		t.Fatal("s1 devrait être live")
 	}
@@ -34,8 +42,8 @@ func TestLiveSessions_StartIdempotent(t *testing.T) {
 }
 
 func TestLiveSessions_SubscribeReceivesEnded(t *testing.T) {
-	ls := NewLiveSessions(context.Background())
-	ls.Start("s1")
+	ls := newTestSessions(context.Background())
+	ls.Start("s1", "")
 
 	ch, unsub := ls.Subscribe("s1")
 	if ch == nil {
@@ -55,7 +63,7 @@ func TestLiveSessions_SubscribeReceivesEnded(t *testing.T) {
 }
 
 func TestLiveSessions_SubscribeNoSession(t *testing.T) {
-	ls := NewLiveSessions(context.Background())
+	ls := newTestSessions(context.Background())
 	ch, unsub := ls.Subscribe("inconnu")
 	if ch != nil || unsub != nil {
 		t.Fatal("Subscribe sur un flux non live devrait retourner (nil, nil)")
@@ -63,9 +71,9 @@ func TestLiveSessions_SubscribeNoSession(t *testing.T) {
 }
 
 func TestLiveSessions_StopAll(t *testing.T) {
-	ls := NewLiveSessions(context.Background())
-	ls.Start("s1")
-	ls.Start("s2")
+	ls := newTestSessions(context.Background())
+	ls.Start("s1", "")
+	ls.Start("s2", "")
 
 	ls.StopAll()
 
@@ -75,8 +83,8 @@ func TestLiveSessions_StopAll(t *testing.T) {
 }
 
 func TestLiveSessions_SlowSubscriberStillCloses(t *testing.T) {
-	ls := NewLiveSessions(context.Background())
-	ls.Start("s1")
+	ls := newTestSessions(context.Background())
+	ls.Start("s1", "")
 
 	ch, unsub := ls.Subscribe("s1")
 	if ch == nil {
@@ -101,8 +109,8 @@ func TestLiveSessions_SlowSubscriberStillCloses(t *testing.T) {
 }
 
 func TestLiveSessions_SubscribeAfterStop(t *testing.T) {
-	ls := NewLiveSessions(context.Background())
-	ls.Start("s1")
+	ls := newTestSessions(context.Background())
+	ls.Start("s1", "")
 	ls.Stop("s1")
 
 	ch, unsub := ls.Subscribe("s1")
@@ -116,8 +124,8 @@ func TestLiveSessions_SubscribeAfterStop(t *testing.T) {
 // abonnés) et qu'aucun abonné tardif ne reste ouvert sans être fermé.
 func TestLiveSessions_SubscribeStopRace(t *testing.T) {
 	for iter := 0; iter < 100; iter++ {
-		ls := NewLiveSessions(context.Background())
-		ls.Start("s1")
+		ls := newTestSessions(context.Background())
+		ls.Start("s1", "")
 
 		var wg sync.WaitGroup
 		wg.Add(2)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,169 @@
+networks:
+  streampulse-net:
+    driver: bridge
+
+volumes:
+  postgres_data:
+  grafana_data:
+  caddy_data:
+  caddy_config:
+
+services:
+
+  # ──────────────────────────────────────────
+  # Base de données
+  # ──────────────────────────────────────────
+  postgres:
+    image: postgres:16-alpine
+    networks:
+      - streampulse-net
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    # Pas de `ports:` en prod — la base reste interne au réseau Docker.
+    # L'API y accède via `postgres:5432` sur streampulse-net.
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+
+  # ──────────────────────────────────────────
+  # API Go (image tirée de GHCR, pas de build en prod)
+  # ──────────────────────────────────────────
+  api:
+    image: ghcr.io/lignacantony/streampulse/api:latest
+    networks:
+      - streampulse-net
+    ports:
+      - "${API_PORT:-8080}:8080"
+    environment:
+      GO_ENV: ${GO_ENV}
+      DB_HOST: postgres
+      DB_PORT: 5432
+      DB_USER: ${POSTGRES_USER}
+      DB_PASSWORD: ${POSTGRES_PASSWORD}
+      DB_NAME: ${POSTGRES_DB}
+      JWT_SECRET: ${JWT_SECRET}
+      DATABASE_URL: ${DATABASE_URL}
+      SMTP_HOST: ${SMTP_HOST:-}
+      SMTP_PORT: ${SMTP_PORT:-587}
+      SMTP_USERNAME: ${SMTP_USERNAME:-}
+      SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+      SMTP_FROM: ${SMTP_FROM:-noreply@streampulse.com}
+      APP_BASE_URL: ${APP_BASE_URL:-http://localhost:8080}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/health || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+    restart: unless-stopped
+
+  # ──────────────────────────────────────────
+  # Reverse proxy + TLS auto (Let's Encrypt) — Caddy
+  # Point d'entrée public HTTPS ; proxifie vers l'API sur le réseau interne.
+  # ──────────────────────────────────────────
+  caddy:
+    image: caddy:2-alpine
+    networks:
+      - streampulse-net
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./docker/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - api
+    restart: unless-stopped
+
+  # ⚠️ Pas de service `mailpit` en prod — utiliser un vrai relais SMTP via les SMTP_* du .env.
+
+  # ──────────────────────────────────────────
+  # Métriques — Prometheus
+  # ──────────────────────────────────────────
+  prometheus:
+    image: prom/prometheus:latest
+    networks:
+      - streampulse-net
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./docker/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+      - "--web.console.templates=/usr/share/prometheus/consoles"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:9090/-/healthy || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+
+  # ──────────────────────────────────────────
+  # Agrégation de logs — Loki
+  # ──────────────────────────────────────────
+  loki:
+    image: grafana/loki:latest
+    networks:
+      - streampulse-net
+    volumes:
+      - ./docker/loki/loki-config.yml:/etc/loki/local-config.yaml:ro
+    command: -config.file=/etc/loki/local-config.yaml
+    restart: unless-stopped
+
+  # ──────────────────────────────────────────
+  # Traces distribuées — Tempo
+  # ──────────────────────────────────────────
+  tempo:
+    image: grafana/tempo:latest
+    networks:
+      - streampulse-net
+    volumes:
+      - ./docker/tempo/tempo-config.yml:/etc/tempo/tempo-config.yaml:ro
+    command: -config.file=/etc/tempo/tempo-config.yaml
+    restart: unless-stopped
+
+  # ──────────────────────────────────────────
+  # Visualisation — Grafana
+  # ──────────────────────────────────────────
+  grafana:
+    image: grafana/grafana:latest
+    networks:
+      - streampulse-net
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./docker/grafana/provisioning:/etc/grafana/provisioning:ro
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    depends_on:
+      prometheus:
+        condition: service_healthy
+      loki:
+        condition: service_started
+      tempo:
+        condition: service_started
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/api/health || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    restart: unless-stopped

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -58,6 +58,10 @@ services:
       SMTP_FROM: ${SMTP_FROM:-noreply@streampulse.com}
       APP_BASE_URL: ${APP_BASE_URL:-http://localhost:8080}
       CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
+      # Préfixe de la stream_source_url renvoyée aux diffuseurs (STR-70/71). Sans
+      # cette variable, le backend retombe sur http://localhost:8080 (config.go),
+      # inutilisable en prod où l'API est exposée via Caddy sur le domaine public.
+      STREAM_INGEST_BASE_URL: ${STREAM_INGEST_BASE_URL:-https://api.streampulse.win}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -1,0 +1,6 @@
+# api.streampulse.win → reverse proxy vers l'API Go (conteneur `api` sur streampulse-net).
+# Caddy obtient et renouvelle automatiquement le certificat TLS (Let's Encrypt).
+# Prérequis : un enregistrement DNS A `api.streampulse.win` → IP du VPS, en DNS-only.
+api.streampulse.win {
+	reverse_proxy api:8080
+}

--- a/docs/adr/015-moteur-hls-segmentation-ffmpeg.md
+++ b/docs/adr/015-moteur-hls-segmentation-ffmpeg.md
@@ -54,9 +54,12 @@ comme obsolète sur ce point.
 
 ### 1. Segmentation déléguée à **ffmpeg** en sous-processus (une instance par session live)
 
-La goroutine `session.run(ctx)` lance un process **ffmpeg** avec `exec.CommandContext(ctx, …)` :
-l'annulation du context (stop diffuseur ou shutdown serveur) tue proprement ffmpeg via le pipeline
-d'arrêt existant (`Stop`/`StopAll` → `cancel()`).
+Le segmenteur (`hlsSegmenter`, `hls.go`) lance un process **ffmpeg** avec `exec.Command` et une
+goroutine `cmd.Wait()` qui ferme un canal `done` à la sortie du process. La goroutine
+`session.run(ctx)` **supervise** : elle attend `ctx.Done()` (stop diffuseur ou shutdown →
+`Stop`/`StopAll` → `cancel()`) **ou** `done` (arrêt spontané de ffmpeg), puis appelle
+`hlsSegmenter.close()`. Le segmenteur est démarré par `LiveSessions.Start` (hors du verrou du
+registre), pas par `run`.
 
 Invocation cible (remux **sans ré-encodage**, AAC/ADTS → MPEG-TS) :
 
@@ -125,8 +128,8 @@ Deux routes de lecture, servies depuis `<dir>` de la session (via `http.ServeFil
 | `GET` | `/api/streams/{id}/segments/{name}.ts` | un segment | `video/mp2t` |
 
 - **Visibilité** : réutilise la logique de `GetStream` (flux privé d'un tiers / absent / archivé →
-  `404`). `Cache-Control: no-cache` sur le manifeste (il change en continu), cache court sur les
-  segments (immuables une fois écrits).
+  `404`). `Cache-Control: no-cache` sur le manifeste **et** les segments (choix conservateur pour le
+  MVP ; mettre les segments — immuables une fois écrits — en cache court reste une optimisation possible).
 - **Auth auditeur** : `RequireAuth` (JWT), cohérent avec les autres lectures. ⚠️ *caveat* connu :
   certains players HLS natifs passent mal les en-têtes `Authorization` sur les sous-requêtes de
   segments ; si cela bloque la démo, un token de lecture court dans l'URL sera tracé comme suivi
@@ -135,10 +138,16 @@ Deux routes de lecture, servies depuis `<dir>` de la session (via `http.ServeFil
 
 ### 4. Câblage dans la session + arrêt
 
-- `session` porte désormais : le `*exec.Cmd` ffmpeg, son `stdin` (`io.WriteCloser`), et le chemin
-  `<dir>`.
-- `run(ctx)` : crée `<dir>`, lance ffmpeg, puis **attend** sa fin **ou** `ctx.Done()`. À la sortie :
-  ferme stdin, tue le process s'il vit encore, **supprime `<dir>`** (`os.RemoveAll`).
+- Le `*exec.Cmd`, son `stdin` (`io.WriteCloser`), le canal `done` et le chemin `<dir>` sont portés
+  par `hlsSegmenter` (pas par `session`). `LiveSessions.Start` le démarre **hors du verrou** du
+  registre (le `fork` ffmpeg peut être lent), puis le publie sous le verrou de session.
+- `session.run(ctx)` **supervise** : attend `ctx.Done()` **ou** l'arrêt spontané de ffmpeg (`done`),
+  puis `hlsSegmenter.close()` (ferme stdin → ffmpeg finalise, kill après un délai de grâce,
+  **supprime `<dir>`**).
+- **Mort spontanée de ffmpeg** (entrée invalide, crash) : la session est marquée morte puis
+  **récoltée** (retrait du registre + événement SSE `ended`), pour éviter une session « zombie » qui
+  servirait des 404 jusqu'au stop. La ligne DB reste `live` jusqu'au stop du diffuseur (réconciliée
+  au boot, cf. ADR 013 §7).
 - L'événement SSE `ended` existant (ADR 013 §7) reste le **signal de fin faisant autorité** pour
   l'auditeur ; le manifeste cesse simplement d'être mis à jour. On n'ajoute pas de dépendance à un
   `#EXT-X-ENDLIST` écrit à la volée (un `kill` en cours de flux ne le garantirait pas).
@@ -191,7 +200,8 @@ dans le `PATH` (`brew install ffmpeg`).
 - **Dépendance système ffmpeg** dans l'image runtime (rompt l'idéal « binaire autonome pur ») et à
   installer en dev local.
 - **Un process par session live** : à surveiller (limites de process, zombies) ; l'arrêt s'appuie
-  sur `exec.CommandContext` + le pipeline `cancel()` existant.
+  sur `hlsSegmenter.close()` (fermeture de stdin, kill après grâce) déclenché par le pipeline
+  `cancel()` existant, ou par la récolte de la session si ffmpeg meurt seul.
 - **Stockage disque temporaire** par session : nettoyage impératif à l'arrêt (`os.RemoveAll`), sous
   peine de fuite d'espace.
 - **Mono-instance** : le tmp dir est local au process — même limite structurelle que le registre

--- a/docs/adr/015-moteur-hls-segmentation-ffmpeg.md
+++ b/docs/adr/015-moteur-hls-segmentation-ffmpeg.md
@@ -1,0 +1,209 @@
+# ADR 015 — Moteur HLS : segmentation et manifeste via ffmpeg
+
+**Date** : 2026-07-13
+**Statut** : Accepté
+**Ticket** : [STR-70](https://linear.app/streampulse/issue/STR-70) (sous-issue [STR-71](https://linear.app/streampulse/issue/STR-71) — endpoint de réception)
+
+---
+
+## Contexte
+
+STR-70 poursuit la milestone **« Moteur de Streaming Live (Backend Go) »**. Après le CRUD des
+flux ([ADR 013](013-domaine-streaming.md)) et le cycle de vie du direct start/stop + SSE
+([ADR 013](013-domaine-streaming.md) §7), il faut désormais **transporter réellement l'audio** :
+
+> En tant que backend, je veux segmenter le flux audio entrant en fichiers `.ts` de ~10 s et
+> générer un manifeste `.m3u8` mis à jour en continu, afin de permettre la lecture HLS par les
+> clients.
+
+Le CDC (§4.3) fixe le transport : **pas de RTMP**. Le diffuseur pousse de l'audio **AAC via un
+endpoint HTTP** du backend, et le backend **segmente en HLS** (protocole de lecture côté auditeur).
+
+### État du code au démarrage de STR-70
+
+- `LiveSessions` ([`session.go`](../../backend/internal/streaming/session.go)) gère déjà le cycle
+  de vie d'une session live : une goroutine par flux, `context.CancelFunc`, mutex, abonnés SSE,
+  drain déterministe via `Wait()`. La goroutine `session.run(ctx)` est un **placeholder**
+  (`<-ctx.Done()`) explicitement réservé à STR-70/71 (cf. ADR 013 §7).
+- L'URL de stream source `{STREAM_INGEST_BASE_URL}/api/streams/ingest/{stream_key}` est **déjà
+  annoncée** au diffuseur ([`handler.go`](../../backend/internal/streaming/handler.go), `toResponse`),
+  mais **aucun endpoint ne l'écoute encore**.
+- Aucun service de manifeste ni de segments côté auditeur.
+
+### Découpage STR-70 / STR-71
+
+STR-71 est une **sous-issue** de STR-70. Répartition retenue :
+
+- **STR-71** = l'**endpoint de réception** (ingest) qui accepte le flux entrant et le pousse dans
+  le moteur.
+- **STR-70** (parent) = le **moteur HLS** : segmentation, manifeste glissant, service des fichiers
+  aux auditeurs, câblage dans la session.
+
+### Incohérence de contrat résolue
+
+Le titre de STR-71 évoque `POST /api/streams/:id/broadcast` (routé par **id**), alors que l'URL
+**déjà exposée au diffuseur** (ADR 013) est routée par **stream_key** :
+`…/api/streams/ingest/{stream_key}`. On **conserve la forme par `stream_key`** : elle est déjà dans
+le contrat, déjà lisible par le diffuseur dans son dashboard, et le `stream_key` est le secret
+d'authentification naturel du push (modèle Twitch/OBS). Le titre de STR-71 est donc considéré
+comme obsolète sur ce point.
+
+---
+
+## Décision
+
+### 1. Segmentation déléguée à **ffmpeg** en sous-processus (une instance par session live)
+
+La goroutine `session.run(ctx)` lance un process **ffmpeg** avec `exec.CommandContext(ctx, …)` :
+l'annulation du context (stop diffuseur ou shutdown serveur) tue proprement ffmpeg via le pipeline
+d'arrêt existant (`Stop`/`StopAll` → `cancel()`).
+
+Invocation cible (remux **sans ré-encodage**, AAC/ADTS → MPEG-TS) :
+
+```
+ffmpeg -hide_banner -loglevel warning \
+  -i pipe:0 \                                  # audio entrant lu sur stdin
+  -c:a copy \                                  # passthrough AAC → TS (pas de transcodage, CPU ~0)
+  -f hls \
+  -hls_time 10 \                               # segments ~10 s
+  -hls_list_size 6 \                           # fenêtre glissante (≈1 min de retard max)
+  -hls_flags delete_segments+append_list+omit_endlist \
+  -hls_segment_type mpegts \
+  -hls_base_url segments/ \                     # URI des segments dans le manifeste → segments/…
+  -hls_segment_filename '<dir>/seg_%05d.ts' \
+  '<dir>/playlist.m3u8'
+```
+
+- `<dir>` = répertoire temporaire **par session** (`os.MkdirTemp`, monté sur tmpfs en prod si
+  possible). ffmpeg y écrit les `.ts` **et** le `.m3u8`, et gère seul la fenêtre glissante
+  (`delete_segments`).
+- `-c:a copy` : le flux étant déjà AAC, on **remux** seulement (empaquetage TS). Pas de
+  transcodage → coût CPU négligeable, pas de perte de qualité.
+- `-hls_base_url segments/` : les players HLS résolvent les URI de segments **relativement au
+  manifeste**. Comme le manifeste est servi à `…/{id}/playlist.m3u8` et les segments à
+  `…/{id}/segments/{seg}`, on préfixe les entrées du manifeste par `segments/` (le fichier sur
+  disque garde son nom nu `seg_%05d.ts`).
+- Le manifeste produit est un **live playlist** (pas de `#EXT-X-ENDLIST` tant que le flux tourne,
+  grâce à `omit_endlist`).
+
+Le segmenteur (`internal/streaming/hls.go`) encapsule ce process : création du `<dir>`, démarrage
+de ffmpeg, exposition de son `stdin` (entrée d'ingest) et des chemins manifeste/segments, puis
+`close()` (ferme stdin → ffmpeg finalise, kill au-delà d'un délai de grâce, supprime `<dir>`). Il
+est injectable dans `LiveSessions` (factory `newSeg`) pour des tests unitaires **sans ffmpeg**.
+
+### 2. Endpoint d'ingest (STR-71) : `POST /api/streams/ingest/{stream_key}`
+
+- **Authentification par `stream_key`, routage 100 % en mémoire** (pas de JWT, **pas de lookup DB**).
+  Le `start` du flux connaît déjà la clé (`stream.StreamKey`) : `Sessions.Start(streamID, streamKey)`
+  indexe la session à la fois par `id` (public : SSE, lecture HLS) et par `stream_key` (secret :
+  ingest). Le handler appelle `LiveSessions.AttachIngest(stream_key)` qui résout la session **en
+  mémoire**. Conséquence : « clé inconnue » et « flux pas en direct » sont indistinguables sans
+  session → **404** unique (on ne divulgue pas la validité d'une clé). Ce choix évite une requête SQL
+  et une nouvelle query sqlc, et colle au fait que `LiveSessions` est déjà l'autorité in-memory du
+  direct (cf. ADR 013 §7).
+- **Corps = flux continu** : `AttachIngest` retourne l'`io.Writer` (stdin ffmpeg) + une fonction de
+  détachement ; le handler **copie `r.Body` dedans** en streaming (`io.Copy`). La requête reste
+  ouverte toute la diffusion. En fin de push, on **ne ferme pas** l'entrée du segmenteur : la session
+  reste live (fenêtre de segments disponible) jusqu'au `stop` explicite.
+- **Un seul push par flux** : un flag `ingesting` (sous mutex) rejette un 2e push concurrent → `409`.
+  Segmenteur indisponible (ffmpeg absent) → `500`.
+- **Timeouts serveur** : le push est long ; le handler neutralise les `ReadTimeout`/`WriteTimeout`
+  d'`http.Server` via `http.NewResponseController` (`SetReadDeadline`/`SetWriteDeadline` à zéro),
+  sinon une diffusion de plusieurs minutes serait coupée.
+- **Note « multipart »** : l'énoncé mentionne « multipart ». Pour un flux **continu** unique, un
+  corps brut en `Transfer-Encoding: chunked` (`Content-Type: audio/aac`) est plus simple et se pipe
+  directement dans `pipe:0`. On accepte le corps en streaming ; la forme brute chunked est la voie
+  recommandée pour le MVP.
+
+### 3. Service des fichiers HLS aux auditeurs
+
+Deux routes de lecture, servies depuis `<dir>` de la session (via `http.ServeFile` / `ServeContent`) :
+
+| Méthode | Route | Contenu | Content-Type |
+|---|---|---|---|
+| `GET` | `/api/streams/{id}/playlist.m3u8` | manifeste courant | `application/vnd.apple.mpegurl` |
+| `GET` | `/api/streams/{id}/segments/{name}.ts` | un segment | `video/mp2t` |
+
+- **Visibilité** : réutilise la logique de `GetStream` (flux privé d'un tiers / absent / archivé →
+  `404`). `Cache-Control: no-cache` sur le manifeste (il change en continu), cache court sur les
+  segments (immuables une fois écrits).
+- **Auth auditeur** : `RequireAuth` (JWT), cohérent avec les autres lectures. ⚠️ *caveat* connu :
+  certains players HLS natifs passent mal les en-têtes `Authorization` sur les sous-requêtes de
+  segments ; si cela bloque la démo, un token de lecture court dans l'URL sera tracé comme suivi
+  (hors périmètre STR-70).
+- **Anti-traversal** : `{name}` validé strictement (`^seg_\d+\.ts$`), jamais concaténé brut au path.
+
+### 4. Câblage dans la session + arrêt
+
+- `session` porte désormais : le `*exec.Cmd` ffmpeg, son `stdin` (`io.WriteCloser`), et le chemin
+  `<dir>`.
+- `run(ctx)` : crée `<dir>`, lance ffmpeg, puis **attend** sa fin **ou** `ctx.Done()`. À la sortie :
+  ferme stdin, tue le process s'il vit encore, **supprime `<dir>`** (`os.RemoveAll`).
+- L'événement SSE `ended` existant (ADR 013 §7) reste le **signal de fin faisant autorité** pour
+  l'auditeur ; le manifeste cesse simplement d'être mis à jour. On n'ajoute pas de dépendance à un
+  `#EXT-X-ENDLIST` écrit à la volée (un `kill` en cours de flux ne le garantirait pas).
+
+### 5. ffmpeg dans l'image runtime
+
+`apk add --no-cache ffmpeg` dans le **stage runner** du [`backend/Dockerfile`](../../backend/Dockerfile)
+(alpine). Le binaire Go reste statique (CGO désactivé) ; ffmpeg est une dépendance **système**
+appelée en sous-processus, pas liée au binaire. En dev local sans Docker, ffmpeg doit être présent
+dans le `PATH` (`brew install ffmpeg`).
+
+---
+
+## Alternatives considérées
+
+- **Bibliothèque HLS Go pure** (`bluenviron/gohlslib`, `asticode/go-astits`) : muxer MPEG-TS en Go,
+  **pas de binaire système**, reste dans l'esprit « binaire statique / zéro dépendance lourde » du
+  projet, très testable en process. **Écartée pour le MVP** : nettement plus de code (parsing ADTS,
+  gestion PTS/DTS, fenêtre glissante, écriture manifeste) et on **possède les bugs de muxing** —
+  exactement la classe de bugs (audio saccadé, timestamps qui dérivent) coûteuse à déboguer sur un
+  projet étudiant. Candidate naturelle si on veut plus tard retirer la dépendance système.
+- **Muxer MPEG-TS maison (stdlib only)** : contrôle et pureté maximales, mais effort et risque de
+  correctness hors budget MVP. Rejetée.
+- **RTMP + serveur média externe (nginx-rtmp, MediaMTX)** : rejeté par le CDC (§4.3, pas de RTMP)
+  et alourdit l'infra.
+- **Transcodage `-c:a aac`** (au lieu de `copy`) : inutile puisque l'entrée est déjà AAC ; ajoute du
+  CPU et de la latence. On garde le **remux** `copy`.
+- **Segments/manifeste en mémoire** (ring buffer, pas de disque) : impose d'intercepter la sortie
+  ffmpeg, ce qui annule la simplicité du `-f hls` vers un répertoire. Rejeté pour le MVP ; le tmp
+  dir sur tmpfs offre déjà un stockage volatil et rapide.
+- **Ingest routé par `id` + JWT** (titre initial STR-71) : rejeté — le `stream_key` est déjà le
+  secret de push exposé au diffuseur (cf. §2 et ADR 013).
+
+---
+
+## Conséquences
+
+### Avantages
+
+- **Correctness quasi gratuite** : ffmpeg est la référence du muxing HLS ; sortie conforme, lue par
+  tout player standard (Safari, `hls.js`, `just_audio`).
+- **Peu de code Go** : la logique de segmentation tient dans une invocation ; le backend se limite à
+  lancer/piloter le process et servir des fichiers. Se greffe sur `LiveSessions` **sans repenser la
+  concurrence** (le placeholder `run()` était prévu pour ça).
+- **CPU négligeable** (remux `-c:a copy`, pas de transcodage).
+- **Chemin le plus court vers une démo qui se lit vraiment.**
+
+### Inconvénients
+
+- **Dépendance système ffmpeg** dans l'image runtime (rompt l'idéal « binaire autonome pur ») et à
+  installer en dev local.
+- **Un process par session live** : à surveiller (limites de process, zombies) ; l'arrêt s'appuie
+  sur `exec.CommandContext` + le pipeline `cancel()` existant.
+- **Stockage disque temporaire** par session : nettoyage impératif à l'arrêt (`os.RemoveAll`), sous
+  peine de fuite d'espace.
+- **Mono-instance** : le tmp dir est local au process — même limite structurelle que le registre
+  `LiveSessions` (multi-réplica hors scope, cf. ADR 013 §7).
+
+---
+
+## Références
+
+- [ADR 013](013-domaine-streaming.md) — domaine streaming, cycle de vie du direct (§7), `LiveSessions`.
+- [ADR 008](008-architecture-handler-service-repository.md) — handler/service/repository.
+- [ADR 012](012-openapi-source-de-verite.md) — OpenAPI source de vérité (mettre à jour `openapi.yaml`
+  puis régénérer le client mobile après ajout des routes).
+- CDC §4.3 — transport d'ingest HTTP, pas de RTMP, segmentation HLS côté backend.
+- STR-70 (moteur HLS) / STR-71 (endpoint de réception, sous-issue).

--- a/docs/adr/015-moteur-hls-segmentation-ffmpeg.md
+++ b/docs/adr/015-moteur-hls-segmentation-ffmpeg.md
@@ -110,6 +110,10 @@ est injectable dans `LiveSessions` (factory `newSeg`) pour des tests unitaires *
   reste live (fenêtre de segments disponible) jusqu'au `stop` explicite.
 - **Un seul push par flux** : un flag `ingesting` (sous mutex) rejette un 2e push concurrent → `409`.
   Segmenteur indisponible (ffmpeg absent) → `500`.
+- **Content-Type** : validation **légère** — si l'en-tête est présent, il doit être `audio/*`, sinon
+  `415` avant toute copie (un push non-audio ferait tourner le demuxer ADTS indéfiniment, sans
+  produire de segment ni tuer ffmpeg — donc ni `dead`/`reap`). Un Content-Type **absent** reste
+  accepté (clients bruts). Garde-fou UX, pas une frontière de sécurité (le type est falsifiable).
 - **Timeouts serveur** : le push est long ; le handler neutralise les `ReadTimeout`/`WriteTimeout`
   d'`http.Server` via `http.NewResponseController` (`SetReadDeadline`/`SetWriteDeadline` à zéro),
   sinon une diffusion de plusieurs minutes serait coupée.
@@ -135,6 +139,10 @@ Deux routes de lecture, servies depuis `<dir>` de la session (via `http.ServeFil
   segments ; si cela bloque la démo, un token de lecture court dans l'URL sera tracé comme suivi
   (hors périmètre STR-70).
 - **Anti-traversal** : `{name}` validé strictement (`^seg_\d+\.ts$`), jamais concaténé brut au path.
+- **Fichier absent** : session vivante mais fichier pas encore écrit (fenêtre start→1er segment, ou
+  push dont ffmpeg n'a rien produit) ou déjà retiré (fenêtre glissante) → un `os.Stat` renvoie
+  l'erreur JSON documentée (manifeste `409`, segment `404`) plutôt que le `404 page not found`
+  text/plain brut de `http.ServeFile` (hors contrat `httpjson`).
 
 ### 4. Câblage dans la session + arrêt
 

--- a/mobile/packages/streampulse_api/README.md
+++ b/mobile/packages/streampulse_api/README.md
@@ -84,10 +84,13 @@ Class | Method | HTTP request | Description
 [*StreamingApi*](doc/StreamingApi.md) | [**createStream**](doc/StreamingApi.md#createstream) | **POST** /api/streams | Create and configure a new live stream (broadcaster only).
 [*StreamingApi*](doc/StreamingApi.md) | [**deleteStream**](doc/StreamingApi.md#deletestream) | **DELETE** /api/streams/{id} | Delete (archive) a stream (owner only).
 [*StreamingApi*](doc/StreamingApi.md) | [**getStream**](doc/StreamingApi.md#getstream) | **GET** /api/streams/{id} | Get a stream by id.
+[*StreamingApi*](doc/StreamingApi.md) | [**ingestStream**](doc/StreamingApi.md#ingeststream) | **POST** /api/streams/ingest/{stream_key} | Push a live audio stream (broadcaster ingest).
 [*StreamingApi*](doc/StreamingApi.md) | [**listStreams**](doc/StreamingApi.md#liststreams) | **GET** /api/streams | List public live streams (paginated).
 [*StreamingApi*](doc/StreamingApi.md) | [**startStream**](doc/StreamingApi.md#startstream) | **PATCH** /api/streams/{id}/start | Start a stream — go live (broadcaster owner only).
 [*StreamingApi*](doc/StreamingApi.md) | [**stopStream**](doc/StreamingApi.md#stopstream) | **PATCH** /api/streams/{id}/stop | Stop a live stream — end it (broadcaster owner only).
 [*StreamingApi*](doc/StreamingApi.md) | [**streamEvents**](doc/StreamingApi.md#streamevents) | **GET** /api/streams/{id}/events | Subscribe to a live stream&#39;s events (SSE).
+[*StreamingApi*](doc/StreamingApi.md) | [**streamPlaylist**](doc/StreamingApi.md#streamplaylist) | **GET** /api/streams/{id}/playlist.m3u8 | Get the live HLS media playlist (manifest).
+[*StreamingApi*](doc/StreamingApi.md) | [**streamSegment**](doc/StreamingApi.md#streamsegment) | **GET** /api/streams/{id}/segments/{segment} | Get an HLS media segment (.ts).
 [*StreamingApi*](doc/StreamingApi.md) | [**updateStream**](doc/StreamingApi.md#updatestream) | **PUT** /api/streams/{id} | Update a stream (owner only).
 
 

--- a/mobile/packages/streampulse_api/lib/src/api/streaming_api.dart
+++ b/mobile/packages/streampulse_api/lib/src/api/streaming_api.dart
@@ -9,6 +9,7 @@ import 'dart:convert';
 import 'package:streampulse_api/src/deserialize.dart';
 import 'package:dio/dio.dart';
 
+import 'dart:typed_data';
 import 'package:streampulse_api/src/model/create_stream_request.dart';
 import 'package:streampulse_api/src/model/error_response.dart';
 import 'package:streampulse_api/src/model/stream_response.dart';
@@ -243,6 +244,70 @@ class StreamingApi {
       statusMessage: _response.statusMessage,
       extra: _response.extra,
     );
+  }
+
+  /// Push a live audio stream (broadcaster ingest).
+  /// Continuous AAC audio ingest for a live stream, authenticated by the &#x60;stream_key&#x60; in the path (no JWT). The request body is a continuous audio stream segmented into HLS by the backend (cf. ADR 015). The stream must be live (started) for the push to be accepted.
+  ///
+  /// Parameters:
+  /// * [streamKey] - The broadcaster's secret stream key (from stream_source_url).
+  /// * [body]
+  /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
+  /// * [headers] - Can be used to add additional headers to the request
+  /// * [extras] - Can be used to add flags to the request
+  /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
+  /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
+  /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
+  ///
+  /// Returns a [Future]
+  /// Throws [DioException] if API call or serialization fails
+  Future<Response<void>> ingestStream({
+    required String streamKey,
+    required MultipartFile body,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    final _path = r'/api/streams/ingest/{stream_key}'.replaceAll(
+      '{'
+      r'stream_key'
+      '}',
+      streamKey.toString(),
+    );
+    final _options = Options(
+      method: r'POST',
+      headers: <String, dynamic>{...?headers},
+      extra: <String, dynamic>{'secure': <Map<String, String>>[], ...?extra},
+      contentType: 'audio/aac',
+      validateStatus: validateStatus,
+    );
+
+    dynamic _bodyData;
+
+    try {
+      _bodyData = jsonEncode(body);
+    } catch (error, stackTrace) {
+      throw DioException(
+        requestOptions: _options.compose(_dio.options, _path),
+        type: DioExceptionType.unknown,
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+
+    final _response = await _dio.request<Object>(
+      _path,
+      data: _bodyData,
+      options: _options,
+      cancelToken: cancelToken,
+      onSendProgress: onSendProgress,
+      onReceiveProgress: onReceiveProgress,
+    );
+
+    return _response;
   }
 
   /// List public live streams (paginated).
@@ -561,6 +626,170 @@ class StreamingApi {
     }
 
     return Response<String>(
+      data: _responseData,
+      headers: _response.headers,
+      isRedirect: _response.isRedirect,
+      requestOptions: _response.requestOptions,
+      redirects: _response.redirects,
+      statusCode: _response.statusCode,
+      statusMessage: _response.statusMessage,
+      extra: _response.extra,
+    );
+  }
+
+  /// Get the live HLS media playlist (manifest).
+  /// Returns the continuously-updated HLS media playlist (&#x60;.m3u8&#x60;) of a live stream. Segment URIs are relative (&#x60;segments/…&#x60;). Requires the stream to be live.
+  ///
+  /// Parameters:
+  /// * [id]
+  /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
+  /// * [headers] - Can be used to add additional headers to the request
+  /// * [extras] - Can be used to add flags to the request
+  /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
+  /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
+  /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
+  ///
+  /// Returns a [Future] containing a [Response] with a [String] as data
+  /// Throws [DioException] if API call or serialization fails
+  Future<Response<String>> streamPlaylist({
+    required String id,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    final _path = r'/api/streams/{id}/playlist.m3u8'.replaceAll(
+      '{'
+      r'id'
+      '}',
+      id.toString(),
+    );
+    final _options = Options(
+      method: r'GET',
+      headers: <String, dynamic>{...?headers},
+      extra: <String, dynamic>{
+        'secure': <Map<String, String>>[
+          {'type': 'http', 'scheme': 'bearer', 'name': 'bearerAuth'},
+        ],
+        ...?extra,
+      },
+      validateStatus: validateStatus,
+    );
+
+    final _response = await _dio.request<Object>(
+      _path,
+      options: _options,
+      cancelToken: cancelToken,
+      onSendProgress: onSendProgress,
+      onReceiveProgress: onReceiveProgress,
+    );
+
+    String? _responseData;
+
+    try {
+      final rawData = _response.data;
+      _responseData = rawData == null
+          ? null
+          : deserialize<String, String>(rawData, 'String', growable: true);
+    } catch (error, stackTrace) {
+      throw DioException(
+        requestOptions: _response.requestOptions,
+        response: _response,
+        type: DioExceptionType.unknown,
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+
+    return Response<String>(
+      data: _responseData,
+      headers: _response.headers,
+      isRedirect: _response.isRedirect,
+      requestOptions: _response.requestOptions,
+      redirects: _response.redirects,
+      statusCode: _response.statusCode,
+      statusMessage: _response.statusMessage,
+      extra: _response.extra,
+    );
+  }
+
+  /// Get an HLS media segment (.ts).
+  /// Returns an MPEG-TS audio segment referenced by the live playlist. Requires the stream to be live.
+  ///
+  /// Parameters:
+  /// * [id]
+  /// * [segment] - Segment file name (e.g. seg_00001.ts).
+  /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
+  /// * [headers] - Can be used to add additional headers to the request
+  /// * [extras] - Can be used to add flags to the request
+  /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
+  /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
+  /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
+  ///
+  /// Returns a [Future] containing a [Response] with a [Uint8List] as data
+  /// Throws [DioException] if API call or serialization fails
+  Future<Response<Uint8List>> streamSegment({
+    required String id,
+    required String segment,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    final _path = r'/api/streams/{id}/segments/{segment}'
+        .replaceAll(
+          '{'
+          r'id'
+          '}',
+          id.toString(),
+        )
+        .replaceAll(
+          '{'
+          r'segment'
+          '}',
+          segment.toString(),
+        );
+    final _options = Options(
+      method: r'GET',
+      responseType: ResponseType.bytes,
+      headers: <String, dynamic>{...?headers},
+      extra: <String, dynamic>{
+        'secure': <Map<String, String>>[
+          {'type': 'http', 'scheme': 'bearer', 'name': 'bearerAuth'},
+        ],
+        ...?extra,
+      },
+      validateStatus: validateStatus,
+    );
+
+    final _response = await _dio.request<Object>(
+      _path,
+      options: _options,
+      cancelToken: cancelToken,
+      onSendProgress: onSendProgress,
+      onReceiveProgress: onReceiveProgress,
+    );
+
+    Uint8List? _responseData;
+
+    try {
+      final rawData = _response.data;
+      _responseData = rawData == null ? null : rawData as Uint8List;
+    } catch (error, stackTrace) {
+      throw DioException(
+        requestOptions: _response.requestOptions,
+        response: _response,
+        type: DioExceptionType.unknown,
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+
+    return Response<Uint8List>(
       data: _responseData,
       headers: _response.headers,
       isRedirect: _response.isRedirect,


### PR DESCRIPTION
## STR-70 — Moteur HLS : segmentation et génération du manifeste

[STR-70](https://linear.app/streampulse/issue/STR-70) · milestone *Moteur de Streaming Live (Backend Go)*. Inclut la sous-issue **STR-71** (endpoint d'ingest).

STR-77 a posé le cycle de vie du direct avec une goroutine de session **placeholder** (`<-ctx.Done()`). STR-70 remplit ce placeholder avec le **moteur HLS réel** : le diffuseur pousse de l'AAC, le backend le segmente en `.ts` de ~10 s via **ffmpeg** et sert un manifeste `.m3u8` glissant aux auditeurs.

### Endpoints
| Méthode | Route | Auth | Effet |
|---|---|---|---|
| `POST` | `/api/streams/ingest/{stream_key}` | clé (pas de JWT) | ingest du flux audio du diffuseur (STR-71) |
| `GET` | `/api/streams/{id}/playlist.m3u8` | JWT | manifeste HLS du direct (**409** si pas live) |
| `GET` | `/api/streams/{id}/segments/{segment}` | JWT | segment `.ts` (nom validé anti-traversal) |

### Décisions (cf. [ADR 015](docs/adr/015-moteur-hls-segmentation-ffmpeg.md))
- **Segmentation déléguée à ffmpeg** (`-c:a copy`, remux AAC→MPEG-TS, CPU ~0) plutôt qu'un muxer Go maison : correctness éprouvée, peu de code, chemin le plus court vers une lecture réelle. Alternative Go pur (`gohlslib`) écartée pour le MVP. ffmpeg ajouté à l'image runtime (`Dockerfile`) **et** à la CI.
- **Ingest routé 100 % en mémoire par `stream_key`** : `Sessions.Start(streamID, streamKey)` indexe la session par id (public) et par clé (secret) ; `AttachIngest(stream_key)` résout **sans requête DB** ni nouvelle query sqlc. Clé inconnue / pas live → **404** (on ne divulgue pas la validité d'une clé), 2ᵉ push concurrent → **409**.
- **Un segmenteur ffmpeg par session live**, possédé par `session.run()` : démarré au start, entrée = stdin ffmpeg, sortie = répertoire temp servi aux auditeurs, **process tué + répertoire supprimé** au stop (aucune fuite). Segmenteur **injectable** (factory `newSeg`) → tests unitaires sans ffmpeg.
- **`-hls_base_url segments/`** : les URI du manifeste pointent vers `segments/…` pour coller à la route auditeur (les players HLS résolvent relativement au manifeste).
- **Timeouts** : le push est long → `ReadTimeout`/`WriteTimeout` neutralisés par requête via `http.NewResponseController`.
- **Fin de push ≠ fin de flux** : à la déconnexion du diffuseur la session reste `live` (dernière fenêtre disponible) jusqu'au `stop` explicite.
- **Aucune migration** de base.

### Vérification
- `go test -race ./...` vert — nouveaux tests HLS : routage par clé, guard un-seul-push, **anti path-traversal**, lookup manifeste/segment, + **test d'intégration ffmpeg réel** (skip si absent, exécuté en CI où ffmpeg est désormais installé). `go vet` / `gofmt` clean.
- OpenAPI mise à jour (3 endpoints) + validée (`openapi_test.go`) ; **client mobile régénéré** (`StreamingApi`).
- **Démo end-to-end réelle** (stack Docker) : create → start → push ffmpeg → manifeste qui se remplit → segment `video/mp2t` (87 Ko) servi → stop. Teardown propre : 0 process ffmpeg, 0 répertoire temp, lecture après stop → **409**.
- **Test de charge — 1 diffuseur → 5 auditeurs simultanés** : **385/385 requêtes en HTTP 200, 0 échec**, 27,4 Mo de segments servis, latence segments p50 = 5,4 ms / p95 = 9,0 ms.

### Contenu de la branche (2 commits)
- `feat(api): implémenter l'ingestion HLS et la génération manifeste` — cette US (backend + tests + OpenAPI + ADR 015 + client mobile).
- `feat(docker): ajouter la configuration de l'infrastructure pour le déploiement en production` — commit d'infra **préexistant** sur la branche (`docker-compose.prod.yml`, `docker/caddy/Caddyfile`), pas encore sur `develop` ; il remonte donc dans cette PR. À sortir si vous préférez le traiter séparément.

### Hors scope
- Consommation SSE côté Flutter (écran auditeur) — ticket mobile dédié.
- Multi-instance : le registre `LiveSessions` et le répertoire temp sont locaux au process (cf. [ADR 013](docs/adr/013-domaine-streaming.md) §7).
- Chiffrement / régénération du `stream_key`.
