### PR TITLE
feat(api): métriques métier du streaming et dashboard Grafana Live

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,13 @@ Config : `backend/sqlc.yaml` — schéma lu depuis `migrations/*.up.sql`.
 - `/metrics` n'est **pas** exposé publiquement : bloqué par Caddy en prod (403), scrape interne uniquement.
 - Dashboards provisionnés (non éditables en UI) : `docker/grafana/provisioning/dashboards/` — la vérité vit dans git.
 
+### Métriques métier du streaming (STR-166, ADR 022)
+
+- Le domaine déclare `streaming.MetricsRecorder` (ISP) ; l'implémentation Prometheus vit dans `observability.NewStreamingMetrics` et est injectée dans `main.go` via `SetMetrics` (sessions + handler).
+- `streampulse_hls_requests_total{stream_id,kind,status}` : seule famille portant un `stream_id` — les séries sont **supprimées à l'arrêt du flux** (`ForgetStream` sur `Stop`/`reap`/`StopAll`), sans quoi la cardinalité croîtrait à chaque diffusion.
+- `streampulse_live_streams_active` : `GaugeFunc` branché sur `LiveSessions.ActiveCount()` — lit l'état réel à chaque scrape, aucune dérive possible.
+- Auditeurs = **estimation** `rate(playlist) × durée de segment` (HLS est sans connexion persistante) ; latence et erreurs viennent des métriques HTTP de l'ADR 019.
+
 ### Traces OpenTelemetry (STR-164, ADR 020)
 
 - `observability.NewTracer(ctx, cfg)` : OTLP/HTTP vers Tempo, noop si `OTEL_EXPORTER_OTLP_ENDPOINT` vide (`go run` local). Shutdown flush déféré dans `main.go`.

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -117,6 +117,14 @@ func run() error {
 	streamingSvc := streaming.NewService(streamingRepo, streamingKeys, streamingSessions)
 	streamingHandler := streaming.NewHandler(streamingSvc, cfg.StreamIngestBaseURL, streamingSessions)
 
+	// Métriques métier du streaming (STR-166, ADR 022) : le domaine reçoit
+	// l'implémentation Prometheus via son interface étroite, et la gauge des
+	// directs lit l'état réel du registre de sessions à chaque scrape.
+	streamingMetrics := observability.NewStreamingMetrics(prometheus.DefaultRegisterer)
+	streamingSessions.SetMetrics(streamingMetrics)
+	streamingHandler.SetMetrics(streamingMetrics)
+	observability.RegisterLiveStreamsGauge(prometheus.DefaultRegisterer, streamingSessions.ActiveCount)
+
 	// Réconciliation : les sessions LiveSessions sont en mémoire et reparties
 	// vides ; on termine les flux restés 'live' en base (orphelins d'un précédent
 	// process) pour éviter une divergence DB/registre.

--- a/backend/internal/observability/streaming_metrics.go
+++ b/backend/internal/observability/streaming_metrics.go
@@ -1,0 +1,48 @@
+package observability
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// StreamingMetrics implémente streaming.MetricsRecorder côté infrastructure
+// (STR-166, ADR 022) : le domaine ne connaît que son interface étroite.
+//
+// Le label stream_id est volontairement porté par cette seule famille de
+// séries — les métriques HTTP génériques (ADR 019) restent agrégées par
+// pattern de route. Les séries d'un flux sont supprimées à son arrêt, si
+// bien que la cardinalité active suit le nombre de directs simultanés.
+type StreamingMetrics struct {
+	requests *prometheus.CounterVec
+}
+
+// NewStreamingMetrics enregistre les métriques métier du streaming.
+func NewStreamingMetrics(reg prometheus.Registerer) *StreamingMetrics {
+	return &StreamingMetrics{
+		requests: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "streampulse_hls_requests_total",
+			Help: "Requêtes de lecture HLS servies aux auditeurs, par flux.",
+		}, []string{"stream_id", "kind", "status"}),
+	}
+}
+
+// RecordHLSRequest compte une lecture HLS (kind = playlist|segment).
+func (m *StreamingMetrics) RecordHLSRequest(streamID, kind, status string) {
+	m.requests.WithLabelValues(streamID, kind, status).Inc()
+}
+
+// ForgetStream supprime toutes les séries d'un flux terminé.
+func (m *StreamingMetrics) ForgetStream(streamID string) {
+	m.requests.DeletePartialMatch(prometheus.Labels{"stream_id": streamID})
+}
+
+// RegisterLiveStreamsGauge expose le nombre de directs en cours. La valeur
+// est lue à chaque scrape via le registre de sessions (GaugeFunc) plutôt
+// qu'incrémentée/décrémentée : la métrique dérive de l'état réel et ne peut
+// pas diverger, y compris si un flux meurt par un chemin imprévu (ADR 022).
+func RegisterLiveStreamsGauge(reg prometheus.Registerer, count func() int) {
+	promauto.With(reg).NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "streampulse_live_streams_active",
+		Help: "Nombre de flux actuellement en direct.",
+	}, func() float64 { return float64(count()) })
+}

--- a/backend/internal/observability/streaming_metrics.go
+++ b/backend/internal/observability/streaming_metrics.go
@@ -1,9 +1,17 @@
 package observability
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
+
+// defaultDrainDelay laisse aux requêtes déjà en cours de service le temps de
+// s'achever avant d'effacer les séries d'un flux arrêté : leur enregistrement
+// différé recréerait sinon une série que plus aucun arrêt ne nettoierait
+// (revue PR #272). Largement au-dessus du temps de service d'un segment.
+const defaultDrainDelay = 30 * time.Second
 
 // StreamingMetrics implémente streaming.MetricsRecorder côté infrastructure
 // (STR-166, ADR 022) : le domaine ne connaît que son interface étroite.
@@ -13,7 +21,8 @@ import (
 // pattern de route. Les séries d'un flux sont supprimées à son arrêt, si
 // bien que la cardinalité active suit le nombre de directs simultanés.
 type StreamingMetrics struct {
-	requests *prometheus.CounterVec
+	requests   *prometheus.CounterVec
+	drainDelay time.Duration // injectable en test
 }
 
 // NewStreamingMetrics enregistre les métriques métier du streaming.
@@ -23,6 +32,7 @@ func NewStreamingMetrics(reg prometheus.Registerer) *StreamingMetrics {
 			Name: "streampulse_hls_requests_total",
 			Help: "Requêtes de lecture HLS servies aux auditeurs, par flux.",
 		}, []string{"stream_id", "kind", "status"}),
+		drainDelay: defaultDrainDelay,
 	}
 }
 
@@ -31,9 +41,16 @@ func (m *StreamingMetrics) RecordHLSRequest(streamID, kind, status string) {
 	m.requests.WithLabelValues(streamID, kind, status).Inc()
 }
 
