### PR TITLE
fix(api): neutraliser le faux positif gosec G204 sur l'appel ffmpeg

### DIFF
--- a/backend/internal/streaming/hls.go
+++ b/backend/internal/streaming/hls.go
@@ -51,7 +51,11 @@ func newHLSSegmenter() (*hlsSegmenter, error) {
 		return nil, fmt.Errorf("hls: create work dir: %w", err)
 	}
 
-	cmd := exec.Command("ffmpeg",
+	// Arguments ffmpeg : uniquement des constantes et des chemins dérivés de `dir`
+	// (os.MkdirTemp, généré côté serveur). AUCUNE entrée diffuseur/auditeur ne
+	// transite par la ligne de commande — le stream_key est un lookup mémoire et
+	// l'audio arrive par stdin (pipe:0). Le G204 de gosec est donc un faux positif.
+	args := []string{
 		"-hide_banner", "-loglevel", "warning",
 		"-i", "pipe:0", // audio lu sur stdin
 		"-c:a", "copy", // remux AAC -> TS, pas de transcodage
@@ -63,8 +67,9 @@ func newHLSSegmenter() (*hlsSegmenter, error) {
 		"-hls_base_url", hlsSegmentPrefix, // les URI du manifeste pointent vers segments/…
 		"-hls_segment_filename", filepath.Join(dir, hlsSegmentPattern),
 		filepath.Join(dir, hlsPlaylistName),
-	)
-	cmd.Stderr = os.Stderr // warnings/erreurs ffmpeg vers les logs du conteneur
+	}
+	cmd := exec.Command("ffmpeg", args...) // #nosec G204 -- args 100% statiques/serveur (os.MkdirTemp), aucune entrée utilisateur
+	cmd.Stderr = os.Stderr                 // warnings/erreurs ffmpeg vers les logs du conteneur
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {


### PR DESCRIPTION
## Contexte

Le job **gosec** de la CI (`security.yml` → `gosec --exclude-generated ./...`) échouait sur `develop` :

> G204 (CWE-78) — *Subprocess launched with a potential tainted input or cmd arguments* (HIGH / MEDIUM) — `backend/internal/streaming/hls.go`

## Analyse : faux positif

Tous les arguments passés à `ffmpeg` sont des **constantes** ou des **chemins dérivés d'`os.MkdirTemp`** (générés côté serveur). **Aucune entrée diffuseur/auditeur ne transite par la ligne de commande** :
- le `stream_key` est un lookup mémoire (jamais passé à ffmpeg) ;
- l'audio arrive par **stdin** (`pipe:0`), pas par les arguments.

Il n'y a donc pas de commande à assainir — c'est un faux positif.

## Fix

Arguments ffmpeg extraits dans un slice pour poser un `// #nosec G204` **justifié** sur la ligne `exec.Command` (là où gosec ancre la finding), en suivant la convention déjà en place dans le repo (`// #nosec G706 -- …` dans `httpjson.go`).

## Vérification

Commande CI reproduite en local :

```
gosec --exclude-generated ./...
  Files  : 32
  Nosec  : 2
  Issues : 0   ✅ (était 1)
```

`go build ./...` · `gofmt` · `go test ./internal/streaming/...` verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
