### PR TITLE
feat(api): permettre la lecture publique HLS sans authentification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,8 +198,8 @@ Domaine `internal/streaming/` (handler/service/repository). Détails dans [ADR 0
 | PATCH | `/api/streams/{id}/stop` | `Handler.Stop` | Oui — rôle `broadcaster`, owner ; `live→ended` (409 si pas live) |
 | GET | `/api/streams/{id}/events` | `Handler.Events` | Oui (JWT) — flux **SSE**, event `ended` à l'arrêt (STR-77) |
 | POST | `/api/streams/ingest/{stream_key}` | `Handler.Ingest` | **Non (JWT)** — auth par `stream_key` dans le path ; push audio AAC segmenté en HLS (STR-70/71) |
-| GET | `/api/streams/{id}/playlist.m3u8` | `Handler.Playlist` | Oui (JWT) — manifeste HLS du direct (409 si pas live) (STR-70) |
-| GET | `/api/streams/{id}/segments/{segment}` | `Handler.Segment` | Oui (JWT) — segment `.ts` (nom validé anti-traversal) (STR-70) |
+| GET | `/api/streams/{id}/playlist.m3u8` | `Handler.Playlist` | **Non — public** (flux publics ; privé → 404) — manifeste HLS du direct, 409 si pas live/pas prêt (STR-108) |
+| GET | `/api/streams/{id}/segments/{segment}` | `Handler.Segment` | **Non — public** (flux publics ; privé → 404) — segment `.ts` (nom validé anti-traversal) (STR-108) |
 
 - Moteur HLS (STR-70) : le diffuseur pousse de l'AAC sur `ingest/{stream_key}` (auth par clé, 100 % mémoire) ; **ffmpeg** (`-c:a copy`) segmente en `.ts` de ~10 s + manifeste `.m3u8` glissant servi aux auditeurs. Un segmenteur par session live, tué + répertoire nettoyé à l'arrêt. Détails [ADR 015](docs/adr/015-moteur-hls-segmentation-ffmpeg.md).
 - Cycle de vie du direct (STR-77) : `start`/`stop` = endpoints dédiés (le PUT ne touche pas au statut) ; **un seul flux live par diffuseur** ; goroutines gérées par `LiveSessions` (context + mutex). Détails [ADR 013](docs/adr/013-domaine-streaming.md) §7.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,8 +198,8 @@ Domaine `internal/streaming/` (handler/service/repository). Détails dans [ADR 0
 | PATCH | `/api/streams/{id}/stop` | `Handler.Stop` | Oui — rôle `broadcaster`, owner ; `live→ended` (409 si pas live) |
 | GET | `/api/streams/{id}/events` | `Handler.Events` | Oui (JWT) — flux **SSE**, event `ended` à l'arrêt (STR-77) |
 | POST | `/api/streams/ingest/{stream_key}` | `Handler.Ingest` | **Non (JWT)** — auth par `stream_key` dans le path ; push audio AAC segmenté en HLS (STR-70/71) |
-| GET | `/api/streams/{id}/playlist.m3u8` | `Handler.Playlist` | **Non — public** (flux publics ; privé → 404) — manifeste HLS du direct, 409 si pas live/pas prêt (STR-108) |
-| GET | `/api/streams/{id}/segments/{segment}` | `Handler.Segment` | **Non — public** (flux publics ; privé → 404) — segment `.ts` (nom validé anti-traversal) (STR-108) |
+| GET | `/api/streams/{id}/playlist.m3u8` | `Handler.Playlist` | **Public** (`OptionalAuth`) — flux publics servis à un anonyme, privé → 404 ; owner authentifié voit ses flux privés — manifeste HLS, 409 si pas live/pas prêt (STR-108) |
+| GET | `/api/streams/{id}/segments/{segment}` | `Handler.Segment` | **Public** (`OptionalAuth`) — idem playlist — segment `.ts` (nom validé anti-traversal) (STR-108) |
 
 - Moteur HLS (STR-70) : le diffuseur pousse de l'AAC sur `ingest/{stream_key}` (auth par clé, 100 % mémoire) ; **ffmpeg** (`-c:a copy`) segmente en `.ts` de ~10 s + manifeste `.m3u8` glissant servi aux auditeurs. Un segmenteur par session live, tué + répertoire nettoyé à l'arrêt. Détails [ADR 015](docs/adr/015-moteur-hls-segmentation-ffmpeg.md).
 - Cycle de vie du direct (STR-77) : `start`/`stop` = endpoints dédiés (le PUT ne touche pas au statut) ; **un seul flux live par diffuseur** ; goroutines gérées par `LiveSessions` (context + mutex). Détails [ADR 013](docs/adr/013-domaine-streaming.md) §7.

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -148,12 +148,12 @@ func run() error {
 	// Ingest du flux audio par le diffuseur (STR-70/71) : auth par stream_key dans
 	// le path (pas de JWT), le corps est un push audio continu segmenté en HLS.
 	mux.Handle("POST /api/streams/ingest/{stream_key}", http.HandlerFunc(streamingHandler.Ingest))
-	// Lecture HLS par l'auditeur (STR-70) : manifeste + segments, auth JWT. La
-	// visibilité (flux privé/absent → 404) est vérifiée dans le handler.
-	mux.Handle("GET /api/streams/{id}/playlist.m3u8", auth.RequireAuth(cfg.JWTSecret,
-		http.HandlerFunc(streamingHandler.Playlist)))
-	mux.Handle("GET /api/streams/{id}/segments/{segment}", auth.RequireAuth(cfg.JWTSecret,
-		http.HandlerFunc(streamingHandler.Segment)))
+	// Lecture HLS par l'auditeur (STR-108) : manifeste + segments, PUBLIQUE (pas de
+	// JWT) — le player natif just_audio ne peut pas porter le Bearer. La visibilité
+	// (flux privé/absent → 404) est vérifiée dans le handler ; seuls les flux publics
+	// sont servis à un anonyme.
+	mux.Handle("GET /api/streams/{id}/playlist.m3u8", http.HandlerFunc(streamingHandler.Playlist))
+	mux.Handle("GET /api/streams/{id}/segments/{segment}", http.HandlerFunc(streamingHandler.Segment))
 	// Documentation OpenAPI (Swagger UI + spec brute) — exposée hors production
 	// uniquement, pour ne pas publier la surface de l'API sur l'environnement public.
 	if !cfg.IsProd() {

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -148,12 +148,14 @@ func run() error {
 	// Ingest du flux audio par le diffuseur (STR-70/71) : auth par stream_key dans
 	// le path (pas de JWT), le corps est un push audio continu segmenté en HLS.
 	mux.Handle("POST /api/streams/ingest/{stream_key}", http.HandlerFunc(streamingHandler.Ingest))
-	// Lecture HLS par l'auditeur (STR-108) : manifeste + segments, PUBLIQUE (pas de
-	// JWT) — le player natif just_audio ne peut pas porter le Bearer. La visibilité
-	// (flux privé/absent → 404) est vérifiée dans le handler ; seuls les flux publics
-	// sont servis à un anonyme.
-	mux.Handle("GET /api/streams/{id}/playlist.m3u8", http.HandlerFunc(streamingHandler.Playlist))
-	mux.Handle("GET /api/streams/{id}/segments/{segment}", http.HandlerFunc(streamingHandler.Segment))
+	// Lecture HLS par l'auditeur (STR-108) : manifeste + segments, PUBLIQUE — le
+	// player natif just_audio ne peut pas porter le Bearer. Auth *optionnelle* : un
+	// anonyme obtient les flux publics (privé → 404 via GetStream) ; un propriétaire
+	// authentifié qui présente un token voit aussi ses propres flux privés.
+	mux.Handle("GET /api/streams/{id}/playlist.m3u8",
+		auth.OptionalAuth(cfg.JWTSecret, http.HandlerFunc(streamingHandler.Playlist)))
+	mux.Handle("GET /api/streams/{id}/segments/{segment}",
+		auth.OptionalAuth(cfg.JWTSecret, http.HandlerFunc(streamingHandler.Segment)))
 	// Documentation OpenAPI (Swagger UI + spec brute) — exposée hors production
 	// uniquement, pour ne pas publier la surface de l'API sur l'environnement public.
 	if !cfg.IsProd() {

--- a/backend/internal/auth/middleware.go
+++ b/backend/internal/auth/middleware.go
@@ -46,6 +46,30 @@ func RequireAuth(jwtSecret string, next http.Handler) http.Handler {
 	})
 }
 
+// OptionalAuth injecte l'identité dans le context SI un Bearer valide est présent,
+// sinon laisse passer la requête en anonyme (UserIDFromContext -> "", false). À
+// l'inverse de RequireAuth, ne rejette jamais (ni token absent, ni token invalide).
+// Usage : routes à lecture publique où un propriétaire authentifié doit toutefois
+// pouvoir accéder à ses propres flux privés (STR-108). Un token présent mais
+// invalide/expiré est traité comme anonyme (la route reste publique).
+func OptionalAuth(jwtSecret string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenStr, ok := strings.CutPrefix(r.Header.Get("Authorization"), "Bearer ")
+		if !ok || tokenStr == "" {
+			next.ServeHTTP(w, r) // anonyme
+			return
+		}
+		claims, err := ParseAccessToken(tokenStr, jwtSecret)
+		if err != nil {
+			next.ServeHTTP(w, r) // token invalide -> anonyme (route publique)
+			return
+		}
+		ctx := context.WithValue(r.Context(), contextKeyUserID, claims.UserID)
+		ctx = context.WithValue(ctx, contextKeyRole, claims.Role)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
 // RequireRole doit être chaîné après RequireAuth.
 func RequireRole(required string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/auth/middleware_test.go
+++ b/backend/internal/auth/middleware_test.go
@@ -96,3 +96,64 @@ func TestRequireRole_Hierarchy(t *testing.T) {
 		})
 	}
 }
+
+func TestOptionalAuth_NoToken_Anonymous(t *testing.T) {
+	var id string
+	var present bool
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id, present = UserIDFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil) // aucun header Authorization
+	rec := httptest.NewRecorder()
+	OptionalAuth(testSecret, next).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200 (anonyme laissé passer), got %d", rec.Code)
+	}
+	if present || id != "" {
+		t.Errorf("anonyme attendu, got id=%q present=%v", id, present)
+	}
+}
+
+func TestOptionalAuth_ValidToken_InjectsIdentity(t *testing.T) {
+	var id, role string
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id, _ = UserIDFromContext(r.Context())
+		role, _ = RoleFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+makeToken(t, "owner-1", "broadcaster", time.Minute))
+	rec := httptest.NewRecorder()
+	OptionalAuth(testSecret, next).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rec.Code)
+	}
+	if id != "owner-1" || role != "broadcaster" {
+		t.Errorf("identité attendue {owner-1, broadcaster}, got {%s, %s}", id, role)
+	}
+}
+
+func TestOptionalAuth_InvalidToken_Anonymous(t *testing.T) {
+	var present bool
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, present = UserIDFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer not-a-valid-jwt")
+	rec := httptest.NewRecorder()
+	OptionalAuth(testSecret, next).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200 (token invalide -> anonyme, jamais 401), got %d", rec.Code)
+	}
+	if present {
+		t.Error("token invalide doit être traité comme anonyme (pas d'identité)")
+	}
+}

