### PR TITLE
feat(infra): dashboard Grafana Logs & Erreurs et alertes provisionnées par email

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,12 @@ Config : `backend/sqlc.yaml` — schéma lu depuis `migrations/*.up.sql`.
 - SQL : `otelpgx` sur le pool (`pool.go`) — un span par query, sans les arguments.
 - Logs corrélés : `trace_id`/`span_id` ajoutés par `AccessLog` quand un span est actif → bouton TraceID dans Grafana (Loki `derivedFields`).
 
+### Alertes Grafana (STR-167, ADR 021)
+
+- Provisionnées as-code : `docker/grafana/provisioning/alerting/` (contact point email, policy, règles 5xx>5%/CPU>90%/goroutines>200, `for: 5m`).
+- Dev : les emails d'alerte partent dans Mailpit (http://localhost:8025). Prod : relay `SMTP_*` du `.env`.
+- Dashboard « Logs & Erreurs » : variables `$level` et `$trace_id`, dernières erreurs cliquables vers Tempo.
+
 ### Patterns à respecter
 
 - **ISP** : le handler déclare des interfaces étroites (`Registrar`, `Authenticator`, `TokenRefresher`) — chacune couvre exactement ce dont le handler a besoin. `*Service` les satisfait toutes.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -200,6 +200,12 @@ services:
     environment:
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}
       GF_USERS_ALLOW_SIGN_UP: "false"
+      # Alertes par email (STR-167, ADR 021) : même relay SMTP que l'API.
+      GF_SMTP_ENABLED: "true"
+      GF_SMTP_HOST: ${SMTP_HOST}:${SMTP_PORT:-587}
+      GF_SMTP_USER: ${SMTP_USERNAME:-}
+      GF_SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+      GF_SMTP_FROM_ADDRESS: ${SMTP_FROM:-noreply@streampulse.com}
     depends_on:
       prometheus:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -196,6 +196,12 @@ services:
     environment:
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}
       GF_USERS_ALLOW_SIGN_UP: "false"
+      # Alertes par email (STR-167, ADR 021) : en dev tout part dans Mailpit
+      # (http://localhost:8025) — aucune sortie réseau réelle.
+      GF_SMTP_ENABLED: "true"
+      GF_SMTP_HOST: mailpit:1025
+      GF_SMTP_FROM_ADDRESS: alertes@streampulse.dev
+      GF_SMTP_SKIP_VERIFY: "true"
     depends_on:
       prometheus:
         condition: service_healthy

--- a/docker/grafana/provisioning/alerting/contactpoints.yml
+++ b/docker/grafana/provisioning/alerting/contactpoints.yml
@@ -1,0 +1,15 @@
+# Contact points provisionnés (STR-167, ADR 021) — la vérité vit dans git.
+# En dev, Grafana envoie via Mailpit (GF_SMTP_HOST=mailpit:1025) : les emails
+# d'alerte sont visibles sur http://localhost:8025. En prod, GF_SMTP_* pointe
+# le relay SMTP réel (mêmes variables que l'API).
+apiVersion: 1
+
+contactPoints:
+  - orgId: 1
+    name: equipe-streampulse
+    receivers:
+      - uid: email-equipe
+        type: email
+        settings:
+          addresses: admin@streampulse.dev
+          singleEmail: true

--- a/docker/grafana/provisioning/alerting/policies.yml
+++ b/docker/grafana/provisioning/alerting/policies.yml
@@ -1,0 +1,12 @@
+# Politique de notification racine (STR-167, ADR 021) : toutes les alertes
+# vers le contact point email. group_by service/alertname évite un email par
+# série ; repeat_interval 4h limite le bruit d'une alerte qui reste firing.
+apiVersion: 1
+
+policies:
+  - orgId: 1
+    receiver: equipe-streampulse
+    group_by: ["alertname", "grafana_folder"]
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 4h