-// ForgetStream supprime toutes les séries d'un flux terminé.
+// ForgetStream supprime les séries d'un flux terminé, après un délai de drain :
+// une requête encore en vol au moment de l'arrêt enregistre sa métrique un
+// instant plus tard, et la suppression doit passer après elle — sinon la série
+// ressuscitée resterait orpheline (revue PR #272).
 func (m *StreamingMetrics) ForgetStream(streamID string) {
-	m.requests.DeletePartialMatch(prometheus.Labels{"stream_id": streamID})
+	labels := prometheus.Labels{"stream_id": streamID}
+	m.requests.DeletePartialMatch(labels) // effacement immédiat des séries connues
+	time.AfterFunc(m.drainDelay, func() {
+		m.requests.DeletePartialMatch(labels) // puis des retardataires
+	})
 }
 
 // RegisterLiveStreamsGauge expose le nombre de directs en cours. La valeur

--- a/backend/internal/observability/streaming_metrics_test.go
+++ b/backend/internal/observability/streaming_metrics_test.go
@@ -1,0 +1,100 @@
+package observability
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestStreamingMetrics_CountsHLSRequestsPerStream(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewStreamingMetrics(reg)
+
+	m.RecordHLSRequest("stream-a", "playlist", "200")
+	m.RecordHLSRequest("stream-a", "playlist", "200")
+	m.RecordHLSRequest("stream-a", "segment", "404")
+	m.RecordHLSRequest("stream-b", "playlist", "200")
+
+	expected := `
+		# HELP streampulse_hls_requests_total Requêtes de lecture HLS servies aux auditeurs, par flux.
+		# TYPE streampulse_hls_requests_total counter
+		streampulse_hls_requests_total{kind="playlist",status="200",stream_id="stream-a"} 2
+		streampulse_hls_requests_total{kind="playlist",status="200",stream_id="stream-b"} 1
+		streampulse_hls_requests_total{kind="segment",status="404",stream_id="stream-a"} 1
+	`
+	if err := testutil.GatherAndCompare(reg, strings.NewReader(expected), "streampulse_hls_requests_total"); err != nil {
+		t.Fatalf("séries inattendues: %v", err)
+	}
+}
+
+func TestStreamingMetrics_ForgetStreamDropsSeries(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewStreamingMetrics(reg)
+
+	m.RecordHLSRequest("stream-a", "playlist", "200")
+	m.RecordHLSRequest("stream-a", "segment", "200")
+	m.RecordHLSRequest("stream-b", "playlist", "200")
+
+	m.ForgetStream("stream-a")
+
+	// Sans cet oubli, chaque diffusion terminée laisserait ses séries
+	// derrière elle et la cardinalité croîtrait sans borne (ADR 022).
+	got := testutil.CollectAndCount(m.requests)
+	if got != 1 {
+		t.Fatalf("séries restantes = %d, want 1 (seul stream-b)", got)
+	}
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, f := range families {
+		for _, metric := range f.GetMetric() {
+			for _, l := range metric.GetLabel() {
+				if l.GetName() == "stream_id" && l.GetValue() == "stream-a" {
+					t.Errorf("série de stream-a encore exposée: %v", metric)
+				}
+			}
+		}
+	}
+}
+
+func TestStreamingMetrics_ActiveStreamsGaugeReadsLiveState(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	active := 0
+	RegisterLiveStreamsGauge(reg, func() int { return active })
+
+	expectGauge := func(want float64) {
+		t.Helper()
+		expected := `
+			# HELP streampulse_live_streams_active Nombre de flux actuellement en direct.
+			# TYPE streampulse_live_streams_active gauge
+			streampulse_live_streams_active ` + trimFloat(want) + `
+		`
+		if err := testutil.GatherAndCompare(reg, strings.NewReader(expected), "streampulse_live_streams_active"); err != nil {
+			t.Fatalf("gauge inattendue: %v", err)
+		}
+	}
+
+	expectGauge(0)
+	// La gauge lit l'état réel à chaque scrape : aucune dérive possible.
+	active = 3
+	expectGauge(3)
+	active = 1
+	expectGauge(1)
+}
+
+func trimFloat(f float64) string {
+	switch f {
+	case 0:
+		return "0"
+	case 1:
+		return "1"
+	case 3:
+		return "3"
+	default:
+		t := int(f)
+		return string(rune('0' + t))
+	}
+}