--- a/backend/internal/openapi/openapi.yaml
+++ b/backend/internal/openapi/openapi.yaml
@@ -764,10 +764,11 @@ paths:
       operationId: streamPlaylist
       summary: Get the live HLS media playlist (manifest).
       description: >-
-        Public — no authentication (native HLS players cannot carry a Bearer
-        token). Returns the continuously-updated HLS media playlist (`.m3u8`) of a
-        live **public** stream. Segment URIs are relative (`segments/…`). A private
-        or absent stream returns 404.
+        Public — authentication is optional (native HLS players cannot carry a
+        Bearer token). Returns the continuously-updated HLS media playlist (`.m3u8`)
+        of a live **public** stream. Segment URIs are relative (`segments/…`). A
+        private or absent stream returns 404; an owner passing a valid Bearer may
+        also access their own private stream.
       responses:
         "200":
           description: HLS media playlist.
@@ -806,9 +807,10 @@ paths:
       operationId: streamSegment
       summary: Get an HLS media segment (.ts).
       description: >-
-        Public — no authentication. Returns an MPEG-TS audio segment referenced by
-        the live playlist of a **public** stream. A private or absent stream
-        returns 404.
+        Public — authentication is optional. Returns an MPEG-TS audio segment
+        referenced by the live playlist of a **public** stream. A private or absent
+        stream returns 404; an owner passing a valid Bearer may also access their
+        own private stream.
       responses:
         "200":
           description: MPEG-TS segment.

