### PR TITLE
feat(api): scalabilité 50 auditeurs — test de charge, limiteur HLS et rapport

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,3 +80,7 @@ CORS_ALLOWED_ORIGINS=
 #   {STREAM_INGEST_BASE_URL}/api/streams/ingest/{stream_key}
 # En prod, pointer vers l'endpoint d'ingest public.
 STREAM_INGEST_BASE_URL=http://localhost:8080
+
+# Nombre max de requêtes HLS (playlist + segments) servies simultanément aux
+# auditeurs — STR-88. 0 = illimité.
+HLS_MAX_CONCURRENT=256

--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -1,0 +1,35 @@
+name: Load Test
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  loadtest:
+    name: Test de charge HLS (STR-90)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache-dependency-path: backend/go.sum
+
+      - name: Install ffmpeg (segmentation HLS — cf. ADR 015)
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
+      - name: Run load test
+        working-directory: ./backend
+        shell: bash
+        run: go test -tags loadtest -race -count=1 -run TestLoad -v -timeout 10m ./internal/streaming/loadtest/ 2>&1 | tee loadtest-report.txt
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: loadtest-report
+          path: backend/loadtest-report.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,8 @@ go run ./cmd/api          # Run dev server
 go test ./...             # Run all tests
 go test ./path/to/pkg/... # Run a single package's tests
 go build -o bin/api ./cmd/api
+make loadtest             # Test de charge HLS 50 auditeurs (STR-90) — depuis la racine, requiert ffmpeg
+# Décision + run de référence : docs/adr/016-scalabilite-test-de-charge-et-limiteur-hls.md
 sqlc generate              # Regénérer le code SQL → Go après modif d'une query
 
 # Mobile (Flutter) — dans mobile/