--- a/backend/internal/observability/streaming_metrics_test.go
+++ b/backend/internal/observability/streaming_metrics_test.go
@@ -3,6 +3,7 @@ package observability
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -96,5 +97,31 @@ func trimFloat(f float64) string {
 	default:
 		t := int(f)
 		return string(rune('0' + t))
+	}
+}
+
+func TestStreamingMetrics_ForgetStreamDrainsInFlightRequests(t *testing.T) {
+	// Une requête déjà en cours de service quand le flux s'arrête enregistre
+	// sa métrique APRÈS ForgetStream : sans délai de drain, elle recréerait
+	// une série que plus aucun arrêt ne viendrait nettoyer (revue PR #272).
+	reg := prometheus.NewRegistry()
+	m := NewStreamingMetrics(reg)
+	m.drainDelay = 60 * time.Millisecond
+
+	m.RecordHLSRequest("stream-a", "playlist", "200")
+	m.ForgetStream("stream-a")
+
+	// Requête en vol, terminée juste après l'arrêt.
+	m.RecordHLSRequest("stream-a", "segment", "200")
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if testutil.CollectAndCount(m.requests) == 0 {
+			return // séries drainées, y compris celle de la requête en vol
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("séries encore présentes après le drain: %d", testutil.CollectAndCount(m.requests))
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }

--- a/backend/internal/streaming/handler.go
+++ b/backend/internal/streaming/handler.go
@@ -589,13 +589,6 @@ func (h *Handler) serveHLSFile(w http.ResponseWriter, r *http.Request, kind, con
 	requesterID, _ := auth.UserIDFromContext(r.Context()) // "" si anonyme (pas de JWT)
 	id := r.PathValue("id")
 
-	// Chaque lecture HLS alimente les métriques par flux (STR-166, ADR 022) :
-	// l'estimation du nombre d'auditeurs dérive du débit de requêtes de
-	// playlist, le taux d'erreurs .ts du status rendu à l'auditeur.
-	sr := &hlsStatusRecorder{ResponseWriter: w}
-	w = sr
-	defer func() { h.metrics.RecordHLSRequest(id, kind, sr.statusText()) }()
-
 	if _, _, err := h.svc.GetStream(r.Context(), id, requesterID); err != nil {
 		httpjson.WriteError(w, r, err)
 		return
@@ -606,6 +599,18 @@ func (h *Handler) serveHLSFile(w http.ResponseWriter, r *http.Request, kind, con
 		httpjson.WriteError(w, r, unavailable)
 		return
 	}
+
+	// À partir d'ici seulement, le flux a une session vivante : ses séries
+	// seront nettoyées par ForgetStream à l'arrêt. Compter plus tôt laisserait
+	// un client créer une série permanente par identifiant inventé — cardinalité
+	// illimitée et DoS mémoire (revue PR #272).
+	//
+	// Les métriques par flux alimentent l'estimation d'auditeurs (débit de
+	// requêtes de playlist) et le taux d'erreurs .ts, d'où la capture du status
+	// réellement rendu — http.ServeFile écrit l'en-tête lui-même.
+	sr := &hlsStatusRecorder{ResponseWriter: w}
+	w = sr
+	defer func() { h.metrics.RecordHLSRequest(id, kind, sr.statusText()) }()
 
 	// Le fichier peut ne pas exister encore (fenêtre entre le start et le premier
 	// segment, ou push dont ffmpeg n'a encore rien produit) ou avoir été retiré

--- a/backend/internal/streaming/handler.go
+++ b/backend/internal/streaming/handler.go
@@ -60,10 +60,27 @@ type Handler struct {
 	svc           StreamService
 	ingestBaseURL string
 	sessions      StreamSessions
+	metrics       MetricsRecorder // jamais nil : noopRecorder par défaut (STR-166)
 }
 
 func NewHandler(svc StreamService, ingestBaseURL string, sessions StreamSessions) *Handler {
-	return &Handler{svc: svc, ingestBaseURL: strings.TrimRight(ingestBaseURL, "/"), sessions: sessions}
+	return &Handler{
+		svc:           svc,
+		ingestBaseURL: strings.TrimRight(ingestBaseURL, "/"),
+		sessions:      sessions,
+		metrics:       noopRecorder{},
+	}
+}
+
+// SetMetrics injecte le collecteur de métriques métier (STR-166, ADR 022).
+// Setter plutôt que paramètre de constructeur : l'observabilité est optionnelle
+// (le domaine tourne sans), et le pattern est le même que LiveSessions.SetMetrics.
+// Appelé une fois au démarrage, avant que le serveur n'accepte des requêtes.
+func (h *Handler) SetMetrics(rec MetricsRecorder) {
+	if rec == nil {
+		rec = noopRecorder{}
+	}
+	h.metrics = rec
 }
 
 // createStreamRequest : pointeurs pour distinguer « champ absent » de zéro.
@@ -545,7 +562,7 @@ func ingestError(err error) error {
 // flux public (lecture publique, cf. serveHLSFile). 409 si le flux n'est pas en
 // direct ou si le manifeste n'est pas encore prêt.
 func (h *Handler) Playlist(w http.ResponseWriter, r *http.Request) {
-	h.serveHLSFile(w, r, "application/vnd.apple.mpegurl",
+	h.serveHLSFile(w, r, HLSKindPlaylist, "application/vnd.apple.mpegurl",
 		func(id string) (string, bool) { return h.sessions.Playlist(id) },
 		apperror.Conflict("stream is not live"))
 }
@@ -554,7 +571,7 @@ func (h *Handler) Playlist(w http.ResponseWriter, r *http.Request) {
 // flux public (lecture publique, cf. serveHLSFile). Le nom du segment est validé
 // (anti path-traversal) dans la couche session ; nom invalide ou segment absent -> 404.
 func (h *Handler) Segment(w http.ResponseWriter, r *http.Request) {
-	h.serveHLSFile(w, r, "video/mp2t",
+	h.serveHLSFile(w, r, HLSKindSegment, "video/mp2t",
 		func(id string) (string, bool) { return h.sessions.Segment(id, r.PathValue("segment")) },
 		apperror.NotFound("segment not found"))
 }
@@ -568,9 +585,16 @@ func (h *Handler) Segment(w http.ResponseWriter, r *http.Request) {
 // (just_audio → AVPlayer/ExoPlayer) ne peut pas porter le Bearer. Un auditeur
 // anonyme a requesterID = "" ; la visibilité de GetStream sert alors les flux
 // publics et renvoie 404 pour un flux privé (jamais propriétaire de "").
-func (h *Handler) serveHLSFile(w http.ResponseWriter, r *http.Request, contentType string, lookup func(id string) (string, bool), unavailable error) {
+func (h *Handler) serveHLSFile(w http.ResponseWriter, r *http.Request, kind, contentType string, lookup func(id string) (string, bool), unavailable error) {
 	requesterID, _ := auth.UserIDFromContext(r.Context()) // "" si anonyme (pas de JWT)
 	id := r.PathValue("id")
+
+	// Chaque lecture HLS alimente les métriques par flux (STR-166, ADR 022) :
+	// l'estimation du nombre d'auditeurs dérive du débit de requêtes de
+	// playlist, le taux d'erreurs .ts du status rendu à l'auditeur.
+	sr := &hlsStatusRecorder{ResponseWriter: w}
+	w = sr
+	defer func() { h.metrics.RecordHLSRequest(id, kind, sr.statusText()) }()
 
 	if _, _, err := h.svc.GetStream(r.Context(), id, requesterID); err != nil {
 		httpjson.WriteError(w, r, err)

--- a/backend/internal/streaming/hls_status.go
+++ b/backend/internal/streaming/hls_status.go
@@ -1,0 +1,39 @@
+package streaming
+
+import (
+	"net/http"
+	"strconv"
+)
+
+// hlsStatusRecorder capture le code HTTP rendu à un auditeur HLS pour le
+// label `status` des métriques par flux (STR-166). http.ServeFile écrit
+// l'en-tête lui-même : sans capture, le status serait inconnu du handler.
+type hlsStatusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (r *hlsStatusRecorder) WriteHeader(status int) {
+	if r.status == 0 {
+		r.status = status
+	}
+	r.ResponseWriter.WriteHeader(status)
+}
+
+func (r *hlsStatusRecorder) Write(p []byte) (int, error) {
+	if r.status == 0 {
+		r.status = http.StatusOK
+	}
+	return r.ResponseWriter.Write(p)
+}
+
+// Unwrap expose le writer sous-jacent à http.ResponseController (ServeFile).
+func (r *hlsStatusRecorder) Unwrap() http.ResponseWriter { return r.ResponseWriter }
+
+// statusText retourne le code rendu ; 200 par défaut (handler muet).
+func (r *hlsStatusRecorder) statusText() string {
+	if r.status == 0 {
+		return strconv.Itoa(http.StatusOK)
+	}
+	return strconv.Itoa(r.status)
+}

--- a/backend/internal/streaming/metrics.go
+++ b/backend/internal/streaming/metrics.go
@@ -1,0 +1,31 @@
+package streaming
+
+// MetricsRecorder est l'interface étroite (ISP) par laquelle le domaine
+// streaming publie ses métriques métier — le domaine ignore Prometheus,
+// l'implémentation vit dans internal/observability et est injectée par
+// main.go (STR-166, ADR 022).
+//
+// Les implémentations doivent être sûres en concurrence : les requêtes HLS
+// arrivent depuis les goroutines des handlers.
+type MetricsRecorder interface {
+	// RecordHLSRequest compte une requête de lecture HLS. kind vaut
+	// "playlist" ou "segment" ; status est le code HTTP rendu à l'auditeur.
+	RecordHLSRequest(streamID, kind, status string)
+
+	// ForgetStream supprime les séries portant ce stream_id : sans cet
+	// oubli, chaque diffusion terminée laisserait une série résiduelle.
+	ForgetStream(streamID string)
+}
+
+// Kinds de requête HLS (label `kind` des métriques).
+const (
+	HLSKindPlaylist = "playlist"
+	HLSKindSegment  = "segment"
+)
+
+// noopRecorder est utilisé tant qu'aucun recorder n'est injecté (tests du
+// domaine, binaires sans métriques) : le domaine ne doit jamais paniquer.
+type noopRecorder struct{}
+
+func (noopRecorder) RecordHLSRequest(string, string, string) {}
+func (noopRecorder) ForgetStream(string)                     {}

--- a/backend/internal/streaming/metrics_test.go
+++ b/backend/internal/streaming/metrics_test.go
@@ -1,0 +1,139 @@
+package streaming
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// stubRecorder capture les appels du domaine vers l'infra métriques.
+type stubRecorder struct {
+	mu        sync.Mutex
+	requests  []string // "streamID|kind|status"
+	forgotten []string
+}
+
+func (s *stubRecorder) RecordHLSRequest(streamID, kind, status string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.requests = append(s.requests, streamID+"|"+kind+"|"+status)
+}
+
+func (s *stubRecorder) ForgetStream(streamID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.forgotten = append(s.forgotten, streamID)
+}
+
+func (s *stubRecorder) forgottenIDs() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.forgotten...)
+}
+
+func TestLiveSessions_ActiveCount(t *testing.T) {
+	ls := NewLiveSessions(context.Background())
+	ls.newSeg = func() (*hlsSegmenter, error) { return nil, errors.New("pas de ffmpeg en test") }
+
+	if got := ls.ActiveCount(); got != 0 {
+		t.Fatalf("ActiveCount() au repos = %d, want 0", got)
+	}
+
+	ls.Start("stream-a", "key-a")
+	ls.Start("stream-b", "key-b")
+	if got := ls.ActiveCount(); got != 2 {
+		t.Errorf("ActiveCount() après 2 démarrages = %d, want 2", got)
+	}
+
+	ls.Stop("stream-a")
+	if got := ls.ActiveCount(); got != 1 {
+		t.Errorf("ActiveCount() après arrêt = %d, want 1", got)
+	}
+
+	ls.StopAll()
+	if got := ls.ActiveCount(); got != 0 {
+		t.Errorf("ActiveCount() après StopAll = %d, want 0", got)
+	}
+}
+
+func TestLiveSessions_ForgetsStreamOnStop(t *testing.T) {
+	rec := &stubRecorder{}
+	ls := NewLiveSessions(context.Background())
+	ls.newSeg = func() (*hlsSegmenter, error) { return nil, errors.New("pas de ffmpeg en test") }
+	ls.SetMetrics(rec)
+
+	ls.Start("stream-a", "key-a")
+	ls.Stop("stream-a")
+
+	// Les séries labellisées par stream_id doivent disparaître à l'arrêt,
+	// sinon la cardinalité croît à chaque diffusion (ADR 022).
+	if got := rec.forgottenIDs(); len(got) != 1 || got[0] != "stream-a" {
+		t.Errorf("ForgetStream = %v, want [stream-a]", got)
+	}
+}
+
+func TestLiveSessions_ForgetsAllStreamsOnStopAll(t *testing.T) {
+	rec := &stubRecorder{}
+	ls := NewLiveSessions(context.Background())
+	ls.newSeg = func() (*hlsSegmenter, error) { return nil, errors.New("pas de ffmpeg en test") }
+	ls.SetMetrics(rec)
+
+	ls.Start("stream-a", "key-a")
+	ls.Start("stream-b", "key-b")
+	ls.StopAll()
+
+	if got := rec.forgottenIDs(); len(got) != 2 {
+		t.Errorf("ForgetStream appelé %d fois (%v), want 2", len(got), got)
+	}
+}
+
+func TestLiveSessions_NilRecorderIsSafe(t *testing.T) {
+	// Aucun recorder injecté (tests existants, binaires sans métriques) :
+	// le domaine ne doit pas paniquer.
+	ls := NewLiveSessions(context.Background())
+	ls.newSeg = func() (*hlsSegmenter, error) { return nil, errors.New("pas de ffmpeg en test") }
+
+	ls.Start("stream-a", "key-a")
+	ls.Stop("stream-a")
+	ls.StopAll()
+}
+
+func TestHandler_RecordsHLSRequests(t *testing.T) {
+	rec := &stubRecorder{}
+	ls := sessionsWithFakeSeg(t)
+	ls.SetMetrics(rec)
+	ls.Start("sid", "KEY-sid")
+	t.Cleanup(ls.StopAll)
+	h := NewHandler(&stubService{getRet: Stream{ID: "sid", UserID: "owner", IsPublic: true}}, testIngestURL, ls)
+	h.SetMetrics(rec)
+
+	// Playlist servie (manifeste présent) puis segment inexistant : les deux
+	// sont comptés, avec le status réellement rendu à l'auditeur.
+	reqPlaylist := httptest.NewRequest(http.MethodGet, "/api/streams/sid/playlist.m3u8", nil)
+	reqPlaylist.SetPathValue("id", "sid")
+	h.Playlist(httptest.NewRecorder(), reqPlaylist)
+
+	reqSegment := httptest.NewRequest(http.MethodGet, "/api/streams/sid/segments/seg_99999.ts", nil)
+	reqSegment.SetPathValue("id", "sid")
+	reqSegment.SetPathValue("segment", "seg_99999.ts")
+	h.Segment(httptest.NewRecorder(), reqSegment)
+
+	rec.mu.Lock()
+	got := append([]string(nil), rec.requests...)
+	rec.mu.Unlock()
+
+	if len(got) != 2 {
+		t.Fatalf("requêtes comptées = %v, want 2 entrées", got)
+	}
+	if got[0] != "sid|playlist|200" {
+		t.Errorf("playlist servie comptée %q, want sid|playlist|200", got[0])
+	}
+	// Le segment absent alimente le taux d'erreurs .ts du dashboard.
+	if !strings.HasPrefix(got[1], "sid|segment|") || strings.HasSuffix(got[1], "|200") {
+		t.Errorf("segment absent compté %q, want sid|segment|<4xx/5xx>", got[1])
+	}
+}

--- a/backend/internal/streaming/metrics_test.go
+++ b/backend/internal/streaming/metrics_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/LignacAntony/streampulse/internal/shared/apperror"
 )
 
 // stubRecorder capture les appels du domaine vers l'infra métriques.
@@ -135,5 +137,75 @@ func TestHandler_RecordsHLSRequests(t *testing.T) {
 	// Le segment absent alimente le taux d'erreurs .ts du dashboard.
 	if !strings.HasPrefix(got[1], "sid|segment|") || strings.HasSuffix(got[1], "|200") {
 		t.Errorf("segment absent compté %q, want sid|segment|<4xx/5xx>", got[1])
+	}
+}
+
+func TestHandler_DoesNotRecordUnknownStreams(t *testing.T) {
+	// Un client anonyme peut marteler /api/streams/<uuid aléatoire>/playlist.m3u8 :
+	// si chaque id inventé créait une série, aucune ForgetStream ne la
+	// nettoierait jamais (aucune session n'a existé) → cardinalité illimitée,
+	// donc DoS mémoire sur Prometheus et l'API (revue PR #272).
+	rec := &stubRecorder{}
+	ls := sessionsWithFakeSeg(t)
+	ls.SetMetrics(rec)
+	h := NewHandler(&stubService{getErr: apperror.NotFound("stream not found")}, testIngestURL, ls)
+	h.SetMetrics(rec)
+
+	for _, id := range []string{"id-invente-1", "id-invente-2", "id-invente-3"} {
+		req := httptest.NewRequest(http.MethodGet, "/api/streams/"+id+"/playlist.m3u8", nil)
+		req.SetPathValue("id", id)
+		h.Playlist(httptest.NewRecorder(), req)
+	}
+
+	rec.mu.Lock()
+	got := append([]string(nil), rec.requests...)
+	rec.mu.Unlock()
+	if len(got) != 0 {
+		t.Fatalf("des flux inexistants ont été comptés: %v", got)
+	}
+}
+
+func TestHandler_DoesNotRecordStreamsThatAreNotLive(t *testing.T) {
+	// Flux visible en base mais sans session : aucune série ne doit naître,
+	// elle ne serait jamais nettoyée non plus.
+	rec := &stubRecorder{}
+	ls := sessionsWithFakeSeg(t) // aucun Start
+	ls.SetMetrics(rec)
+	h := NewHandler(&stubService{getRet: Stream{ID: "idle", UserID: "owner", IsPublic: true}}, testIngestURL, ls)
+	h.SetMetrics(rec)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/streams/idle/playlist.m3u8", nil)
+	req.SetPathValue("id", "idle")
+	h.Playlist(httptest.NewRecorder(), req)
+
+	rec.mu.Lock()
+	got := append([]string(nil), rec.requests...)
+	rec.mu.Unlock()
+	if len(got) != 0 {
+		t.Fatalf("un flux non live a été compté: %v", got)
+	}
+}
+
+func TestHandler_RecordsErrorsOfLiveStreams(t *testing.T) {
+	// En revanche, une erreur survenue sur un flux BIEN live doit être
+	// comptée : c'est le taux d'erreurs .ts du dashboard (fenêtre glissante).
+	rec := &stubRecorder{}
+	ls := sessionsWithFakeSeg(t)
+	ls.SetMetrics(rec)
+	ls.Start("live", "KEY-live")
+	t.Cleanup(ls.StopAll)
+	h := NewHandler(&stubService{getRet: Stream{ID: "live", UserID: "owner", IsPublic: true}}, testIngestURL, ls)
+	h.SetMetrics(rec)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/streams/live/segments/seg_00042.ts", nil)
+	req.SetPathValue("id", "live")
+	req.SetPathValue("segment", "seg_00042.ts")
+	h.Segment(httptest.NewRecorder(), req)
+
+	rec.mu.Lock()
+	got := append([]string(nil), rec.requests...)
+	rec.mu.Unlock()
+	if len(got) != 1 || !strings.HasPrefix(got[0], "live|segment|4") {
+		t.Fatalf("erreur d'un flux live = %v, want [live|segment|404]", got)
 	}
 }

--- a/backend/internal/streaming/session.go
+++ b/backend/internal/streaming/session.go
@@ -45,21 +45,50 @@ type LiveSessions struct {
 	base   context.Context
 	newSeg func() (*hlsSegmenter, error) // injectable (tests sans ffmpeg)
 
-	mu    sync.Mutex
-	byID  map[string]*session // id public -> session (SSE, lecture HLS, stop)
-	byKey map[string]*session // stream_key secret -> session (ingest)
-	wg    sync.WaitGroup
+	mu      sync.Mutex
+	byID    map[string]*session // id public -> session (SSE, lecture HLS, stop)
+	byKey   map[string]*session // stream_key secret -> session (ingest)
+	wg      sync.WaitGroup
+	metrics MetricsRecorder // jamais nil : noopRecorder par défaut (STR-166)
 }
 
 // NewLiveSessions construit le registre. base est le context de cycle de vie du
 // serveur : son annulation (shutdown) propage l'arrêt à toutes les sessions.
 func NewLiveSessions(base context.Context) *LiveSessions {
 	return &LiveSessions{
-		base:   base,
-		newSeg: newHLSSegmenter,
-		byID:   make(map[string]*session),
-		byKey:  make(map[string]*session),
+		base:    base,
+		newSeg:  newHLSSegmenter,
+		byID:    make(map[string]*session),
+		byKey:   make(map[string]*session),
+		metrics: noopRecorder{},
 	}
+}
+
+// SetMetrics injecte le collecteur de métriques métier (STR-166). Appelé
+// une fois au démarrage, avant que le serveur HTTP n'accepte des requêtes.
+func (ls *LiveSessions) SetMetrics(rec MetricsRecorder) {
+	if rec == nil {
+		rec = noopRecorder{}
+	}
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	ls.metrics = rec
+}
+
+// ActiveCount retourne le nombre de sessions live en cours. Lu à chaque
+// scrape Prometheus via un GaugeFunc : la gauge dérive de l'état réel du
+// registre, elle ne peut pas diverger (ADR 022).
+func (ls *LiveSessions) ActiveCount() int {
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	return len(ls.byID)
+}
+
+// recorder retourne le collecteur courant sous verrou.
+func (ls *LiveSessions) recorder() MetricsRecorder {
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	return ls.metrics
 }
 
 // Start enregistre une session pour streamID (indexée aussi par streamKey pour
@@ -148,6 +177,7 @@ func (ls *LiveSessions) reap(streamID string, s *session) {
 		}
 	}
 	ls.mu.Unlock()
+	ls.recorder().ForgetStream(streamID)
 	s.publish(SessionEvent{Type: "ended"})
 	s.closeSubscribers()
 }
@@ -168,6 +198,7 @@ func (ls *LiveSessions) Stop(streamID string) {
 	if !ok {
 		return
 	}
+	ls.recorder().ForgetStream(streamID)
 	s.publish(SessionEvent{Type: "ended"})
 	s.closeSubscribers()
 	s.cancel()
@@ -289,7 +320,9 @@ func (ls *LiveSessions) StopAll() {
 	ls.byKey = make(map[string]*session)
 	ls.mu.Unlock()
 
-	for _, s := range sessions {
+	rec := ls.recorder()
+	for id, s := range sessions {
+		rec.ForgetStream(id)
 		s.closeSubscribers()
 		s.cancel()
 	}

--- a/docker/grafana/provisioning/dashboards/live-streaming.json
+++ b/docker/grafana/provisioning/dashboards/live-streaming.json
@@ -1,0 +1,107 @@
+{
+  "uid": "streampulse-live",
+  "title": "StreamPulse — Live Streaming",
+  "tags": ["streampulse", "live", "str-166"],
+  "schemaVersion": 39,
+  "editable": false,
+  "timezone": "browser",
+  "time": { "from": "now-1h", "to": "now" },
+  "refresh": "15s",
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Flux en direct",
+      "description": "Lu à chaque scrape depuis le registre de sessions : reflète l'état réel, pas un compteur incrémenté.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 4, "x": 0, "y": 0 },
+      "targets": [
+        { "refId": "A", "expr": "streampulse_live_streams_active" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "text", "value": null }, { "color": "green", "value": 1 } ] }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Auditeurs (estimé, total)",
+      "description": "HLS est sans connexion persistante : le nombre d'auditeurs est estimé à partir du débit de requêtes de playlist, chaque client en demandant une par segment (~10 s). Voir ADR 022.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 4, "x": 4, "y": 0 },
+      "targets": [
+        { "refId": "A", "expr": "round(sum(rate(streampulse_hls_requests_total{kind=\"playlist\",status=\"200\"}[2m])) * 10)" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "decimals": 0 }, "overrides": [] }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Latence HLS p95",
+      "description": "Temps de service des manifestes et segments (histogramme HTTP, ADR 019).",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 4, "x": 8, "y": 0 },
+      "targets": [
+        { "refId": "A", "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{path=~\"/api/streams/\\\\{id\\\\}/(playlist.m3u8|segments/\\\\{segment\\\\})\"}[5m])))" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s", "decimals": 3 }, "overrides": [] }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Taux d'erreurs segments .ts",
+      "description": "Part des requêtes de segments qui n'aboutissent pas (404 fenêtre glissante, 503 capacité atteinte, 5xx).",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 4, "x": 12, "y": 0 },
+      "targets": [
+        { "refId": "A", "expr": "(sum(rate(streampulse_hls_requests_total{kind=\"segment\",status!=\"200\"}[5m])) or vector(0)) / clamp_min(sum(rate(streampulse_hls_requests_total{kind=\"segment\"}[5m])), 0.001)" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2,
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "orange", "value": 0.02 }, { "color": "red", "value": 0.1 } ] }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Auditeurs estimés par flux",
+      "description": "rate(playlist) × durée cible de segment, par stream_id. Les séries disparaissent à l'arrêt du flux.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 6 },
+      "targets": [
+        { "refId": "A", "expr": "round(sum by (stream_id) (rate(streampulse_hls_requests_total{kind=\"playlist\",status=\"200\"}[2m])) * 10)", "legendFormat": "{{stream_id}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "short", "decimals": 0 }, "overrides": [] }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Requêtes HLS par seconde (playlist / segment)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 15 },
+      "targets": [
+        { "refId": "A", "expr": "sum by (kind) (rate(streampulse_hls_requests_total[5m]))", "legendFormat": "{{kind}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] }
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Erreurs HLS par seconde et par status",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 24 },
+      "targets": [
+        { "refId": "A", "expr": "sum by (status) (rate(streampulse_hls_requests_total{status!=\"200\"}[5m]))", "legendFormat": "{{status}}" }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] }
+    }
+  ]
+}

--- a/docker/grafana/provisioning/dashboards/live-streaming.json
+++ b/docker/grafana/provisioning/dashboards/live-streaming.json
@@ -1,11 +1,18 @@
 {
   "uid": "streampulse-live",
   "title": "StreamPulse — Live Streaming",
-  "tags": ["streampulse", "live", "str-166"],
+  "tags": [
+    "streampulse",
+    "live",
+    "str-166"
+  ],
   "schemaVersion": 39,
   "editable": false,
   "timezone": "browser",
-  "time": { "from": "now-1h", "to": "now" },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
   "refresh": "15s",
   "panels": [
     {
@@ -13,15 +20,38 @@
       "type": "stat",
       "title": "Flux en direct",
       "description": "Lu à chaque scrape depuis le registre de sessions : reflète l'état réel, pas un compteur incrémenté.",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 6, "w": 4, "x": 0, "y": 0 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
       "targets": [
-        { "refId": "A", "expr": "streampulse_live_streams_active" }
+        {
+          "refId": "A",
+          "expr": "streampulse_live_streams_active"
+        }
       ],
       "fieldConfig": {
         "defaults": {
           "unit": "short",
-          "thresholds": { "mode": "absolute", "steps": [ { "color": "text", "value": null }, { "color": "green", "value": 1 } ] }
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
         },
         "overrides": []
       }
@@ -31,40 +61,101 @@
       "type": "stat",
       "title": "Auditeurs (estimé, total)",
       "description": "HLS est sans connexion persistante : le nombre d'auditeurs est estimé à partir du débit de requêtes de playlist, chaque client en demandant une par segment (~10 s). Voir ADR 022.",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 6, "w": 4, "x": 4, "y": 0 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
       "targets": [
-        { "refId": "A", "expr": "round(sum(rate(streampulse_hls_requests_total{kind=\"playlist\",status=\"200\"}[2m])) * 10)" }
+        {
+          "refId": "A",
+          "expr": "round(sum(rate(streampulse_hls_requests_total{kind=\"playlist\",status=\"200\"}[2m])) * 10)"
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "short", "decimals": 0 }, "overrides": [] }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0
+        },
+        "overrides": []
+      }
     },
     {
       "id": 3,
       "type": "stat",
       "title": "Latence HLS p95",
       "description": "Temps de service des manifestes et segments (histogramme HTTP, ADR 019).",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 6, "w": 4, "x": 8, "y": 0 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
       "targets": [
-        { "refId": "A", "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{path=~\"/api/streams/\\\\{id\\\\}/(playlist.m3u8|segments/\\\\{segment\\\\})\"}[5m])))" }
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{path=~\"/api/streams/\\\\{id\\\\}/(playlist.m3u8|segments/\\\\{segment\\\\})\"}[5m])))"
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "s", "decimals": 3 }, "overrides": [] }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 3
+        },
+        "overrides": []
+      }
     },
     {
       "id": 4,
       "type": "stat",
       "title": "Taux d'erreurs segments .ts",
-      "description": "Part des requêtes de segments qui n'aboutissent pas (404 fenêtre glissante, 503 capacité atteinte, 5xx).",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 6, "w": 4, "x": 12, "y": 0 },
+      "description": "Part des requêtes de segments en échec (4xx/5xx). 206 Partial Content (requêtes Range des players) et 304 Not Modified sont des réponses normales, exclues du numérateur.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
       "targets": [
-        { "refId": "A", "expr": "(sum(rate(streampulse_hls_requests_total{kind=\"segment\",status!=\"200\"}[5m])) or vector(0)) / clamp_min(sum(rate(streampulse_hls_requests_total{kind=\"segment\"}[5m])), 0.001)" }
+        {
+          "refId": "A",
+          "expr": "(sum(rate(streampulse_hls_requests_total{kind=\"segment\",status=~\"4..|5..\"}[5m])) or vector(0)) / clamp_min(sum(rate(streampulse_hls_requests_total{kind=\"segment\"}[5m])), 0.001)"
+        }
       ],
       "fieldConfig": {
         "defaults": {
           "unit": "percentunit",
           "decimals": 2,
-          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "orange", "value": 0.02 }, { "color": "red", "value": 0.1 } ] }
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.02
+              },
+              {
+                "color": "red",
+                "value": 0.1
+              }
+            ]
+          }
         },
         "overrides": []
       }