--- a/backend/internal/openapi/openapi.yaml
+++ b/backend/internal/openapi/openapi.yaml
@@ -764,11 +764,10 @@ paths:
       operationId: streamPlaylist
       summary: Get the live HLS media playlist (manifest).
       description: >-
-        Returns the continuously-updated HLS media playlist (`.m3u8`) of a live
-        stream. Segment URIs are relative (`segments/…`). Requires the stream to
-        be live.
-      security:
-        - bearerAuth: []
+        Public — no authentication (native HLS players cannot carry a Bearer
+        token). Returns the continuously-updated HLS media playlist (`.m3u8`) of a
+        live **public** stream. Segment URIs are relative (`segments/…`). A private
+        or absent stream returns 404.
       responses:
         "200":
           description: HLS media playlist.
@@ -776,8 +775,6 @@ paths:
             application/vnd.apple.mpegurl:
               schema:
                 type: string
-        "401":
-          $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
         "409":
@@ -809,10 +806,9 @@ paths:
       operationId: streamSegment
       summary: Get an HLS media segment (.ts).
       description: >-
-        Returns an MPEG-TS audio segment referenced by the live playlist. Requires
-        the stream to be live.
-      security:
-        - bearerAuth: []
+        Public — no authentication. Returns an MPEG-TS audio segment referenced by
+        the live playlist of a **public** stream. A private or absent stream
+        returns 404.
       responses:
         "200":
           description: MPEG-TS segment.
@@ -821,8 +817,6 @@ paths:
               schema:
                 type: string
                 format: binary
-        "401":
-          $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
 components:

--- a/backend/internal/streaming/handler.go
+++ b/backend/internal/streaming/handler.go
@@ -484,17 +484,18 @@ func ingestError(err error) error {
 	}
 }
 
-// Playlist gère GET /api/streams/{id}/playlist.m3u8 : sert le manifeste HLS à un
-// auditeur authentifié. 409 si le flux n'est pas en direct.
+// Playlist gère GET /api/streams/{id}/playlist.m3u8 : sert le manifeste HLS d'un
+// flux public (lecture publique, cf. serveHLSFile). 409 si le flux n'est pas en
+// direct ou si le manifeste n'est pas encore prêt.
 func (h *Handler) Playlist(w http.ResponseWriter, r *http.Request) {
 	h.serveHLSFile(w, r, "application/vnd.apple.mpegurl",
 		func(id string) (string, bool) { return h.sessions.Playlist(id) },
 		apperror.Conflict("stream is not live"))
 }
 