--- a/docker/grafana/provisioning/alerting/rules.yml
+++ b/docker/grafana/provisioning/alerting/rules.yml
@@ -1,0 +1,103 @@
+# Règles d'alerte provisionnées (STR-167 / STR-189, ADR 021).
+# Évaluation chaque minute, déclenchement après 5 minutes au-dessus du seuil
+# (`for: 5m`). Datasource : uid `prometheus` (provisionnée ADR 001).
+#
+# Format : chaque règle porte une requête A (PromQL) et une condition C
+# (threshold) — le modèle « classic condition » simple de Grafana alerting.
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: streampulse-critiques
+    folder: StreamPulse
+    interval: 1m
+    rules:
+      - uid: alerte-taux-5xx
+        title: Taux d'erreurs HTTP 5xx > 5%
+        condition: C
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Plus de 5% des requêtes HTTP échouent en 5xx sur 5 minutes."
+          description: "Vérifier les logs {service=\"api\"} | json | level=\"error\" dans Loki, puis remonter à la trace via le TraceID."
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: prometheus
+            model:
+              expr: (sum(rate(http_requests_total{status=~"5.."}[5m])) or vector(0)) / sum(rate(http_requests_total[5m]))
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0.05] }
+        noDataState: OK
+        execErrState: Error
+
+      - uid: alerte-cpu-machine
+        title: CPU machine > 90%
+        condition: C
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "CPU au-dessus de 90% depuis 5 minutes (node_exporter)."
+          description: "Vérifier le dashboard Infrastructure (goroutines, heap) et les flux HLS actifs."
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: prometheus
+            model:
+              expr: 1 - avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m]))
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0.9] }
+        noDataState: NoData
+        execErrState: Error
+
+      - uid: alerte-goroutines
+        title: Goroutines API > 200
+        condition: C
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Plus de 200 goroutines depuis 5 minutes — fuite probable (baseline ~15, pic légitime 50 auditeurs < 100)."
+          description: "Comparer avec streams/auditeurs actifs ; pprof si la croissance est monotone (STR-89)."
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: prometheus
+            model:
+              expr: go_goroutines{job="api"}
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [200] }
+        noDataState: NoData
+        execErrState: Error

--- a/docker/grafana/provisioning/alerting/rules.yml
+++ b/docker/grafana/provisioning/alerting/rules.yml
@@ -19,14 +19,14 @@ groups:
         labels:
           severity: critical
         annotations:
-          summary: "Plus de 5% des requêtes HTTP échouent en 5xx sur 5 minutes."
-          description: "Vérifier les logs {service=\"api\"} | json | level=\"error\" dans Loki, puis remonter à la trace via le TraceID."
+          summary: "Plus de 5% des requêtes HTTP échouent en 5xx sur 5 minutes (trafic significatif)."
+          description: "Le ratio n'est évalué qu'au-dessus de 0,1 req/s (~30 requêtes sur 5 min) : en dessous, une erreur isolée donnerait un ratio trompeur. Vérifier les logs {service=\"api\"} | json | level=\"error\" dans Loki, puis remonter à la trace via le TraceID."
         data:
           - refId: A
             relativeTimeRange: { from: 300, to: 0 }
             datasourceUid: prometheus
             model:
-              expr: (sum(rate(http_requests_total{status=~"5.."}[5m])) or vector(0)) / sum(rate(http_requests_total[5m]))
+              expr: ((sum(rate(http_requests_total{status=~"5.."}[5m])) or vector(0)) / sum(rate(http_requests_total[5m]))) and (sum(rate(http_requests_total[5m])) > 0.1)
               instant: true
               intervalMs: 1000
               maxDataPoints: 43200
@@ -100,4 +100,34 @@ groups:
               conditions:
                 - evaluator: { type: gt, params: [200] }
         noDataState: NoData
+        execErrState: Error
+
+      - uid: alerte-api-injoignable
+        title: API injoignable
+        condition: C
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Prometheus ne parvient plus à scraper l'API depuis 2 minutes."
+          description: "Panne totale ou conteneur arrêté : la règle sur le taux de 5xx ne peut pas la détecter (plus aucune requête n'est comptée). Vérifier `docker compose ps` et les logs du service api."
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: prometheus
+            model:
+              expr: up{job="api"}
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              refId: C
+              expression: A
+              conditions:
+                - evaluator: { type: lt, params: [1] }
+        noDataState: Alerting
         execErrState: Error