@@ -74,34 +165,115 @@
       "type": "timeseries",
       "title": "Auditeurs estimés par flux",
       "description": "rate(playlist) × durée cible de segment, par stream_id. Les séries disparaissent à l'arrêt du flux.",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 6 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
       "targets": [
-        { "refId": "A", "expr": "round(sum by (stream_id) (rate(streampulse_hls_requests_total{kind=\"playlist\",status=\"200\"}[2m])) * 10)", "legendFormat": "{{stream_id}}" }
+        {
+          "refId": "A",
+          "expr": "round(sum by (stream_id) (rate(streampulse_hls_requests_total{kind=\"playlist\",status=\"200\"}[2m])) * 10)",
+          "legendFormat": "{{stream_id}}"
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "short", "decimals": 0 }, "overrides": [] }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0
+        },
+        "overrides": []
+      }
     },
     {
       "id": 6,
       "type": "timeseries",
       "title": "Requêtes HLS par seconde (playlist / segment)",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 15 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
       "targets": [
-        { "refId": "A", "expr": "sum by (kind) (rate(streampulse_hls_requests_total[5m]))", "legendFormat": "{{kind}}" }
+        {
+          "refId": "A",
+          "expr": "sum by (kind) (rate(streampulse_hls_requests_total[5m]))",
+          "legendFormat": "{{kind}}"
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      }
     },
     {
       "id": 7,
       "type": "timeseries",
-      "title": "Erreurs HLS par seconde et par status",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 24 },
+      "title": "Erreurs HLS par seconde et par status (4xx/5xx)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
       "targets": [
-        { "refId": "A", "expr": "sum by (status) (rate(streampulse_hls_requests_total{status!=\"200\"}[5m]))", "legendFormat": "{{status}}" }
+        {
+          "refId": "A",
+          "expr": "sum by (status) (rate(streampulse_hls_requests_total{status=~\"4..|5..\"}[5m]))",
+          "legendFormat": "{{status}}"
+        }
       ],
-      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] }
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Rejets de capacité HLS (503)",
+      "description": "Le limiteur HLS_MAX_CONCURRENT (STR-88) répond avant le handler : ces rejets ne portent pas de stream_id et se lisent dans les métriques HTTP (ADR 019). Un plateau non nul signale une capacité atteinte.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (path) (rate(http_requests_total{path=~\"/api/streams/\\\\{id\\\\}/(playlist.m3u8|segments/\\\\{segment\\\\})\",status=\"503\"}[5m]))",
+          "legendFormat": "{{path}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      }
     }
   ]
 }