@@ -198,8 +200,8 @@ Domaine `internal/streaming/` (handler/service/repository). Détails dans [ADR 0
 | PATCH | `/api/streams/{id}/stop` | `Handler.Stop` | Oui — rôle `broadcaster`, owner ; `live→ended` (409 si pas live) |
 | GET | `/api/streams/{id}/events` | `Handler.Events` | Oui (JWT) — flux **SSE**, event `ended` à l'arrêt (STR-77) |
 | POST | `/api/streams/ingest/{stream_key}` | `Handler.Ingest` | **Non (JWT)** — auth par `stream_key` dans le path ; push audio AAC segmenté en HLS (STR-70/71) |
-| GET | `/api/streams/{id}/playlist.m3u8` | `Handler.Playlist` | **Public** (`OptionalAuth`) — flux publics servis à un anonyme, privé → 404 ; owner authentifié voit ses flux privés — manifeste HLS, 409 si pas live/pas prêt (STR-108) |
-| GET | `/api/streams/{id}/segments/{segment}` | `Handler.Segment` | **Public** (`OptionalAuth`) — idem playlist — segment `.ts` (nom validé anti-traversal) (STR-108) |
+| GET | `/api/streams/{id}/playlist.m3u8` | `Handler.Playlist` | **Public** (`OptionalAuth`) — flux publics servis à un anonyme, privé → 404 ; owner authentifié voit ses flux privés — manifeste HLS, 409 si pas live/pas prêt (STR-108) ; 503 si capacité atteinte (`HLS_MAX_CONCURRENT`, STR-88) |
+| GET | `/api/streams/{id}/segments/{segment}` | `Handler.Segment` | **Public** (`OptionalAuth`) — idem playlist — segment `.ts` (nom validé anti-traversal) (STR-108) ; 503 si capacité atteinte (`HLS_MAX_CONCURRENT`, STR-88) |
 
 - Moteur HLS (STR-70) : le diffuseur pousse de l'AAC sur `ingest/{stream_key}` (auth par clé, 100 % mémoire) ; **ffmpeg** (`-c:a copy`) segmente en `.ts` de ~10 s + manifeste `.m3u8` glissant servi aux auditeurs. Un segmenteur par session live, tué + répertoire nettoyé à l'arrêt. Détails [ADR 015](docs/adr/015-moteur-hls-segmentation-ffmpeg.md).
 - Cycle de vie du direct (STR-77) : `start`/`stop` = endpoints dédiés (le PUT ne touche pas au statut) ; **un seul flux live par diffuseur** ; goroutines gérées par `LiveSessions` (context + mutex). Détails [ADR 013](docs/adr/013-domaine-streaming.md) §7.
@@ -412,6 +414,7 @@ Copier `.env.example` en `.env` avant le premier lancement. Ne jamais committer 
 | `APP_BASE_URL` | Schéma URL pour les liens d'email (deep link mobile) | `streampulse://app` |
 | `CORS_ALLOWED_ORIGINS` | Origines CORS autorisées, séparées par des virgules (en dev, localhost/127.0.0.1 autorisés d'office) | `https://app.streampulse.com` |
 | `STREAM_INGEST_BASE_URL` | Préfixe de l'URL de stream source du diffuseur (cf. ADR 013) : `{base}/api/streams/ingest/{stream_key}` | `http://localhost:8080` |
+| `HLS_MAX_CONCURRENT` | Nombre max de requêtes HLS simultanées servies aux auditeurs (0 = illimité) | `256` |
 
 ## Santé des services
 
@@ -474,7 +477,7 @@ xcrun simctl openurl booted \
 | `docs/adr/012-openapi-source-de-verite.md` | Décision : OpenAPI source de vérité du contrat HTTP + client Dart/Dio généré |
 
 **Règle :** toute nouvelle décision d'architecture significative → nouvel ADR dans `docs/adr/`
-avec le numéro suivant (prochain : `015-...`). Référencer le ticket Linear correspondant.
+avec le numéro suivant (prochain : `017-...`). Référencer le ticket Linear correspondant.
 
 ## Principes SOLID
 

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,7 @@ generate-openapi-client:
 	cd mobile/packages/streampulse_api && dart pub get && dart run build_runner build --delete-conflicting-outputs
 	dart format mobile/packages/streampulse_api/lib
 	rm -rf mobile/packages/streampulse_api/.dart_tool mobile/packages/streampulse_api/pubspec.lock
+
+.PHONY: loadtest
+loadtest:
+	cd backend && go test -tags loadtest -race -count=1 -run TestLoad -v -timeout 5m ./internal/streaming/loadtest/

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -152,10 +152,15 @@ func run() error {
 	// player natif just_audio ne peut pas porter le Bearer. Auth *optionnelle* : un
 	// anonyme obtient les flux publics (privé → 404 via GetStream) ; un propriétaire
 	// authentifié qui présente un token voit aussi ses propres flux privés.
+	// Limiteur de charge (STR-88) : budget partagé entre les deux routes, à
+	// l'extérieur de OptionalAuth pour rejeter sous surcharge avant tout traitement.
+	// L'ingest n'est pas concerné (un seul push par flux, déjà garanti par
+	// errIngestInProgress).
+	hlsLimit := streaming.NewMaxInFlight(cfg.HLSMaxConcurrent)
 	mux.Handle("GET /api/streams/{id}/playlist.m3u8",
-		auth.OptionalAuth(cfg.JWTSecret, http.HandlerFunc(streamingHandler.Playlist)))
+		hlsLimit(auth.OptionalAuth(cfg.JWTSecret, http.HandlerFunc(streamingHandler.Playlist))))
 	mux.Handle("GET /api/streams/{id}/segments/{segment}",
-		auth.OptionalAuth(cfg.JWTSecret, http.HandlerFunc(streamingHandler.Segment)))
+		hlsLimit(auth.OptionalAuth(cfg.JWTSecret, http.HandlerFunc(streamingHandler.Segment))))
 	// Documentation OpenAPI (Swagger UI + spec brute) — exposée hors production
 	// uniquement, pour ne pas publier la surface de l'API sur l'environnement public.
 	if !cfg.IsProd() {

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -23,6 +23,7 @@ const (
 	defaultDBHost              = "localhost"
 	defaultDBPort              = "5432"
 	defaultStreamIngestBaseURL = "http://localhost:8080"
+	defaultHLSMaxConcurrent    = 256
 
 	minJWTSecretLen = 32
 )
@@ -56,6 +57,10 @@ type Config struct {
 	// (cf. ADR 013) : {StreamIngestBaseURL}/api/streams/ingest/{stream_key}.
 	StreamIngestBaseURL string `mapstructure:"STREAM_INGEST_BASE_URL"`
 
+	// HLSMaxConcurrent borne le nombre de requêtes HLS (playlist + segments)
+	// servies simultanément — STR-88. <= 0 désactive la borne.
+	HLSMaxConcurrent int `mapstructure:"HLS_MAX_CONCURRENT"`
+
 	// CORSAllowedOrigins : origines autorisées par CORS (CSV dans CORS_ALLOWED_ORIGINS).
 	CORSAllowedOrigins []string `mapstructure:"-"`
 }
@@ -72,6 +77,7 @@ func Load() (*Config, error) {
 	v.SetDefault("DB_HOST", defaultDBHost)
 	v.SetDefault("DB_PORT", defaultDBPort)
 	v.SetDefault("STREAM_INGEST_BASE_URL", defaultStreamIngestBaseURL)
+	v.SetDefault("HLS_MAX_CONCURRENT", defaultHLSMaxConcurrent)
 
 	// Charge .env à la racine du repo si présent (dev local uniquement).
 	v.SetConfigName(".env")
@@ -96,6 +102,7 @@ func Load() (*Config, error) {
 		"DB_HOST", "DB_PORT", "DB_USER", "DB_PASSWORD", "DB_NAME",
 		"SMTP_HOST", "SMTP_PORT", "SMTP_USERNAME", "SMTP_PASSWORD", "SMTP_FROM",
 		"APP_BASE_URL", "CORS_ALLOWED_ORIGINS", "STREAM_INGEST_BASE_URL",
+		"HLS_MAX_CONCURRENT",
 	} {
 		if err := v.BindEnv(key); err != nil {
 			return nil, fmt.Errorf("config: bind %s: %w", key, err)
@@ -114,6 +121,15 @@ func Load() (*Config, error) {
 	// Viper ne le fait pas seul : os.Getenv retourne "" pour set vide ET pour
 	// absent, et viper privilégie cette chaîne vide sur SetDefault.
 	cfg.applyDefaultsForEmpty()
+
+	// HLSMaxConcurrent est un int : le weak-decode de viper a déjà transformé
+	// "" en 0 pendant l'Unmarshal ci-dessus, indiscernable d'un 0 explicite
+	// (= limiteur désactivé, cf. commentaire du champ). On revérifie donc la
+	// chaîne brute — via .env ou l'environnement OS — plutôt que le champ cfg
+	// déjà converti : seule une chaîne vide retombe sur le défaut.
+	if strings.TrimSpace(v.GetString("HLS_MAX_CONCURRENT")) == "" {
+		cfg.HLSMaxConcurrent = defaultHLSMaxConcurrent
+	}
 
 	if err := cfg.validate(); err != nil {
 		return nil, err

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -128,6 +128,50 @@ func assertDefaults(t *testing.T, cfg *Config) {
 	}
 }
 
+// TestLoad_HLSMaxConcurrent couvre le fix « "" ≠ désactivé » : une valeur
+// vide est équivalente à absente (retombe sur le défaut 256), alors qu'un 0
+// explicite reste 0 (limiteur désactivé, cf. commentaire du champ
+// Config.HLSMaxConcurrent).
+//
+// Limite connue : ces sous-tests positionnent HLS_MAX_CONCURRENT via
+// l'environnement OS (t.Setenv) — ce fichier n'a pas de harnais pour écrire
+// un .env temporaire et le faire lire par Load() (AddConfigPath dépend du
+// cwd du process au moment de l'appel, que ces tests ne modifient pas).
+// Le code de production traite les deux sources de façon identique :
+// v.GetString("HLS_MAX_CONCURRENT") est relu après Unmarshal quelle que soit
+// la couche d'où vient la valeur (env OS, fichier .env, ou défaut viper) —
+// le cas « vide via .env » emprunte donc exactement le même chemin que le
+// cas « vide via env » couvert ci-dessous.
+func TestLoad_HLSMaxConcurrent(t *testing.T) {
+	tests := []struct {
+		name   string
+		setEnv bool // false = variable absente (ni env ni .env)
+		value  string
+		want   int
+	}{
+		{name: "vide -> défaut 256", setEnv: true, value: "", want: defaultHLSMaxConcurrent},
+		{name: "0 explicite -> désactivé", setEnv: true, value: "0", want: 0},
+		{name: "absente -> défaut 256", setEnv: false, want: defaultHLSMaxConcurrent},
+		{name: "128 -> 128", setEnv: true, value: "128", want: 128},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setEnv(t, validVars())
+			if tt.setEnv {
+				t.Setenv("HLS_MAX_CONCURRENT", tt.value)
+			}
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load() unexpected error: %v", err)
+			}
+			if cfg.HLSMaxConcurrent != tt.want {
+				t.Errorf("HLSMaxConcurrent = %d, want %d", cfg.HLSMaxConcurrent, tt.want)
+			}
+		})
+	}
+}
+
 func TestConfig_DBDSN(t *testing.T) {
 	cfg := &Config{
 		DBHost:     "db.example.com",

--- a/backend/internal/openapi/openapi.yaml
+++ b/backend/internal/openapi/openapi.yaml
@@ -786,6 +786,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: >-
+            Server at listener capacity (HLS_MAX_CONCURRENT concurrent requests
+            reached). Retry after the delay given in the Retry-After header.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /api/streams/{id}/segments/{segment}:
     parameters:
       - name: id
@@ -821,6 +829,14 @@ paths:
                 format: binary
         "404":
           $ref: "#/components/responses/NotFound"
+        "503":
+          description: >-
+            Server at listener capacity (HLS_MAX_CONCURRENT concurrent requests
+            reached). Retry after the delay given in the Retry-After header.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 components:
   securitySchemes:
     bearerAuth:

--- a/backend/internal/streaming/limiter.go
+++ b/backend/internal/streaming/limiter.go
@@ -1,0 +1,33 @@
+package streaming
+
+import (
+	"net/http"
+
+	"github.com/LignacAntony/streampulse/internal/shared/httpjson"
+)
+
+// NewMaxInFlight fabrique un middleware bornant le nombre de requêtes servies
+// simultanément par TOUTES les routes qu'il enveloppe (budget partagé) — STR-88.
+// Au-delà de limit : refus immédiat 503 + Retry-After, pas de file d'attente
+// (sous un pic d'auditeurs, un refus net vaut mieux qu'une dégradation générale).
+// limit <= 0 désactive la borne.
+func NewMaxInFlight(limit int) func(http.Handler) http.Handler {
+	if limit <= 0 {
+		return func(next http.Handler) http.Handler { return next }
+	}
+	slots := make(chan struct{}, limit)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			select {
+			case slots <- struct{}{}:
+				defer func() { <-slots }()
+				next.ServeHTTP(w, r)
+			default:
+				w.Header().Set("Retry-After", "2")
+				httpjson.WriteError(w, r, httpjson.StatusError(
+					http.StatusServiceUnavailable, "server_overloaded",
+					"too many concurrent listeners, retry later"))
+			}
+		})
+	}
+}

--- a/backend/internal/streaming/limiter_test.go
+++ b/backend/internal/streaming/limiter_test.go
@@ -1,0 +1,97 @@
+package streaming
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+// TestNewMaxInFlight_RejetAuDelaDeLaLimite : limite 1 partagée, une requête
+// bloquée dans le handler → la 2e reçoit 503 + Retry-After, puis le slot
+// libéré resert normalement.
+func TestNewMaxInFlight_RejetAuDelaDeLaLimite(t *testing.T) {
+	entered := make(chan struct{})
+	var enteredOnce sync.Once
+	release := make(chan struct{})
+	mw := NewMaxInFlight(1)
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		enteredOnce.Do(func() { close(entered) })
+		<-release
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	first := httptest.NewRecorder()
+	go func() {
+		defer wg.Done()
+		h.ServeHTTP(first, httptest.NewRequest(http.MethodGet, "/x", nil))
+	}()
+	<-entered // la 1re requête occupe le seul slot
+
+	second := httptest.NewRecorder()
+	h.ServeHTTP(second, httptest.NewRequest(http.MethodGet, "/x", nil))
+	if second.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, attendu 503", second.Code)
+	}
+	if got := second.Header().Get("Retry-After"); got != "2" {
+		t.Fatalf("Retry-After = %q, attendu \"2\"", got)
+	}
+
+	close(release)
+	wg.Wait()
+	if first.Code != http.StatusOK {
+		t.Fatalf("première requête = %d, attendu 200", first.Code)
+	}
+
+	third := httptest.NewRecorder()
+	h.ServeHTTP(third, httptest.NewRequest(http.MethodGet, "/x", nil))
+	if third.Code != http.StatusOK {
+		t.Fatalf("après libération = %d, attendu 200", third.Code)
+	}
+}
+
+// TestNewMaxInFlight_BudgetPartage : deux handlers enveloppés par la même
+// instance partagent le budget (celui des routes playlist + segments).
+func TestNewMaxInFlight_BudgetPartage(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	mw := NewMaxInFlight(1)
+	blocking := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(entered)
+		<-release
+		w.WriteHeader(http.StatusOK)
+	}))
+	other := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		blocking.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/a", nil))
+	}()
+	<-entered
+	defer func() { close(release); wg.Wait() }()
+
+	rec := httptest.NewRecorder()
+	other.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/b", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, attendu 503 (budget partagé)", rec.Code)
+	}
+}
+
+// TestNewMaxInFlight_Desactive : limit <= 0 → passthrough sans borne.
+func TestNewMaxInFlight_Desactive(t *testing.T) {
+	mw := NewMaxInFlight(0)
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/x", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, attendu 200", rec.Code)
+	}
+}