-// Segment gère GET /api/streams/{id}/segments/{segment} : sert un segment .ts à un
-// auditeur authentifié. Le nom du segment est validé (anti path-traversal) dans
-// la couche session ; nom invalide ou segment absent -> 404.
+// Segment gère GET /api/streams/{id}/segments/{segment} : sert un segment .ts d'un
+// flux public (lecture publique, cf. serveHLSFile). Le nom du segment est validé
+// (anti path-traversal) dans la couche session ; nom invalide ou segment absent -> 404.
 func (h *Handler) Segment(w http.ResponseWriter, r *http.Request) {
 	h.serveHLSFile(w, r, "video/mp2t",
 		func(id string) (string, bool) { return h.sessions.Segment(id, r.PathValue("segment")) },

--- a/backend/internal/streaming/handler.go
+++ b/backend/internal/streaming/handler.go
@@ -502,15 +502,16 @@ func (h *Handler) Segment(w http.ResponseWriter, r *http.Request) {
 }
 
 // serveHLSFile factorise le service d'un fichier HLS (manifeste ou segment) à un
-// auditeur authentifié : contrôle de visibilité (GetStream, 404 si absent/privé),
-// lookup de la session (unavailable si le flux n'est pas en direct), en-têtes puis
-// ServeFile. lookup renvoie le chemin disque et sa validité.
+// auditeur : contrôle de visibilité (GetStream, 404 si absent/privé), lookup de la
+// session (unavailable si le flux n'est pas en direct), en-têtes puis ServeFile.
+// lookup renvoie le chemin disque et sa validité.
+//
+// Lecture PUBLIQUE (STR-108) : pas d'authentification requise — le player natif
+// (just_audio → AVPlayer/ExoPlayer) ne peut pas porter le Bearer. Un auditeur
+// anonyme a requesterID = "" ; la visibilité de GetStream sert alors les flux
+// publics et renvoie 404 pour un flux privé (jamais propriétaire de "").
 func (h *Handler) serveHLSFile(w http.ResponseWriter, r *http.Request, contentType string, lookup func(id string) (string, bool), unavailable error) {
-	requesterID, ok := auth.UserIDFromContext(r.Context())
-	if !ok {
-		httpjson.WriteError(w, r, apperror.Unauthorized("unauthenticated"))
-		return
-	}
+	requesterID, _ := auth.UserIDFromContext(r.Context()) // "" si anonyme (pas de JWT)
 	id := r.PathValue("id")
 
 	if _, _, err := h.svc.GetStream(r.Context(), id, requesterID); err != nil {

--- a/backend/internal/streaming/handler_test.go
+++ b/backend/internal/streaming/handler_test.go
@@ -650,3 +650,65 @@ func TestHandler_Playlist_NotReadyReturnsJSON409(t *testing.T) {
 		t.Fatalf("l'erreur doit rester JSON, content-type=%q", ct)
 	}
 }
+
+// TestHandler_Playlist_PublicNoAuth : lecture publique (STR-108) — un flux public
+// est servi SANS token ni RequireAuth.
+func TestHandler_Playlist_PublicNoAuth(t *testing.T) {
+	ls := sessionsWithFakeSeg(t)
+	ls.Start("pub", "KEYPUB")
+	defer ls.StopAll()
+	stub := &stubService{getRet: Stream{ID: "pub", UserID: "owner-uuid", IsPublic: true}}
+	h := NewHandler(stub, testIngestURL, ls)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/streams/pub/playlist.m3u8", nil)
+	req.SetPathValue("id", "pub")
+	rec := httptest.NewRecorder()
+
+	h.Playlist(rec, req) // aucun token, aucun RequireAuth
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200 (lecture publique), got %d: %s", rec.Code, rec.Body)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/vnd.apple.mpegurl") {
+		t.Fatalf("content-type manifeste attendu, got %q", ct)
+	}
+}
+
+func TestHandler_Segment_PublicNoAuth(t *testing.T) {
+	ls := sessionsWithFakeSeg(t)
+	ls.Start("pub2", "KEYPUB2")
+	defer ls.StopAll()
+	stub := &stubService{getRet: Stream{ID: "pub2", UserID: "owner-uuid", IsPublic: true}}
+	h := NewHandler(stub, testIngestURL, ls)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/streams/pub2/segments/seg_00000.ts", nil)
+	req.SetPathValue("id", "pub2")
+	req.SetPathValue("segment", "seg_00000.ts")
+	rec := httptest.NewRecorder()
+
+	h.Segment(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200 (segment public), got %d: %s", rec.Code, rec.Body)
+	}
+}
+
+// TestHandler_Playlist_PrivateNoAuth_Returns404 : un anonyme sur un flux privé/absent
+// reçoit 404 (visibilité gérée par GetStream), jamais 401.
+func TestHandler_Playlist_PrivateNoAuth_Returns404(t *testing.T) {
+	ls := sessionsWithFakeSeg(t)
+	ls.Start("priv", "KEYPRIV")
+	defer ls.StopAll()
+	stub := &stubService{getErr: apperror.NotFound("stream not found")}
+	h := NewHandler(stub, testIngestURL, ls)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/streams/priv/playlist.m3u8", nil)
+	req.SetPathValue("id", "priv")
+	rec := httptest.NewRecorder()
+
+	h.Playlist(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("want 404 (flux privé/absent, anonyme), got %d: %s", rec.Code, rec.Body)
+	}
+}

--- a/backend/internal/streaming/handler_test.go
+++ b/backend/internal/streaming/handler_test.go
@@ -651,20 +651,27 @@ func TestHandler_Playlist_NotReadyReturnsJSON409(t *testing.T) {
 	}
 }
 
-// TestHandler_Playlist_PublicNoAuth : lecture publique (STR-108) — un flux public
-// est servi SANS token ni RequireAuth.
-func TestHandler_Playlist_PublicNoAuth(t *testing.T) {
+// newLiveHandler construit un handler dont le flux `id` a une session live
+// (segmenteur simulé), avec le service stubbé fourni. La session est nettoyée en
+// fin de test.
+func newLiveHandler(t *testing.T, id string, svc StreamService) *Handler {
+	t.Helper()
 	ls := sessionsWithFakeSeg(t)
-	ls.Start("pub", "KEYPUB")
-	defer ls.StopAll()
-	stub := &stubService{getRet: Stream{ID: "pub", UserID: "owner-uuid", IsPublic: true}}
-	h := NewHandler(stub, testIngestURL, ls)
+	ls.Start(id, "KEY-"+id)
+	t.Cleanup(ls.StopAll)
+	return NewHandler(svc, testIngestURL, ls)
+}
+
+// TestHandler_Playlist_PublicNoAuth : lecture publique (STR-108) — le handler sert
+// un flux public sans identité dans le context (anonyme).
+func TestHandler_Playlist_PublicNoAuth(t *testing.T) {
+	h := newLiveHandler(t, "pub", &stubService{getRet: Stream{ID: "pub", UserID: "owner-uuid", IsPublic: true}})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/streams/pub/playlist.m3u8", nil)
 	req.SetPathValue("id", "pub")
 	rec := httptest.NewRecorder()
 
-	h.Playlist(rec, req) // aucun token, aucun RequireAuth
+	h.Playlist(rec, req) // aucune identité dans le context
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("want 200 (lecture publique), got %d: %s", rec.Code, rec.Body)
@@ -675,11 +682,7 @@ func TestHandler_Playlist_PublicNoAuth(t *testing.T) {
 }
 
 func TestHandler_Segment_PublicNoAuth(t *testing.T) {
-	ls := sessionsWithFakeSeg(t)
-	ls.Start("pub2", "KEYPUB2")
-	defer ls.StopAll()
-	stub := &stubService{getRet: Stream{ID: "pub2", UserID: "owner-uuid", IsPublic: true}}
-	h := NewHandler(stub, testIngestURL, ls)
+	h := newLiveHandler(t, "pub2", &stubService{getRet: Stream{ID: "pub2", UserID: "owner-uuid", IsPublic: true}})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/streams/pub2/segments/seg_00000.ts", nil)
 	req.SetPathValue("id", "pub2")
@@ -694,13 +697,10 @@ func TestHandler_Segment_PublicNoAuth(t *testing.T) {
 }
 
 // TestHandler_Playlist_PrivateNoAuth_Returns404 : un anonyme sur un flux privé/absent
-// reçoit 404 (visibilité gérée par GetStream), jamais 401.
+// reçoit 404 (visibilité gérée par GetStream), jamais 401. Aucune session live n'est
+// nécessaire : le handler sort sur GetStream avant le lookup de session.
 func TestHandler_Playlist_PrivateNoAuth_Returns404(t *testing.T) {
-	ls := sessionsWithFakeSeg(t)
-	ls.Start("priv", "KEYPRIV")
-	defer ls.StopAll()
-	stub := &stubService{getErr: apperror.NotFound("stream not found")}
-	h := NewHandler(stub, testIngestURL, ls)
+	h := NewHandler(&stubService{getErr: apperror.NotFound("stream not found")}, testIngestURL, NewLiveSessions(context.Background()))
 
 	req := httptest.NewRequest(http.MethodGet, "/api/streams/priv/playlist.m3u8", nil)
 	req.SetPathValue("id", "priv")
@@ -710,5 +710,35 @@ func TestHandler_Playlist_PrivateNoAuth_Returns404(t *testing.T) {
 
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("want 404 (flux privé/absent, anonyme), got %d: %s", rec.Code, rec.Body)
+	}
+}
+
+// TestHandler_Playlist_ViaOptionalAuth exerce la vraie chaîne middleware (comme
+// main.go) : anonyme sur flux public -> 200 ; propriétaire authentifié sur flux
+// privé -> 200 (préserve la lecture propriétaire — régression corrigée).
+func TestHandler_Playlist_ViaOptionalAuth(t *testing.T) {
+	// Anonyme (aucun header Authorization), flux public -> 200.
+	pub := newLiveHandler(t, "pubc", &stubService{getRet: Stream{ID: "pubc", UserID: testUserID, IsPublic: true}})
+	req := httptest.NewRequest(http.MethodGet, "/api/streams/pubc/playlist.m3u8", nil)
+	req.SetPathValue("id", "pubc")
+	rec := httptest.NewRecorder()
+	auth.OptionalAuth(testSecret, http.HandlerFunc(pub.Playlist)).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("anonyme/flux public via OptionalAuth: want 200, got %d: %s", rec.Code, rec.Body)
+	}
+
+	// Propriétaire authentifié (token valide), flux privé -> 200.
+	owner := newLiveHandler(t, "prvc", &stubService{getRet: Stream{ID: "prvc", UserID: testUserID, IsPublic: false}, getOwner: true})
+	token, err := auth.GenerateAccessToken(testUserID, "broadcaster", testSecret, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	req2 := httptest.NewRequest(http.MethodGet, "/api/streams/prvc/playlist.m3u8", nil)
+	req2.SetPathValue("id", "prvc")
+	req2.Header.Set("Authorization", "Bearer "+token)
+	rec2 := httptest.NewRecorder()
+	auth.OptionalAuth(testSecret, http.HandlerFunc(owner.Playlist)).ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("propriétaire/flux privé via OptionalAuth: want 200, got %d: %s", rec2.Code, rec2.Body)
 	}
 }

--- a/backend/internal/streaming/service_test.go
+++ b/backend/internal/streaming/service_test.go
@@ -333,6 +333,37 @@ func TestService_GetStream_PrivateNonOwner_NotFound(t *testing.T) {
 	}
 }
 
+// TestService_GetStream_Anonymous : un demandeur anonyme (requesterID = "") — cas
+// central de la lecture publique HLS (STR-108) — obtient les flux publics et un 404
+// sur les flux privés (jamais propriétaire de "").
+func TestService_GetStream_Anonymous(t *testing.T) {
+	t.Run("flux public servi", func(t *testing.T) {
+		repo := &fakeRepo{getRet: Stream{ID: "s1", UserID: "u1", IsPublic: true}}
+		svc := NewService(repo, fakeKeys{}, &fakeSessions{})
+
+		got, isOwner, err := svc.GetStream(context.Background(), "s1", "")
+		if err != nil {
+			t.Fatalf("flux public anonyme: erreur inattendue %v", err)
+		}
+		if isOwner {
+			t.Error("un anonyme ne doit jamais être propriétaire")
+		}
+		if got.ID != "s1" {
+			t.Errorf("stream = %+v, want id s1", got)
+		}
+	})
+
+	t.Run("flux privé -> 404", func(t *testing.T) {
+		repo := &fakeRepo{getRet: Stream{ID: "s1", UserID: "u1", IsPublic: false}}
+		svc := NewService(repo, fakeKeys{}, &fakeSessions{})
+
+		_, _, err := svc.GetStream(context.Background(), "s1", "")
+		if !apperror.IsCode(err, apperror.CodeNotFound) {
+			t.Fatalf("flux privé anonyme: code = %v, want not_found", err)
+		}
+	})
+}
+
 func TestService_UpdateStream_ValidationError(t *testing.T) {
 	repo := &fakeRepo{}
 	svc := NewService(repo, fakeKeys{}, &fakeSessions{})

--- a/docs/adr/015-moteur-hls-segmentation-ffmpeg.md
+++ b/docs/adr/015-moteur-hls-segmentation-ffmpeg.md
@@ -1,8 +1,8 @@
 # ADR 015 — Moteur HLS : segmentation et manifeste via ffmpeg
 
 **Date** : 2026-07-13
-**Statut** : Accepté
-**Ticket** : [STR-70](https://linear.app/streampulse/issue/STR-70) (sous-issue [STR-71](https://linear.app/streampulse/issue/STR-71) — endpoint de réception)
+**Statut** : Accepté — **révisé le 2026-07-19 par [STR-108](https://linear.app/streampulse/issue/STR-108)** (lecture HLS auditeur : `RequireAuth` JWT → **lecture publique des flux publics**, cf. §3)
+**Ticket** : [STR-70](https://linear.app/streampulse/issue/STR-70) (sous-issue [STR-71](https://linear.app/streampulse/issue/STR-71) — endpoint de réception) · révision [STR-108](https://linear.app/streampulse/issue/STR-108)
 
 ---
 
@@ -134,14 +134,19 @@ Deux routes de lecture, servies depuis `<dir>` de la session (via `http.ServeFil
 - **Visibilité** : réutilise la logique de `GetStream` (flux privé d'un tiers / absent / archivé →
   `404`). `Cache-Control: no-cache` sur le manifeste **et** les segments (choix conservateur pour le
   MVP ; mettre les segments — immuables une fois écrits — en cache court reste une optimisation possible).
-- **Auth auditeur — lecture PUBLIQUE** (révisé pour STR-108) : `playlist.m3u8` et `segments/{name}`
-  sont servis **sans authentification**. Motif : le player natif (just_audio → AVPlayer/ExoPlayer)
-  fait ses propres requêtes HTTP et **ne peut pas porter le `Bearer`** de façon fiable (surtout iOS
-  sur les sous-requêtes de segments), et le token d'accès (15 min) expirerait en cours d'écoute. La
-  visibilité est déléguée à `GetStream` : un anonyme (`requesterID = ""`) obtient les flux **publics**
-  et un **404** sur un flux privé (jamais propriétaire de `""`). Cohérent avec la découverte déjà
-  publique (STR-107) et le rôle `anonymous`. *Décision initiale (STR-70) : `RequireAuth` JWT —
-  remplacée ici.* La lecture d'un flux **privé** (owner authentifié) reste un suivi hors scope.
+- **Auth auditeur — lecture PUBLIQUE, auth optionnelle** (révisé pour STR-108) : `playlist.m3u8` et
+  `segments/{name}` sont montés derrière `auth.OptionalAuth` (et non `RequireAuth`). Motif : le player
+  natif (just_audio → AVPlayer/ExoPlayer) fait ses propres requêtes HTTP et **ne peut pas porter le
+  `Bearer`** de façon fiable (surtout iOS sur les sous-requêtes de segments), et le token d'accès
+  (15 min) expirerait en cours d'écoute. `OptionalAuth` parse le Bearer **s'il est présent** (sinon
+  anonyme, jamais de 401). La visibilité est déléguée à `GetStream` :
+  - **anonyme** (`requesterID = ""`) → flux **publics** servis, **404** sur un flux privé (jamais
+    propriétaire de `""`) ;
+  - **propriétaire authentifié** (token présent) → voit aussi ses **propres flux privés** (pas de
+    régression vs le `RequireAuth` initial).
+
+  Cohérent avec la découverte déjà publique (STR-107) et le rôle `anonymous`. *Décision initiale
+  (STR-70) : `RequireAuth` JWT — remplacée par `OptionalAuth`.*
 - **Anti-traversal** : `{name}` validé strictement (`^seg_\d+\.ts$`), jamais concaténé brut au path.
 - **Fichier absent** : session vivante mais fichier pas encore écrit (fenêtre start→1er segment, ou
   push dont ffmpeg n'a rien produit) ou déjà retiré (fenêtre glissante) → un `os.Stat` renvoie

--- a/docs/adr/015-moteur-hls-segmentation-ffmpeg.md
+++ b/docs/adr/015-moteur-hls-segmentation-ffmpeg.md
@@ -134,10 +134,14 @@ Deux routes de lecture, servies depuis `<dir>` de la session (via `http.ServeFil
 - **Visibilité** : réutilise la logique de `GetStream` (flux privé d'un tiers / absent / archivé →
   `404`). `Cache-Control: no-cache` sur le manifeste **et** les segments (choix conservateur pour le
   MVP ; mettre les segments — immuables une fois écrits — en cache court reste une optimisation possible).
-- **Auth auditeur** : `RequireAuth` (JWT), cohérent avec les autres lectures. ⚠️ *caveat* connu :
-  certains players HLS natifs passent mal les en-têtes `Authorization` sur les sous-requêtes de
-  segments ; si cela bloque la démo, un token de lecture court dans l'URL sera tracé comme suivi
-  (hors périmètre STR-70).
+- **Auth auditeur — lecture PUBLIQUE** (révisé pour STR-108) : `playlist.m3u8` et `segments/{name}`
+  sont servis **sans authentification**. Motif : le player natif (just_audio → AVPlayer/ExoPlayer)
+  fait ses propres requêtes HTTP et **ne peut pas porter le `Bearer`** de façon fiable (surtout iOS
+  sur les sous-requêtes de segments), et le token d'accès (15 min) expirerait en cours d'écoute. La
+  visibilité est déléguée à `GetStream` : un anonyme (`requesterID = ""`) obtient les flux **publics**
+  et un **404** sur un flux privé (jamais propriétaire de `""`). Cohérent avec la découverte déjà
+  publique (STR-107) et le rôle `anonymous`. *Décision initiale (STR-70) : `RequireAuth` JWT —
+  remplacée ici.* La lecture d'un flux **privé** (owner authentifié) reste un suivi hors scope.
 - **Anti-traversal** : `{name}` validé strictement (`^seg_\d+\.ts$`), jamais concaténé brut au path.
 - **Fichier absent** : session vivante mais fichier pas encore écrit (fenêtre start→1er segment, ou
   push dont ffmpeg n'a rien produit) ou déjà retiré (fenêtre glissante) → un `os.Stat` renvoie

--- a/mobile/packages/streampulse_api/lib/src/api/streaming_api.dart
+++ b/mobile/packages/streampulse_api/lib/src/api/streaming_api.dart
@@ -633,7 +633,7 @@ class StreamingApi {
   }
 
   /// Get the live HLS media playlist (manifest).
-  /// Returns the continuously-updated HLS media playlist (&#x60;.m3u8&#x60;) of a live stream. Segment URIs are relative (&#x60;segments/…&#x60;). Requires the stream to be live.
+  /// Public — no authentication (native HLS players cannot carry a Bearer token). Returns the continuously-updated HLS media playlist (&#x60;.m3u8&#x60;) of a live **public** stream. Segment URIs are relative (&#x60;segments/…&#x60;). A private or absent stream returns 404.
   ///
   /// Parameters:
   /// * [id]
@@ -664,12 +664,7 @@ class StreamingApi {
     final _options = Options(
       method: r'GET',
       headers: <String, dynamic>{...?headers},
-      extra: <String, dynamic>{
-        'secure': <Map<String, String>>[
-          {'type': 'http', 'scheme': 'bearer', 'name': 'bearerAuth'},
-        ],
-        ...?extra,
-      },
+      extra: <String, dynamic>{'secure': <Map<String, String>>[], ...?extra},
       validateStatus: validateStatus,
     );
 
@@ -711,7 +706,7 @@ class StreamingApi {
   }
 
   /// Get an HLS media segment (.ts).
-  /// Returns an MPEG-TS audio segment referenced by the live playlist. Requires the stream to be live.
+  /// Public — no authentication. Returns an MPEG-TS audio segment referenced by the live playlist of a **public** stream. A private or absent stream returns 404.
   ///
   /// Parameters:
   /// * [id]
@@ -752,12 +747,7 @@ class StreamingApi {
       method: r'GET',
       responseType: ResponseType.bytes,
       headers: <String, dynamic>{...?headers},
-      extra: <String, dynamic>{
-        'secure': <Map<String, String>>[
-          {'type': 'http', 'scheme': 'bearer', 'name': 'bearerAuth'},
-        ],
-        ...?extra,
-      },
+      extra: <String, dynamic>{'secure': <Map<String, String>>[], ...?extra},
       validateStatus: validateStatus,
     );
 

--- a/mobile/packages/streampulse_api/lib/src/api/streaming_api.dart
+++ b/mobile/packages/streampulse_api/lib/src/api/streaming_api.dart
@@ -633,7 +633,7 @@ class StreamingApi {
   }
 
   /// Get the live HLS media playlist (manifest).
-  /// Public — no authentication (native HLS players cannot carry a Bearer token). Returns the continuously-updated HLS media playlist (&#x60;.m3u8&#x60;) of a live **public** stream. Segment URIs are relative (&#x60;segments/…&#x60;). A private or absent stream returns 404.
+  /// Public — authentication is optional (native HLS players cannot carry a Bearer token). Returns the continuously-updated HLS media playlist (&#x60;.m3u8&#x60;) of a live **public** stream. Segment URIs are relative (&#x60;segments/…&#x60;). A private or absent stream returns 404; an owner passing a valid Bearer may also access their own private stream.
   ///
   /// Parameters:
   /// * [id]
@@ -706,7 +706,7 @@ class StreamingApi {
   }
 
   /// Get an HLS media segment (.ts).
-  /// Public — no authentication. Returns an MPEG-TS audio segment referenced by the live playlist of a **public** stream. A private or absent stream returns 404.
+  /// Public — authentication is optional. Returns an MPEG-TS audio segment referenced by the live playlist of a **public** stream. A private or absent stream returns 404; an owner passing a valid Bearer may also access their own private stream.
   ///
   /// Parameters:
   /// * [id]


### PR DESCRIPTION
## Contexte

Prérequis backend pour **[STR-108](https://linear.app/streampulse/issue/STR-108)** (lecteur audio HLS, milestone *Expérience Auditeur Mobile*). Le player natif `just_audio` (→ AVPlayer iOS / ExoPlayer Android) fait ses **propres requêtes HTTP** pour le manifeste et les segments — il **ne peut pas porter le `Bearer`** de façon fiable (surtout iOS sur les sous-requêtes de segments), et le token d'accès (15 min) expirerait en cours d'écoute. On rend donc la **lecture HLS publique** pour les flux publics.

## Décision (révise l'[ADR 015](docs/adr/015-moteur-hls-segmentation-ffmpeg.md) §3)

`GET /api/streams/{id}/playlist.m3u8` et `.../segments/{segment}` passent de `RequireAuth` à **`auth.OptionalAuth`** (auth *optionnelle*, jamais de 401) :

- **anonyme** (pas de token) → flux **publics** servis ; flux **privé/absent** → **404** (un anonyme n'est jamais propriétaire de `""`).
- **propriétaire authentifié** (token présent) → voit aussi ses **propres flux privés** — *pas de régression* vs le `RequireAuth` initial.

Cohérent avec la découverte déjà publique (STR-107) et le rôle `anonymous`. Le `stream_key`/ingest reste **secret** ; seule la **lecture** devient publique. La protection des flux privés contre un accès non autorisé est intacte.

## Contenu

- **`auth.OptionalAuth`** (nouveau middleware) : parse le Bearer s'il est présent (sinon anonyme). `main.go` monte les 2 routes HLS avec.
- `handler.go` (`serveHLSFile`) : identité optionnelle (`requesterID = ""` si anonyme), visibilité déléguée à `GetStream`.
- **OpenAPI** : `401` retiré, descriptions « auth optionnelle » → **client Dart régénéré**.
- ADR 015 (en-tête + §3), table des routes `CLAUDE.md` alignés (décision + révision tracées).

## Vérification

- `go build` · `go vet` · `gofmt` · `go test -race` (auth + streaming + openapi) **verts**.
- Tests : `OptionalAuth` (no-token / token valide / token invalide) ; manifeste & segment publics → `200` ; flux privé anonyme → `404` ; **propriétaire/flux privé via `OptionalAuth` → `200`** ; `GetStream` service avec `requesterID = ""` (public servi, privé → `404`).
- `gosec --exclude-generated ./...` → **Issues : 0**. OpenAPI YAML valide.

## Hors scope

Lecture d'un flux **privé depuis le player natif** `just_audio` : le player ne porte pas de token, donc en pratique seul un **client authentifié** (qui présente un Bearer) accède à un flux privé. Suffisant pour l'auditeur MVP (flux publics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