--- a/docs/adr/022-metriques-metier-streaming-et-panel-live.md
+++ b/docs/adr/022-metriques-metier-streaming-et-panel-live.md
@@ -1,0 +1,90 @@
+# ADR 022 — Métriques métier du streaming et panel Live
+
+**Date** : 2026-07-26
+**Statut** : Accepté
+**Ticket** : [STR-166](https://linear.app/streampulse/issue/STR-166) (sous-issues [STR-184](https://linear.app/streampulse/issue/STR-184), [STR-185](https://linear.app/streampulse/issue/STR-185), [STR-186](https://linear.app/streampulse/issue/STR-186))
+
+---
+
+## Contexte
+
+US-07-04, dernière US de l'épic Observabilité. Les métriques HTTP génériques
+(ADR 019) mesurent l'API sans rien savoir du métier : elles ignorent combien de
+flux sont en direct et ne distinguent pas un flux d'un autre (le label `path` est
+volontairement agrégé au pattern de route). Le panel Live demande des données par
+flux, « réelles, pas des fixtures ».
+
+## Décision
+
+### 1. N'ajouter que ce qui n'est pas dérivable
+
+Deux des quatre demandes du ticket sont **déjà couvertes** par l'ADR 019 : la
+latence HLS p95 et le taux d'erreurs se lisent dans
+`http_request_duration_seconds` et `http_requests_total` filtrés sur les paths
+HLS. Le dashboard les réutilise plutôt que de créer un second histogramme —
+une seule source, pas de divergence possible.
+
+Deux métriques sont ajoutées :
+
+| Métrique | Type | Labels |
+|---|---|---|
+| `streampulse_live_streams_active` | gauge | — |
+| `streampulse_hls_requests_total` | counter | `stream_id`, `kind` (playlist\|segment), `status` |
+
+### 2. Auditeurs : estimation par le débit de requêtes
+
+HLS n'a pas de connexion persistante — un auditeur est une suite de `GET` de la
+playlist, un par segment (~10 s). Aucune gauge ne peut donc « compter les
+connectés » :
+
+- un **tracker avec TTL** côté Go supposerait d'identifier le client (IP+UA :
+  le NAT fusionne plusieurs auditeurs, un changement de réseau en invente) et
+  ajouterait un état à purger ;
+- les **abonnés SSE** seraient exacts mais ne mesurent rien d'utile : le client
+  mobile n'ouvre pas `/events`.
+
+Retenu : `rate(streampulse_hls_requests_total{kind="playlist",status="200"}[2m]) × 10`,
+soit le débit de requêtes multiplié par la durée cible d'un segment. Le panel
+est explicitement titré « estimé » et sa description porte la méthode. Un
+comptage exact ne se justifierait que pour de la facturation ou des quotas.
+
+### 3. Cardinalité de `stream_id` : bornée par l'oubli, pas par l'absence
+
+Le « par flux » du ticket impose un label à valeurs non bornées dans l'absolu.
+La croissance est contenue en supprimant les séries d'un flux à son arrêt
+(`ForgetStream` → `DeletePartialMatch`), sur **tous** les chemins de sortie :
+`Stop` (arrêt explicite), `reap` (ffmpeg meurt seul) et `StopAll` (arrêt du
+serveur). La cardinalité *active* suit donc le nombre de directs simultanés —
+une poignée de séries — et le label reste cantonné à cette seule famille.
+
+### 4. Architecture : interface étroite pour les événements, GaugeFunc pour l'état
+
+- Le domaine `internal/streaming` déclare `MetricsRecorder`
+  (`RecordHLSRequest`, `ForgetStream`) et ignore Prometheus ; l'implémentation
+  `StreamingMetrics` vit dans `internal/observability` et est injectée par
+  `main.go` — même schéma ISP que `admin.LiveStopper`. Un `noopRecorder` est
+  posé par défaut : le domaine tourne sans observabilité (tests, binaires nus).
+- Les flux actifs sont un **état**, pas un événement : `RegisterLiveStreamsGauge`
+  branche un `GaugeFunc` sur `LiveSessions.ActiveCount()`, lu à chaque scrape.
+  La gauge ne peut pas diverger de la réalité, y compris si une session meurt
+  par un chemin imprévu — contrairement à un compteur incrémenté/décrémenté.
+- L'injection passe par `SetMetrics` plutôt que par le constructeur :
+  `NewHandler` a 47 sites d'appel, et l'observabilité est optionnelle par
+  construction.
+
+### 5. Status réel des lectures HLS
+
+`http.ServeFile` écrit l'en-tête lui-même : le handler ne connaîtrait pas le
+code rendu. Un `hlsStatusRecorder` (même principe que le `statusRecorder` des
+middlewares) le capture pour le label `status`, ce qui rend le taux d'erreurs
+`.ts` fidèle — 404 de fenêtre glissante et 503 de capacité (STR-88) inclus.
+
+## Conséquences
+
+- Le dashboard « Live Streaming » complète les trois autres ; l'épic
+  Observabilité est clos (logs ADR 018, métriques ADR 019, traces ADR 020,
+  alertes ADR 021, métier ADR 022).
+- Une alerte sur le taux d'erreurs `.ts` ou sur l'absence de flux pourrait être
+  ajoutée au groupe `streampulse-critiques` (ADR 021) sans nouveau socle.
+- Si un comptage exact des auditeurs devient nécessaire, il remplacera
+  l'estimation sans toucher au reste : seul le panel change de requête.

