### PR TITLE
fix(api): masquer le stream_key dans les logs d'erreur HTTP

### DIFF
--- a/backend/internal/shared/httpjson/httpjson.go
+++ b/backend/internal/shared/httpjson/httpjson.go
@@ -138,6 +138,26 @@ func writeInternalError(w http.ResponseWriter) error {
 	}})
 }
 
+// ingestPathPrefix marks the route whose last path segment is the secret
+// stream_key — it must never appear in logs.
+const ingestPathPrefix = "/api/streams/ingest/"
+
+// loggablePath returns a log-safe representation of the request path: the
+// route pattern (which holds placeholders, never path values) when the mux
+// populated it, otherwise the raw path with the stream_key segment redacted.
+func loggablePath(r *http.Request) string {
+	if p := r.Pattern; p != "" {
+		if _, after, ok := strings.Cut(p, " "); ok {
+			return after
+		}
+		return p
+	}
+	if rest, ok := strings.CutPrefix(r.URL.Path, ingestPathPrefix); ok && rest != "" {
+		return ingestPathPrefix + "[redacted]"
+	}
+	return r.URL.Path
+}
+
 func logRequestError(r *http.Request, err error) {
 	if r == nil {
 		log.Printf("http: %v", err)
@@ -146,5 +166,5 @@ func logRequestError(r *http.Request, err error) {
 	sanitize := func(s string) string {
 		return strings.NewReplacer("\n", "", "\r", "").Replace(s)
 	}
-	log.Printf("http: %s %s %s: %v", r.Method, sanitize(r.URL.Path), sanitize(r.RemoteAddr), err) // #nosec G706 -- path and remoteAddr stripped of newlines by sanitize()
+	log.Printf("http: %s %s %s: %v", r.Method, sanitize(loggablePath(r)), sanitize(r.RemoteAddr), err) // #nosec G706 -- path and remoteAddr stripped of newlines by sanitize()
 }

--- a/backend/internal/shared/httpjson/httpjson_test.go
+++ b/backend/internal/shared/httpjson/httpjson_test.go
@@ -1,8 +1,10 @@
 package httpjson
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -80,6 +82,66 @@ func TestWriteError_MapsAppErrors(t *testing.T) {
 			}
 			if got.Error.Message != tt.wantError {
 				t.Fatalf("message: want %q, got %q", tt.wantError, got.Error.Message)
+			}
+		})
+	}
+}
+
+func TestWriteError_RedactsStreamKeyInLogs(t *testing.T) {
+	tests := []struct {
+		name      string
+		viaMux    bool
+		path      string
+		wantInLog string
+		notInLog  string
+	}{
+		{
+			name:      "ingest path is redacted without route pattern",
+			path:      "/api/streams/ingest/secret-key-123",
+			wantInLog: "/api/streams/ingest/[redacted]",
+			notInLog:  "secret-key-123",
+		},
+		{
+			name:      "route pattern is preferred when set",
+			viaMux:    true,
+			path:      "/api/streams/ingest/secret-key-123",
+			wantInLog: "/api/streams/ingest/{stream_key}",
+			notInLog:  "secret-key-123",
+		},
+		{
+			name:      "non-sensitive path is logged verbatim",
+			path:      "/api/auth/login",
+			wantInLog: "/api/auth/login",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			prev := log.Writer()
+			log.SetOutput(&buf)
+			t.Cleanup(func() { log.SetOutput(prev) })
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, tt.path, nil)
+			ingestErr := apperror.Internal("ingest interrupted", errors.New("unexpected EOF"))
+
+			if tt.viaMux {
+				mux := http.NewServeMux()
+				mux.Handle("POST /api/streams/ingest/{stream_key}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					WriteError(w, r, ingestErr)
+				}))
+				mux.ServeHTTP(rec, req)
+			} else {
+				WriteError(rec, req, ingestErr)
+			}
+
+			logged := buf.String()
+			if !strings.Contains(logged, tt.wantInLog) {
+				t.Fatalf("log: want %q in %q", tt.wantInLog, logged)
+			}
+			if tt.notInLog != "" && strings.Contains(logged, tt.notInLog) {
+				t.Fatalf("log: secret %q leaked in %q", tt.notInLog, logged)
 			}
 		})
 	}


### PR DESCRIPTION
## Problème

Pour tout statut >= 500, `logRequestError` (`internal/shared/httpjson`) loggait `r.URL.Path` brut. Sur `POST /api/streams/ingest/{stream_key}`, le path contient le stream_key secret : chaque déconnexion brutale d'un diffuseur (cas normal, ex. `unexpected EOF`) écrivait la clé en clair dans les logs collectés par Loki.

Observé pendant le test de charge STR-90 :
`http: POST /api/streams/ingest/loadtest-key 127.0.0.1:58699: internal: ingest interrupted: unexpected EOF`

## Fix

- `loggablePath` : privilégie `r.Pattern` (placeholders de route, jamais de valeurs de path) quand le mux l'a renseigné → le log devient `POST /api/streams/ingest/{stream_key} …`
- Fallback (Pattern vide, ex. appel avant routage) : dernier segment de `/api/streams/ingest/` remplacé par `[redacted]`
- Autres paths inchangés, `sanitize` conservé

## Tests

- `TestWriteError_RedactsStreamKeyInLogs` (stdlib, capture de `log`) : redaction sans pattern, pattern préféré via vrai `ServeMux`, path normal loggé verbatim — test écrit en TDD (rouge observé avant le fix)
- `gofmt` clean, `go vet ./...` OK, `go test ./...` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)