--- a/backend/internal/streaming/loadtest/load_test.go
+++ b/backend/internal/streaming/loadtest/load_test.go
@@ -1,0 +1,404 @@
+//go:build loadtest
+
+// Package loadtest exerce le moteur HLS sous charge réaliste (STR-90) :
+// un diffuseur ffmpeg réel + N auditeurs HTTP simulés, critères STR-87.
+// Exclu de `go test ./...` par le build tag ; lancé via `make loadtest`.
+package loadtest
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"regexp"
+	"runtime"
+	"runtime/pprof"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/LignacAntony/streampulse/internal/auth"
+	"github.com/LignacAntony/streampulse/internal/streaming"
+)
+
+const (
+	listeners        = 50
+	listenDuration   = 60 * time.Second
+	pollInterval     = 2 * time.Second
+	p95Budget        = 300 * time.Millisecond
+	memPerConnBudget = 2 << 20 // 2 Mo/connexion (STR-87)
+
+	streamID  = "loadtest-stream"
+	streamKey = "loadtest-key"
+	jwtSecret = "loadtest-secret-0123456789abcdef" // ≥ 32 chars comme en prod
+)
+
+// stubService satisfait streaming.StreamService sans DB : seul GetStream est
+// réellement utilisé par les routes HLS (contrôle de visibilité auditeur).
+type stubService struct{}
+
+func (stubService) CreateStream(context.Context, streaming.CreateStreamInput) (streaming.Stream, error) {
+	return streaming.Stream{}, nil
+}
+func (stubService) ListPublicLive(context.Context, int32, int32) ([]streaming.Stream, error) {
+	return nil, nil
+}
+func (stubService) GetStream(_ context.Context, id, _ string) (streaming.Stream, bool, error) {
+	return streaming.Stream{ID: id, Status: "live", IsPublic: true}, false, nil
+}
+func (stubService) UpdateStream(context.Context, string, string, streaming.UpdateStreamInput) (streaming.Stream, error) {
+	return streaming.Stream{}, nil
+}
+func (stubService) ArchiveStream(context.Context, string, string) error { return nil }
+func (stubService) StartStream(context.Context, string, string) (streaming.Stream, error) {
+	return streaming.Stream{}, nil
+}
+func (stubService) StopStream(context.Context, string, string) (streaming.Stream, error) {
+	return streaming.Stream{}, nil
+}
+
+// startServer monte les 3 routes HLS comme cmd/api/main.go les monte : ingest
+// sans JWT, playlist/segments en lecture publique (OptionalAuth, STR-108) sous
+// le limiteur de charge partagé (STR-88). L'auditeur simulé présente quand même
+// un Bearer valide — OptionalAuth l'accepte comme un propriétaire authentifié.
+func startServer(t *testing.T, ls *streaming.LiveSessions) *httptest.Server {
+	t.Helper()
+	h := streaming.NewHandler(stubService{}, "http://loadtest.invalid", ls)
+	mux := http.NewServeMux()
+	mux.Handle("POST /api/streams/ingest/{stream_key}", http.HandlerFunc(h.Ingest))
+	hlsLimit := streaming.NewMaxInFlight(256)
+	mux.Handle("GET /api/streams/{id}/playlist.m3u8", hlsLimit(auth.OptionalAuth(jwtSecret, http.HandlerFunc(h.Playlist))))
+	mux.Handle("GET /api/streams/{id}/segments/{segment}", hlsLimit(auth.OptionalAuth(jwtSecret, http.HandlerFunc(h.Segment))))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// mintToken fabrique un JWT auditeur valide (le middleware réel le vérifie,
+// comme en prod).
+func mintToken(t *testing.T) string {
+	t.Helper()
+	tok, err := auth.GenerateAccessToken("loadtest-user", "user", jwtSecret, time.Now())
+	if err != nil {
+		t.Fatalf("GenerateAccessToken: %v", err)
+	}
+	return tok
+}
+
+// startBroadcast lance ffmpeg (sine AAC temps réel, ~90 s de matière) et pousse
+// sa sortie ADTS sur l'ingest via un POST chunké — le chemin exact d'un vrai
+// diffuseur. L'annulation de ctx tue ffmpeg (CommandContext) et coupe le POST.
+func startBroadcast(t *testing.T, ctx context.Context, ingestURL string) {
+	t.Helper()
+	cmd := exec.CommandContext(ctx, "ffmpeg", "-hide_banner", "-loglevel", "error",
+		"-re", "-f", "lavfi", "-i", "sine=frequency=440:sample_rate=44100",
+		"-t", "90", "-c:a", "aac", "-b:a", "128k", "-f", "adts", "-")
+	out, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("StdoutPipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("démarrage ffmpeg: %v", err)
+	}
+	// La goroutine POST lit `out` (stdout ffmpeg) : os/exec interdit d'appeler
+	// Wait avant la fin des lectures du pipe. On attend donc la fin de la
+	// goroutine (via done) AVANT de laisser le cleanup appeler Wait.
+	done := make(chan struct{})
+	t.Cleanup(func() {
+		<-done
+		_ = cmd.Wait() // récolte le process après cancel + fin des lectures du pipe
+	})
+	go func() {
+		defer close(done)
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, ingestURL, out)
+		if err != nil {
+			return
+		}
+		req.Header.Set("Content-Type", "audio/aac")
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}
+	}()
+}
+
+// waitFirstManifest bloque jusqu'à ce que la playlist réponde 200 (premier
+// segment produit par ffmpeg, ~10-12 s) — deadline 30 s.
+func waitFirstManifest(t *testing.T, client *http.Client, url, token string) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		req, _ := http.NewRequest(http.MethodGet, url, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := client.Do(req)
+		if err == nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatal("aucun manifeste disponible après 30 s (ffmpeg n'a rien produit)")
+}
+
+// sample : une requête auditeur mesurée.
+type sample struct {
+	kind   string // "playlist" | "segment"
+	dur    time.Duration
+	status int
+	size   int64
+}
+
+// collector agrège les mesures des 50 goroutines auditeurs.
+type collector struct {
+	mu      sync.Mutex
+	samples []sample
+}
+
+func (c *collector) add(s sample) {
+	c.mu.Lock()
+	c.samples = append(c.samples, s)
+	c.mu.Unlock()
+}
+
+// durations retourne les latences d'un type, triées (prêtes pour percentile).
+func (c *collector) durations(kind string) []time.Duration {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var out []time.Duration
+	for _, s := range c.samples {
+		if s.kind == kind {
+			out = append(out, s.dur)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+func (c *collector) failures() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	n := 0
+	for _, s := range c.samples {
+		if s.status != http.StatusOK {
+			n++
+		}
+	}
+	return n
+}
+
+func (c *collector) bytes() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var n int64
+	for _, s := range c.samples {
+		n += s.size
+	}
+	return n
+}
+
+// percentile : sorted doit être trié ; p dans (0,100]. Index par la méthode
+// « nearest rank » : ceil(p/100·N)-1.
+func percentile(sorted []time.Duration, p float64) time.Duration {
+	if len(sorted) == 0 {
+		return 0
+	}
+	idx := int(float64(len(sorted))*p/100+0.9999999) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
+}
+
+var segmentRe = regexp.MustCompile(`seg_\d+\.ts`)
+
+// timedGet mesure un GET authentifié et l'enregistre dans le collecteur.
+// Retourne le corps (nil si erreur transport, comptée comme échec status 0).
+func timedGet(ctx context.Context, client *http.Client, url, token, kind string, col *collector) []byte {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	start := time.Now()
+	resp, err := client.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil // arrêt du test : pas un échec
+		}
+		col.add(sample{kind: kind, dur: time.Since(start), status: 0})
+		return nil
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	col.add(sample{kind: kind, dur: time.Since(start), status: resp.StatusCode, size: int64(len(body))})
+	return body
+}
+
+// listen est la boucle d'un auditeur : GET playlist → GET des segments pas
+// encore vus → pause pollInterval, jusqu'à annulation du contexte.
+func listen(ctx context.Context, base, token string, col *collector) {
+	client := &http.Client{Timeout: 10 * time.Second}
+	seen := make(map[string]bool)
+	playlistURL := fmt.Sprintf("%s/api/streams/%s/playlist.m3u8", base, streamID)
+	for ctx.Err() == nil {
+		if body := timedGet(ctx, client, playlistURL, token, "playlist", col); body != nil {
+			for _, seg := range segmentRe.FindAllString(string(body), -1) {
+				if seen[seg] {
+					continue
+				}
+				seen[seg] = true
+				segURL := fmt.Sprintf("%s/api/streams/%s/segments/%s", base, streamID, seg)
+				timedGet(ctx, client, segURL, token, "segment", col)
+			}
+		}
+		select {
+		case <-ctx.Done():
+		case <-time.After(pollInterval):
+		}
+	}
+}
+
+// waitSessionsDrained : LiveSessions.Wait borné (même approche déterministe que
+// waitDrained dans session_pprof_test.go, non exporté par le package streaming).
+func waitSessionsDrained(t *testing.T, ls *streaming.LiveSessions) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() { ls.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("goroutines de session non libérées après stop (fuite)")
+	}
+}
+
+// dumpGoroutines rend le profil pprof "goroutine" (debug=1) : en cas de fuite,
+// le rapport de test contient directement les stacks fuyardes (STR-89).
+func dumpGoroutines() string {
+	var buf bytes.Buffer
+	if err := pprof.Lookup("goroutine").WriteTo(&buf, 1); err != nil {
+		return fmt.Sprintf("profil goroutine indisponible: %v", err)
+	}
+	return buf.String()
+}
+
+// TestLoad_50Listeners : voir les tasks suivantes — à ce stade, smoke du harnais.
+func TestLoad_50Listeners(t *testing.T) {
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg absent du PATH : test de charge ignoré")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ls := streaming.NewLiveSessions(ctx)
+	t.Cleanup(ls.StopAll)
+	srv := startServer(t, ls)
+	token := mintToken(t)
+
+	ls.Start(streamID, streamKey)
+	startBroadcast(t, ctx, srv.URL+"/api/streams/ingest/"+streamKey)
+
+	playlistURL := fmt.Sprintf("%s/api/streams/%s/playlist.m3u8", srv.URL, streamID)
+	waitFirstManifest(t, http.DefaultClient, playlistURL, token)
+
+	loadCtx, stopLoad := context.WithTimeout(ctx, listenDuration)
+	defer stopLoad()
+
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+	goroutinesBefore := runtime.NumGoroutine()
+
+	// Échantillonneur du pic mémoire pendant la charge (1 Hz).
+	var peakHeap uint64 = before.HeapAlloc
+	samplerDone := make(chan struct{})
+	go func() {
+		defer close(samplerDone)
+		tick := time.NewTicker(time.Second)
+		defer tick.Stop()
+		for {
+			select {
+			case <-loadCtx.Done():
+				return
+			case <-tick.C:
+				var m runtime.MemStats
+				runtime.ReadMemStats(&m)
+				if m.HeapAlloc > peakHeap {
+					peakHeap = m.HeapAlloc
+				}
+			}
+		}
+	}()
+
+	col := &collector{}
+	var wg sync.WaitGroup
+	for i := 0; i < listeners; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			listen(loadCtx, srv.URL, token, col)
+		}()
+	}
+	wg.Wait()
+
+	playlists, segments := col.durations("playlist"), col.durations("segment")
+	if len(playlists) == 0 || len(segments) == 0 {
+		t.Fatalf("aucune mesure collectée (playlists=%d, segments=%d)", len(playlists), len(segments))
+	}
+	t.Logf("requêtes: %d playlists, %d segments, %d échecs, %.1f Mo servis",
+		len(playlists), len(segments), col.failures(), float64(col.bytes())/(1<<20))
+
+	<-samplerDone
+
+	// Arrêt : fin du diffuseur (cancel ctx tue ffmpeg), stop session, drain.
+	cancel()
+	ls.Stop(streamID)
+	waitSessionsDrained(t, ls)
+
+	// 1) Latence (STR-87 : p95 < 300 ms).
+	for kind, durs := range map[string][]time.Duration{"playlist": playlists, "segment": segments} {
+		p50, p95, p99 := percentile(durs, 50), percentile(durs, 95), percentile(durs, 99)
+		t.Logf("%s: n=%d p50=%s p95=%s p99=%s", kind, len(durs), p50, p95, p99)
+		if p95 > p95Budget {
+			t.Errorf("p95 %s = %s > budget %s", kind, p95, p95Budget)
+		}
+	}
+
+	// 2) Zéro échec après le premier manifeste.
+	if n := col.failures(); n > 0 {
+		t.Errorf("%d requêtes en échec (attendu 0)", n)
+	}
+
+	// 3) Mémoire (STR-87 : < 2 Mo/connexion, sur le pic de charge).
+	perConn := (peakHeap - before.HeapAlloc) / listeners
+	t.Logf("mémoire: base=%.1f Mo pic=%.1f Mo soit %.2f Mo/connexion",
+		float64(before.HeapAlloc)/(1<<20), float64(peakHeap)/(1<<20), float64(perConn)/(1<<20))
+	if perConn > memPerConnBudget {
+		t.Errorf("mémoire/connexion = %d octets > budget %d", perConn, memPerConnBudget)
+	}
+
+	// 4) Goroutines : retour au niveau initial (tolérance 3, retries GC).
+	deadline := time.Now().Add(5 * time.Second)
+	goroutinesAfter := runtime.NumGoroutine()
+	for time.Now().Before(deadline) && goroutinesAfter > goroutinesBefore+3 {
+		runtime.GC()
+		time.Sleep(100 * time.Millisecond)
+		goroutinesAfter = runtime.NumGoroutine()
+	}
+	t.Logf("goroutines: avant=%d après=%d", goroutinesBefore, goroutinesAfter)
+	if goroutinesAfter > goroutinesBefore+3 {
+		t.Errorf("fuite suspecte: %d goroutines avant charge, %d après drain\nprofil pprof:\n%s",
+			goroutinesBefore, goroutinesAfter, dumpGoroutines())
+	}
+}