--- a/docs/adr/022-metriques-metier-streaming-et-panel-live.md
+++ b/docs/adr/022-metriques-metier-streaming-et-panel-live.md
@@ -51,11 +51,23 @@ comptage exact ne se justifierait que pour de la facturation ou des quotas.
 ### 3. Cardinalité de `stream_id` : bornée par l'oubli, pas par l'absence
 
 Le « par flux » du ticket impose un label à valeurs non bornées dans l'absolu.
-La croissance est contenue en supprimant les séries d'un flux à son arrêt
-(`ForgetStream` → `DeletePartialMatch`), sur **tous** les chemins de sortie :
-`Stop` (arrêt explicite), `reap` (ffmpeg meurt seul) et `StopAll` (arrêt du
-serveur). La cardinalité *active* suit donc le nombre de directs simultanés —
-une poignée de séries — et le label reste cantonné à cette seule famille.
+Trois garde-fous, dont deux ajoutés en revue de PR :
+
+1. **Seuls les flux réellement en direct sont comptés** : l'enregistrement
+   n'a lieu qu'après un lookup de session réussi. Compter plus tôt laisserait
+   n'importe quel client créer une série permanente par identifiant inventé
+   (`GET /api/streams/<uuid aléatoire>/playlist.m3u8`) — aucune session n'ayant
+   existé, aucun `ForgetStream` ne serait jamais appelé : cardinalité illimitée
+   et DoS mémoire.
+2. **Les séries sont supprimées à l'arrêt** (`ForgetStream` →
+   `DeletePartialMatch`) sur **tous** les chemins de sortie : `Stop` (arrêt
+   explicite), `reap` (ffmpeg meurt seul), `StopAll` (arrêt du serveur).
+3. **Un délai de drain** (30 s) rejoue la suppression : une requête encore en
+   vol au moment de l'arrêt enregistre sa métrique juste après `ForgetStream`
+   et ressusciterait sinon une série orpheline.
+
+La cardinalité *active* suit donc le nombre de directs simultanés — une
+poignée de séries — et le label reste cantonné à cette seule famille.
 
 ### 4. Architecture : interface étroite pour les événements, GaugeFunc pour l'état
 