--- a/docker/grafana/provisioning/dashboards/logs-erreurs.json
+++ b/docker/grafana/provisioning/dashboards/logs-erreurs.json
@@ -1,0 +1,119 @@
+{
+  "uid": "streampulse-logs",
+  "title": "StreamPulse — Logs & Erreurs",
+  "tags": ["streampulse", "logs", "str-167"],
+  "schemaVersion": 39,
+  "editable": false,
+  "timezone": "browser",
+  "time": { "from": "now-1h", "to": "now" },
+  "refresh": "15s",
+  "templating": {
+    "list": [
+      {
+        "name": "level",
+        "label": "Niveau",
+        "type": "custom",
+        "query": "all : .+, info, warn, error",
+        "current": { "text": "all", "value": ".+" },
+        "options": [
+          { "text": "all", "value": ".+", "selected": true },
+          { "text": "info", "value": "info", "selected": false },
+          { "text": "warn", "value": "warn", "selected": false },
+          { "text": "error", "value": "error", "selected": false }
+        ]
+      },
+      {
+        "name": "trace_id",
+        "label": "Trace ID",
+        "type": "textbox",
+        "query": "",
+        "current": { "text": "", "value": "" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Erreurs 5xx / s",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 5, "w": 4, "x": 0, "y": 0 },
+      "targets": [
+        { "refId": "A", "expr": "sum(rate(http_requests_total{status=~\"5..\"}[5m])) or vector(0)" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "decimals": 3,
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 0.01 } ] }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Logs error (5 min)",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 5, "w": 4, "x": 4, "y": 0 },
+      "targets": [
+        { "refId": "A", "expr": "sum(count_over_time({service=\"api\"} | json | level=\"error\" [5m]))" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "orange", "value": 1 }, { "color": "red", "value": 10 } ] }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Volume de logs par niveau",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 5, "w": 4, "x": 8, "y": 0 },
+      "targets": [
+        { "refId": "A", "expr": "sum by (level) (count_over_time({service=\"api\"} | json [1m]))", "legendFormat": "{{level}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] }
+    },
+    {
+      "id": 4,
+      "type": "logs",
+      "title": "Logs API — filtrables par niveau et trace_id",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 12, "w": 12, "x": 0, "y": 5 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "{service=\"api\"} | json | level=~\"$level\" | trace_id=~\".*$trace_id.*\""
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "enableLogDetails": true,
+        "dedupStrategy": "none",
+        "sortOrder": "Descending"
+      }
+    },
+    {
+      "id": 5,
+      "type": "logs",
+      "title": "Dernières erreurs (level=error) — cliquer une ligne → bouton TraceID vers Tempo",
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 17 },
+      "targets": [
+        { "refId": "A", "expr": "{service=\"api\"} | json | level=\"error\"" }
+      ],
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "enableLogDetails": true,
+        "dedupStrategy": "none",
+        "sortOrder": "Descending"
+      }
+    }
+  ]
+}