--- a/docs/adr/016-scalabilite-test-de-charge-et-limiteur-hls.md
+++ b/docs/adr/016-scalabilite-test-de-charge-et-limiteur-hls.md
@@ -1,0 +1,105 @@
+# ADR 016 — Scalabilité : test de charge Go in-process et limiteur de capacité HLS
+
+**Date** : 2026-07-19
+**Statut** : Accepté
+**Ticket** : [STR-87](https://linear.app/streampulse/issue/STR-87) (sous-issues [STR-88](https://linear.app/streampulse/issue/STR-88), [STR-89](https://linear.app/streampulse/issue/STR-89), [STR-90](https://linear.app/streampulse/issue/STR-90), [STR-91](https://linear.app/streampulse/issue/STR-91))
+
+---
+
+## Contexte
+
+Le moteur HLS ([ADR 015](015-moteur-hls-segmentation-ffmpeg.md)) transporte l'audio d'un
+diffuseur vers les auditeurs. STR-87 exige la preuve de sa tenue en charge :
+
+> Given un flux HLS actif, when **50 clients** simulent la récupération du manifeste et des
+> segments, then p95 < **300 ms**, mémoire < **2 Mo/connexion**, **aucune goroutine leak**
+> (détection pprof).
+
+Deux questions d'architecture en découlent : **comment mesurer** (outil et cible du test de
+charge), et **comment protéger** le serveur quand la demande dépasse la capacité (gestion des
+connexions concurrentes).
+
+## Décision
+
+### 1. Test de charge : Go pur, in-process, hors CI bloquante (STR-90)
+
+- **Go pur** (pas k6) : un test `go test` classique dans
+  [`backend/internal/streaming/loadtest/`](../../backend/internal/streaming/loadtest/load_test.go).
+  Zéro outil nouveau, et surtout mémoire + goroutines mesurables **dans le même process** via
+  `runtime`/`pprof` — un outil externe n'aurait vu que la latence.
+- **In-process** : le test démarre le vrai serveur (vrai mux, vraies `LiveSessions`, vrai
+  middleware JWT, **vrai ffmpeg** — skip si absent). Un stub remplace uniquement le
+  `StreamService` (la DB n'est pas l'objet mesuré). 1 diffuseur sine AAC temps réel,
+  50 goroutines auditeurs pendant 60 s (playlist → segments nouveaux → pause 2 s),
+  latences agrégées par tri (percentiles nearest-rank).
+- **Build tag `loadtest`** : exclu de `go test ./...` (pas de +75 s ni de flakiness de seuils
+  sur runner partagé à chaque push). Exécution : `make loadtest` (`-race -count=1` — un test de
+  charge ne doit jamais être servi depuis le cache) ou workflow **« Load Test »**
+  (`workflow_dispatch`, rapport en artifact, `shell: bash` pour que pipefail propage un échec).
+- **Détection de fuite (STR-89)** : goroutines comptées avant charge puis après stop + drain
+  (`LiveSessions.Wait` borné, retries + GC, tolérance 3) ; en cas de dépassement, le message
+  d'échec embarque le dump `pprof.Lookup("goroutine")` — les stacks fuyardes sont directement
+  dans le rapport de test.
+
+### 2. Limiteur de capacité : refus immédiat 503, budget partagé (STR-88)
+
+Le modèle `net/http` (une goroutine par connexion) n'a pas besoin d'un « pool de goroutines » :
+les mesures ci-dessous le confirment avec ~15× de marge. Le risque réel est l'**absence de
+borne** — un pic d'auditeurs au-delà de la capacité dégraderait tout le monde. D'où
+[`limiter.go`](../../backend/internal/streaming/limiter.go) :
+
+- `NewMaxInFlight(limit)` : sémaphore (canal bufferisé), acquisition **non bloquante**, slot
+  libéré en `defer` (sûr même si le handler panique). Budget **partagé** entre les routes
+  enveloppées par la même instance — playlist + segments consomment la même capacité.
+- Au-delà de la limite : **503 JSON** (`server_overloaded`) + `Retry-After: 2`, **sans file
+  d'attente** — refus net, déterministe et testable ; pas de log sur ce chemin (pas
+  d'inondation sous surcharge).
+- Monté dans `main.go` **avant** `RequireAuth` (on refuse avant même de parser le JWT sous
+  surcharge). L'ingest n'est **pas** limité : un seul push par flux, déjà garanti par
+  `errIngestInProgress`.
+- Config : `HLS_MAX_CONCURRENT` (défaut **256**, `0` explicite = désactivé, valeur vide ≡
+  absente → défaut, conformément à la convention de `config.go`). Réponse 503 documentée dans
+  l'OpenAPI des deux routes auditeur.
+
+## Alternatives écartées
+
+- **k6** : standard du load test, mais dépendance binaire nouvelle (CI + local), scripts JS à
+  maintenir, et aveugle sur mémoire/goroutines côté serveur — il aurait fallu un second outillage
+  pprof à côté. Le critère STR-87 est précisément serveur-side.
+- **Test contre la stack Docker** : plus réaliste (réseau, container limits) mais mesures
+  mémoire/goroutines seulement via pprof HTTP à exposer + `docker stats`, et CI beaucoup plus
+  lourde. L'in-process mesure ce que STR-87 demande ; la limite (pas de RTT réseau) est assumée.
+- **Worker pool / pool de goroutines côté serveur** : combattrait le modèle de `net/http` sans
+  bénéfice mesuré (0,13 Mo/connexion observé) ; complexité et risque de famine pour rien.
+- **File d'attente dans le limiteur** (backpressure douce) : ajoute de la latence cachée et un
+  état à dimensionner ; le refus immédiat + `Retry-After` est compréhensible par les players
+  HLS (retry naturel au prochain poll) et trivialement testable. Réévaluable si le besoin
+  apparaît.
+
+## Validation (run de référence, 2026-07-19)
+
+Sortie locale de `make loadtest` (Apple M3, 8 Go, Go 1.26.1, ffmpeg 8.1.2), limiteur monté
+à 256 dans le harnais :
+
+| Critère STR-87 | Seuil | Mesuré | Verdict |
+|---|---|---|---|
+| p95 playlist | < 300 ms | **23,52 ms** | ✅ |
+| p95 segment | < 300 ms | **41,02 ms** | ✅ |
+| Mémoire/connexion | < 2 Mo | **0,13 Mo** | ✅ |
+| Échecs HTTP | 0 | **0 / 1800 requêtes** | ✅ |
+| Goroutine leak | 0 | goroutines 13 → 10 après drain | ✅ |
+
+1500 requêtes playlist + 300 segments (~50 Mo servis), `-race` sans warning, aucun 503 émis
+(50 auditeurs < 256). Limites connues : in-process (latences hors RTT réseau/TLS), source sine
+à débit constant, matériel local ≠ VPS — refaire le run via le workflow « Load Test » pour des
+chiffres CI reproductibles.
+
+## Conséquences
+
+- Les auditeurs peuvent recevoir un **503** sur playlist/segments à saturation : les clients
+  (mobile inclus) doivent le traiter comme réessayable (`Retry-After`).
+- Le registre et la borne restent **locaux au process** (mono-instance, cf. ADR 013 §7) : le
+  multi-instance reste hors scope.
+- Aucune métrique de shedding (compteur de 503) : piste ticket observabilité si le limiteur
+  déclenche en réel.
+- Aucune migration ; `.env.example` et CLAUDE.md documentent la nouvelle variable.