@@ -77,7 +89,20 @@ une poignée de séries — et le label reste cantonné à cette seule famille.
 `http.ServeFile` écrit l'en-tête lui-même : le handler ne connaîtrait pas le
 code rendu. Un `hlsStatusRecorder` (même principe que le `statusRecorder` des
 middlewares) le capture pour le label `status`, ce qui rend le taux d'erreurs
-`.ts` fidèle — 404 de fenêtre glissante et 503 de capacité (STR-88) inclus.
+`.ts` fidèle aux 404 de fenêtre glissante.
+
+Deux précisions issues de la revue :
+
+- **Les 503 de capacité n'y figurent pas.** Le limiteur `HLS_MAX_CONCURRENT`
+  (STR-88) enveloppe le handler et répond avant lui : `serveHLSFile` ne
+  s'exécute pas. Ces rejets sont de toute façon *globaux* (une limite d'in-flight
+  totale, pas par flux) et se lisent dans les métriques HTTP de l'ADR 019 — le
+  dashboard leur consacre un panel dédié plutôt que de les faire remonter
+  artificiellement dans une série par flux.
+- **206 et 304 ne sont pas des erreurs.** `http.ServeFile` répond `206 Partial
+  Content` aux requêtes `Range` (courantes chez AVPlayer/ExoPlayer) et `304 Not
+  Modified` aux requêtes conditionnelles : le taux d'erreurs ne retient que
+  `4xx|5xx`, sinon un flux parfaitement sain afficherait un taux d'erreurs élevé.
 
 ## Conséquences
 