--- a/docs/adr/021-alertes-grafana-provisionnees-email.md
+++ b/docs/adr/021-alertes-grafana-provisionnees-email.md
@@ -1,0 +1,69 @@
+# ADR 021 — Alertes Grafana provisionnées, notification par email
+
+**Date** : 2026-07-24
+**Statut** : Accepté
+**Ticket** : [STR-167](https://linear.app/streampulse/issue/STR-167) (sous-issues [STR-187](https://linear.app/streampulse/issue/STR-187), [STR-188](https://linear.app/streampulse/issue/STR-188), [STR-189](https://linear.app/streampulse/issue/STR-189), [STR-190](https://linear.app/streampulse/issue/STR-190))
+
+---
+
+## Contexte
+
+US-07-05, dernier volet de l'épic Observabilité : logs consultables dans un dashboard
+dédié et alertes proactives sur les seuils critiques. Tout le socle existe — logs JSON
+labellisés dans Loki (ADR 018), `http_requests_total` et node_exporter (ADR 019),
+`trace_id` dans les logs et corrélation Tempo (ADR 020).
+
+## Décision
+
+### 1. Alerting as-code : provisioning YAML, pas de configuration UI
+
+`docker/grafana/provisioning/alerting/` — `contactpoints.yml`, `policies.yml`,
+`rules.yml` (groupe `streampulse-critiques`, folder StreamPulse, évaluation 1 min,
+`for: 5m`). Même principe que les dashboards (ADR 019) : la vérité vit dans git, l'UI
+est en lecture seule sur ces objets.
+
+### 2. Trois règles
+
+| Règle | Expression | Seuil |
+|---|---|---|
+| Taux 5xx | `(sum(rate(http_requests_total{status=~"5.."}[5m])) or vector(0)) / sum(rate(...))` | > 5 % (ticket) |
+| CPU machine | `1 - avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m]))` | > 90 % (ticket) |
+| Goroutines API | `go_goroutines{job="api"}` | > 200 |
+
+Le seuil goroutines n'était pas fixé par le ticket : baseline ~15 au repos, pic
+légitime < 100 avec 50 auditeurs (STR-90) — 200 = marge ×4 sous la fuite franche.
+`noDataState: OK` sur la règle 5xx (`vector(0)` garantit une valeur) ; `NoData` sur
+les deux autres (une cible qui disparaît mérite un signal).
+
+### 3. Notification : email via le SMTP déjà présent dans le projet
+
+Canal retenu : email — seul canal branchable sur l'infra existante ET testable en
+local. En dev, `GF_SMTP_HOST=mailpit:1025` : les alertes arrivent dans Mailpit
+(http://localhost:8025), aucune sortie réseau. En prod, les mêmes variables `SMTP_*`
+que l'API alimentent `GF_SMTP_*` (relay réel). Contact point `equipe-streampulse`
+(email), politique racine groupée par `alertname` avec `repeat_interval: 4h`
+(anti-bruit). Slack/webhook : rien d'existant côté projet, écarté.
+
+### 4. Dashboard « Logs & Erreurs » (Panel 4)
+
+`logs-erreurs.json` : panel logs Loki piloté par deux variables — `$level`
+(all/info/warn/error) et `$trace_id` (textbox, filtre par sous-chaîne) — plus stat
+5xx/s, compteur d'erreurs 5 min, volume par niveau, et un panel « dernières erreurs »
+dont chaque ligne ouvre la trace Tempo via le bouton TraceID (`derivedFields`,
+ADR 020). Critère « filtrable par niveau et par trace_id » couvert.
+
+### 5. Preuve de déclenchement (STR-190)
+
+Scénario E2E documenté et rejoué sur stack isolée : arrêt de postgres, trafic sur
+`/api/streams` → 100 % de 5xx → la règle passe `pending` puis `firing` après les
+5 min de `for`, et l'email d'alerte est vérifié dans Mailpit via son API. Aucune
+route de test ni seuil trafiqué.
+
+## Conséquences
+
+- Toute nouvelle alerte = une entrée dans `rules.yml`, revue en PR comme du code.
+- Le `repeat_interval` de 4 h borne le volume d'emails d'une alerte persistante.
+- STR-166 (panel Live Streaming) pourra alerter sur ses métriques custom dans le
+  même groupe.
+- En prod, les emails partent dès que les `SMTP_*` du `.env` VPS sont renseignés —
+  aucune action Grafana manuelle.

--- a/docs/adr/021-alertes-grafana-provisionnees-email.md
+++ b/docs/adr/021-alertes-grafana-provisionnees-email.md
@@ -26,9 +26,22 @@ est en lecture seule sur ces objets.
 
 | Règle | Expression | Seuil |
 |---|---|---|
-| Taux 5xx | `(sum(rate(http_requests_total{status=~"5.."}[5m])) or vector(0)) / sum(rate(...))` | > 5 % (ticket) |
+| Taux 5xx | ratio 5xx/total **`and sum(rate(http_requests_total[5m])) > 0.1`** | > 5 % (ticket) |
 | CPU machine | `1 - avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m]))` | > 90 % (ticket) |
 | Goroutines API | `go_goroutines{job="api"}` | > 200 |
+| API injoignable | `up{job="api"}` | < 1, `for: 2m` |
+
+**Plancher de trafic** (ajouté en revue) : le ratio seul déclenche à 100 % dès
+qu'une unique requête échoue sur une fenêtre creuse. La condition n'est évaluée
+qu'au-dessus de 0,1 req/s (~30 requêtes sur 5 min), volume à partir duquel 5 %
+est statistiquement parlant.
+
+**Panne totale** (ajoutée en revue) : si l'API tombe, plus aucune requête n'est
+comptée — la série devient stale, le ratio 5xx repasse en `NoData` et la règle
+reste verte pendant l'indisponibilité. `up{job="api"} == 0` couvre ce cas que le
+ratio ne peut structurellement pas détecter ; `for: 2m` (un redémarrage de
+déploiement prend ~30 s) et `noDataState: Alerting` (la cible qui disparaît de
+Prometheus est elle-même un incident).
 
 Le seuil goroutines n'était pas fixé par le ticket : baseline ~15 au repos, pic
 légitime < 100 avec 50 auditeurs (STR-90) — 200 = marge ×4 sous la fuite franche.
@@ -66,4 +79,9 @@ route de test ni seuil trafiqué.
 - STR-166 (panel Live Streaming) pourra alerter sur ses métriques custom dans le
   même groupe.
 - En prod, les emails partent dès que les `SMTP_*` du `.env` VPS sont renseignés —
-  aucune action Grafana manuelle.
+  aucune action Grafana manuelle. **Limite connue** (relevée en revue) :
+  `GF_SMTP_ENABLED` vaut `true` sans condition ; avec un `SMTP_HOST` vide, Grafana
+  considère le SMTP actif et échoue à l'envoi en ne loggant que côté serveur — les
+  alertes se déclenchent sans notifier. Un gating conditionnel est peu commode en
+  Compose : la contrainte est donc documentée dans le runbook de déploiement, avec
+  un test du contact point en vérification post-déploiement obligatoire.

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -364,11 +364,16 @@ donc la procédure ci-dessous, **une seule fois**, après le merge.
 | Job de scrape `node` | `docker/prometheus/prometheus.yml` | #268 |
 | Dashboards API / Infrastructure | `docker/grafana/provisioning/dashboards/` | #268 |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` sur l'api | `docker-compose.prod.yml` | #269 |
-| `GF_SMTP_*` sur Grafana + règles d'alerte + dashboard Logs | `docker-compose.prod.yml`, `docker/grafana/provisioning/` | #270 |
+| `GF_SMTP_*` sur Grafana + règles d'alerte + dashboard Logs | `docker-compose.prod.yml`, `docker/grafana/provisioning/` | #271 |
 
-Aucune nouvelle variable n'est **requise** dans le `.env` du VPS : `LOG_LEVEL`,
-`OTEL_EXPORTER_OTLP_ENDPOINT` et les `GF_SMTP_*` ont des défauts fonctionnels. Les
-alertes par email partent dès que les `SMTP_*` existants sont renseignés.
+Aucune nouvelle variable n'est **requise** dans le `.env` du VPS : `LOG_LEVEL` et
+`OTEL_EXPORTER_OTLP_ENDPOINT` ont des défauts fonctionnels.
+
+> ⚠️ **`SMTP_HOST` doit être renseigné pour que les alertes soient notifiées.**
+> Grafana démarre avec `GF_SMTP_ENABLED=true` ; si `SMTP_HOST` est vide, l'hôte
+> devient `:587`, l'envoi échoue et l'erreur ne sort que dans les logs Grafana —
+> les alertes se déclenchent mais **aucun email ne part**. Vérification obligatoire
+> après déploiement (ci-dessous).
 
 #### Procédure
 
@@ -425,9 +430,17 @@ ssh deploy@<VPS_HOST> "cd /opt/streampulse && docker compose ps"
 ```
 
 Puis dans Grafana : les dashboards **API Backend**, **Infrastructure** et
-**Logs & Erreurs** doivent apparaître dans le dossier StreamPulse, les 3 règles
+**Logs & Erreurs** doivent apparaître dans le dossier StreamPulse, les 4 règles
 d'alerte dans **Alerting → Alert rules**, et une requête `{service="api"}` dans
 Explore → Loki doit remonter les logs JSON de l'API (preuve qu'Alloy collecte).
+
+**Vérifier que les notifications partent** (l'échec SMTP est silencieux côté
+alerting) : Grafana → **Alerting → Contact points** → `equipe-streampulse` →
+**Test**. Un email doit arriver sur l'adresse configurée. En cas d'échec :
+
+```bash
+ssh deploy@<VPS_HOST> "cd /opt/streampulse && docker compose logs grafana | grep -i smtp"
+```
 
 ### Tester le build Docker localement avant de push
 

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -335,13 +335,99 @@ Aller dans **Settings → Secrets and variables → Actions → New repository s
 # 1. Vérifier le statut du workflow dans l'UI GitHub
 #    → onglet "Actions" du dépôt, workflow "CD"
 
-# 2. Sur le VPS, vérifier que l'API répond
-curl -s -o /dev/null -w "%{http_code}" http://<VPS_HOST>:8080/health
+# 2. Vérifier que l'API répond, via Caddy (HTTPS)
+curl -s -o /dev/null -w "%{http_code}" https://api.streampulse.win/health
 # Attendu : 200
+# NB : http://<VPS_HOST>:8080/health ne répond plus depuis l'ADR 019 —
+# le port de l'API est bindé sur 127.0.0.1, tout passe par Caddy.
 
 # 3. Vérifier que l'image fraîchement déployée est bien en cours d'exécution
 ssh deploy@<VPS_HOST> "docker compose -f /opt/streampulse/docker-compose.yml ps api"
 ```
+
+### Mise à jour manuelle du VPS (compose et configs)
+
+**Le workflow CD ne déploie que l'image de l'API** (`docker compose pull api` +
+`up -d --no-deps api`). Il ne synchronise **ni** `docker-compose.prod.yml`, **ni** le
+dossier `docker/` : ces fichiers ont été copiés à la main sur le VPS lors de
+l'installation. Toute PR qui ajoute un service ou modifie une config d'infra exige
+donc la procédure ci-dessous, **une seule fois**, après le merge.
+
+#### Changements d'infra en attente de déploiement (épic Observabilité)
+
+| Changement | Fichier | PR |
+|---|---|---|
+| Service `alloy` (collecte des logs Docker → Loki) | `docker-compose.prod.yml`, `docker/alloy/config.alloy` | #265 |
+| Service `node_exporter` (métriques machine) | `docker-compose.prod.yml` | #268 |
+| Port de l'API bindé sur `127.0.0.1` | `docker-compose.prod.yml` | #268 |
+| `/metrics` bloqué publiquement (403) | `docker/caddy/Caddyfile` | #268 |
+| Job de scrape `node` | `docker/prometheus/prometheus.yml` | #268 |
+| Dashboards API / Infrastructure | `docker/grafana/provisioning/dashboards/` | #268 |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` sur l'api | `docker-compose.prod.yml` | #269 |
+| `GF_SMTP_*` sur Grafana + règles d'alerte + dashboard Logs | `docker-compose.prod.yml`, `docker/grafana/provisioning/` | #270 |
+
+Aucune nouvelle variable n'est **requise** dans le `.env` du VPS : `LOG_LEVEL`,
+`OTEL_EXPORTER_OTLP_ENDPOINT` et les `GF_SMTP_*` ont des défauts fonctionnels. Les
+alertes par email partent dès que les `SMTP_*` existants sont renseignés.
+
+#### Procédure
+
+Les deux copies transfèrent l'**état final du dépôt** : une seule exécution rattrape
+toutes les PR listées ci-dessus, inutile de les rejouer une par une. À lancer depuis
+la racine du dépôt, sur `main` à jour, une fois toute la pile mergée.
+
+```bash
+# 1. Copier les configs (alloy, caddy, prometheus, grafana) — depuis le poste local
+rsync -av docker/ deploy@<VPS_HOST>:/opt/streampulse/docker/
+```
+
+```bash
+# 2. Copier le compose de production (il se nomme docker-compose.yml sur le VPS)
+scp docker-compose.prod.yml deploy@<VPS_HOST>:/opt/streampulse/docker-compose.yml
+```
+
+```bash
+# 3. Se connecter au VPS
+ssh deploy@<VPS_HOST>
+```
+
+```bash
+# 4. Sur le VPS — récupérer les images des nouveaux services
+cd /opt/streampulse && docker compose pull
+```
+
+```bash
+# 5. Sur le VPS — créer/mettre à jour les conteneurs selon le nouveau compose
+docker compose up -d
+```
+
+```bash
+# 6. Sur le VPS — recharger la configuration de Caddy (blocage de /metrics)
+docker compose restart caddy
+```
+
+#### Vérifications
+
+```bash
+# /metrics n'est plus public (403 attendu)
+curl -s -o /dev/null -w "%{http_code}\n" https://api.streampulse.win/metrics
+```
+
+```bash
+# L'API répond toujours (200 attendu)
+curl -s -o /dev/null -w "%{http_code}\n" https://api.streampulse.win/health
+```
+
+```bash
+# Tous les services tournent (api, postgres, caddy, prometheus, loki, alloy,
+# node_exporter, tempo, grafana)
+ssh deploy@<VPS_HOST> "cd /opt/streampulse && docker compose ps"
+```
+
+Puis dans Grafana : les dashboards **API Backend**, **Infrastructure** et
+**Logs & Erreurs** doivent apparaître dans le dossier StreamPulse, les 3 règles
+d'alerte dans **Alerting → Alert rules**, et une requête `{service="api"}` dans
+Explore → Loki doit remonter les logs JSON de l'API (preuve qu'Alloy collecte).
 
 ### Tester le build Docker localement avant de push
 


### PR DESCRIPTION
## US-07-05 (STR-167) — Panel Logs & Erreurs + Alertes

Décisions dans l'[ADR 021](docs/adr/021-alertes-grafana-provisionnees-email.md).

### Contenu

- **Alerting as-code** (`docker/grafana/provisioning/alerting/`) : contact point email, politique groupée anti-bruit (`repeat_interval: 4h`), 3 règles évaluées chaque minute avec `for: 5m` :
  - **5xx > 5 %** sur 5 min (critère du ticket) — numérateur `or vector(0)` (leçon de #268), `noDataState: OK`
  - **CPU machine > 90 %** (node_exporter, `by (instance)`)
  - **Goroutines API > 200** — seuil non fixé par le ticket : baseline ~15, pic légitime 50 auditeurs < 100 (STR-90), 200 = marge ×4 sous la fuite franche
- **Dashboard « Logs & Erreurs »** (`streampulse-logs`) : panel logs Loki filtrable par variables **$level** (all/info/warn/error) et **$trace_id** (textbox), stat 5xx/s, compteur d'erreurs 5 min, volume par niveau, panel « dernières erreurs » dont chaque ligne ouvre la trace Tempo (bouton TraceID, derivedFields ADR 020).
- **SMTP Grafana** : Mailpit en dev (`GF_SMTP_HOST=mailpit:1025` — alertes testables localement, zéro sortie réseau), relay `SMTP_*` du `.env` en prod. Dans les deux composes.

### Preuve de déclenchement (STR-190, faite sur stack isolée)

Scénario réel sans seuil trafiqué ni route de test : baseline saine 60 s → `docker stop postgres` → trafic sur `/api/streams` (100 % de 500) :

```
22:44:41  inactive
22:45:11  pending      ← seuil franchi
22:50:13  firing       ← après les 5 min de for
Mailpit : [FIRING:1] Taux d'erreurs HTTP 5xx > 5% StreamPulse (critical)
          de alertes@streampulse.dev → admin@streampulse.dev
```

Provisioning vérifié par l'API Grafana : 3 règles chargées (folder StreamPulse), contact point email, dashboard `streampulse-logs` servi.

### Runbook de déploiement VPS

Cette PR embarque aussi la section « Mise à jour manuelle du VPS » de `docs/infrastructure.md` : le workflow CD ne déploie que l'image de l'API, les changements d'infra des PR #265/#268/#269/#270 demandent une synchronisation manuelle du compose et du dossier `docker/` (procédure, tableau des changements par PR, vérifications).

### Épic Observabilité

Dernière US de l'épic 07 avec STR-166 — logs (#265) ✅, métriques (#268) ✅, traces (#269, en review), alertes (celle-ci).