### PR DESCRIPTION
## STR-87 — Scalabilité : gestion de N auditeurs simultanés

[STR-87](https://linear.app/streampulse/issue/STR-87) · milestone *Moteur de Streaming Live (Backend Go)*. Couvre les 4 sous-issues : **STR-90** (test de charge), **STR-89** (détection goroutine leak via pprof), **STR-88** (gestion des connexions concurrentes), **STR-91** (analyse et documentation).

### Contenu

**Test de charge (STR-90)** — `backend/internal/streaming/loadtest/` (build tag `loadtest`, exclu de `go test ./...`) : le test démarre le vrai serveur in-process (vrai mux, vraies `LiveSessions`, vrai middleware JWT, **vrai ffmpeg** — skip si absent), 1 diffuseur pousse un sine AAC en continu, **50 auditeurs** simulés bouclent playlist → segments pendant 60 s. Assertions sur les critères de l'epic : p95 < 300 ms (playlist et segments), < 2 Mo/connexion (pic `HeapAlloc` échantillonné à 1 Hz), 0 échec HTTP, goroutines revenues au niveau initial après drain.

**Détection de fuite via pprof (STR-89)** — en cas de dépassement de la tolérance goroutines, le message d'échec embarque le dump `pprof.Lookup("goroutine")` (debug=1) : les stacks fuyardes sont directement dans le rapport de test.

**Limiteur de capacité (STR-88)** — `NewMaxInFlight` (`backend/internal/streaming/limiter.go`) : sémaphore non bloquant à **budget partagé** entre playlist et segments, monté **avant** `RequireAuth` dans `main.go` (on délète avant de parser le JWT sous surcharge). Au-delà de `HLS_MAX_CONCURRENT` (env, défaut **256**, `0` = désactivé) → **503 JSON + `Retry-After: 2`**, sans file d'attente. L'ingest n'est pas limité (un push par flux déjà garanti). OpenAPI mise à jour (503 sur les 2 routes auditeur), client mobile régénéré (aucun diff — dart-dio ne matérialise pas les réponses par status). Valeur vide dans `.env` → retombe sur le défaut (convention du fichier de config, testée).

**Décision + validation (STR-91)** — [ADR 016](docs/adr/016-scalabilite-test-de-charge-et-limiteur-hls.md) : décisions (Go pur, in-process, 503 sans file d'attente), alternatives écartées, et le run de référence du 2026-07-19 (Apple M3, 8 Go) — les 5 critères ✅ : p95 playlist **23,52 ms** / segment **41,02 ms** (seuil 300 ms), **0,13 Mo/connexion** (seuil 2 Mo), **0 échec / 1800 requêtes**, goroutines 13→10 (aucune fuite), limiteur monté à 256 sans aucun 503.

### Outillage

- `make loadtest` (racine) — `-race -count=1` (jamais servi depuis le cache de `go test`).
- Workflow **« Load Test »** (`.github/workflows/loadtest.yml`) : `workflow_dispatch`, ffmpeg installé, rapport uploadé en artifact, `shell: bash` (pipefail : un test rouge fait échouer le job), `permissions: contents: read`.
- Docs : `CLAUDE.md` (commande, pointeur rapport, 503 sur les routes, table env) et `.env.example` (`HLS_MAX_CONCURRENT`).

### Décisions

- **Go pur plutôt que k6** : zéro nouvel outil, mémoire/goroutines mesurables dans le même process via `runtime`/`pprof`, intégration CI directe.
- **In-process plutôt que stack Docker** : mesures précises, exécutable en CI sans compose ; les latences excluent le RTT réseau (limite documentée dans le rapport).
- **Pas de « pool de goroutines »** au sens strict : le modèle net/http (1 goroutine/connexion) tient les seuils avec 15× de marge ; le vrai risque était l'absence de borne → limiteur 503, comportement déterministe et testé.
- Tout est consolidé dans l'[ADR 016](docs/adr/016-scalabilite-test-de-charge-et-limiteur-hls.md) (contexte, décisions, alternatives écartées, validation chiffrée).

### Vérification

- `go test ./...` : 233 tests verts, 18 packages (loadtest exclu par le tag).
- `make loadtest` : PASS en ~72 s, `-race` sans warning, exécuté plusieurs fois pendant le développement (chiffres stables : 1500 playlists, 300 segments, 0 échec, ~50 Mo servis).
- Tests unitaires du limiteur : rejet 503 + `Retry-After`, budget partagé entre routes, passthrough si désactivé — synchronisation par canaux, zéro sleep.
- `gofmt` / `go vet` propres.

### Hors scope

- Métrique de shedding (compteur des 503) — piste ticket observabilité.
- Multi-instance (registre `LiveSessions` local au process, cf. ADR 013 §7).
- Run du workflow « Load Test » en CI : à déclencher après merge (`workflow_dispatch` lit la branche par défaut).