### PR DESCRIPTION
## US-07-04 (STR-166) — Panel Live Streaming

Dernière US de l'épic Observabilité. Décisions dans l'[ADR 022](docs/adr/022-metriques-metier-streaming-et-panel-live.md).

### Contenu

- **`streaming.MetricsRecorder`** — interface étroite déclarée par le domaine (ISP, même schéma que `admin.LiveStopper`), implémentée par `observability.StreamingMetrics`, injectée dans `main.go`. Le domaine ignore Prometheus ; un `noopRecorder` par défaut lui permet de tourner sans observabilité.
- **`streampulse_hls_requests_total{stream_id,kind,status}`** — seule famille portant un `stream_id`. Les séries d'un flux sont **supprimées à son arrêt** (`ForgetStream` sur **les trois** chemins de sortie : `Stop`, `reap` quand ffmpeg meurt, `StopAll`), donc la cardinalité active suit le nombre de directs simultanés.
- **`streampulse_live_streams_active`** — `GaugeFunc` sur `LiveSessions.ActiveCount()`, lu à chaque scrape : la gauge dérive de l'état réel et ne peut pas diverger, contrairement à un compteur incrémenté/décrémenté.
- **`hlsStatusRecorder`** — `http.ServeFile` écrit l'en-tête lui-même ; sans capture, le taux d'erreurs `.ts` serait aveugle aux 404 de fenêtre glissante et aux 503 de capacité (STR-88).
- **Dashboard « Live Streaming »** provisionné (7 panels) : flux en direct, auditeurs estimés (global + par flux), latence p95, taux d'erreurs segments, débits par `kind` et par `status`.

### Deux décisions à connaître

**Auditeurs = estimation, pas comptage.** HLS n'a pas de connexion persistante : un auditeur est une suite de `GET` de playlist (un par segment). Le panel affiche `rate(playlist[2m]) × 10`, titré « estimé » avec la méthode en description. Un tracker avec TTL supposerait d'identifier le client (IP+UA : le NAT fusionne, un changement de réseau invente) ; les abonnés SSE seraient exacts mais vides (le mobile n'ouvre pas `/events`).

**Rien de dupliqué.** Deux des quatre demandes du ticket étaient déjà couvertes par l'ADR 019 : la latence p95 et le taux d'erreurs se lisent dans les métriques HTTP existantes. Le dashboard les réutilise — une seule source, pas de divergence.

### Vérification E2E (faite, diffusion réelle)

Stack isolée, flux créé par le compte broadcaster, **ffmpeg poussant de l'AAC sur l'ingest** et 3 auditeurs simulés :

```
streampulse_live_streams_active 1
streampulse_hls_requests_total{kind="playlist",status="200",stream_id="651e67bd…"} 30
streampulse_hls_requests_total{kind="segment",status="200",stream_id="651e67bd…"} 5
streampulse_hls_requests_total{kind="segment",status="404",stream_id="651e67bd…"} 1
```

Puis, à l'arrêt du flux : **2 séries → 0**, gauge **1 → 0**. Prometheus scrape la gauge, dashboard chargé (7 panels, dossier StreamPulse).

- `go test ./...` : **379 tests** ; `golangci-lint` : 0 issue
- Critère « données réelles, pas des fixtures » : honoré par la diffusion ffmpeg ci-dessus

### Épic Observabilité — complet

logs (#265) · métriques (#268) · traces (#269) · alertes (#271) · métier (celle-ci).