### PR TITLE
feat(mobile): lecteur audio HLS play/pause/volume (STR-108)

### DIFF
--- a/backend/internal/openapi/openapi.yaml
+++ b/backend/internal/openapi/openapi.yaml
@@ -1598,6 +1598,7 @@ components:
         - is_public
         - started_at
         - created_at
+        - broadcaster_username
       properties:
         id:
           type: string
@@ -1625,6 +1626,9 @@ components:
         created_at:
           type: string
           format: date-time
+        broadcaster_username:
+          type: string
+          description: Username of the broadcaster (display name in the listener UI).
     StreamResponse:
       type: object
       required:

--- a/backend/internal/streaming/db/favorites.sql.go
+++ b/backend/internal/streaming/db/favorites.sql.go
@@ -31,9 +31,11 @@ func (q *Queries) AddFavorite(ctx context.Context, arg AddFavoriteParams) error 
 
 const listFavoritesByUser = `-- name: ListFavoritesByUser :many
 SELECT s.id::text AS id, s.user_id::text AS user_id, s.title, s.description, s.category,
-       s.status, s.is_public, s.started_at, s.ended_at, s.created_at, s.updated_at
+       s.status, s.is_public, s.started_at, s.ended_at, s.created_at, s.updated_at,
+       u.username AS broadcaster_username
 FROM favorites f
 JOIN streams s ON s.id = f.stream_id
+JOIN users u ON u.id = s.user_id
 WHERE f.user_id = $1::uuid
   AND s.archived_at IS NULL
   AND (s.is_public = true OR s.user_id = $1::uuid)
@@ -41,17 +43,18 @@ ORDER BY f.created_at DESC
 `
 
 type ListFavoritesByUserRow struct {
-	ID          string
-	UserID      string
-	Title       string
-	Description pgtype.Text
-	Category    pgtype.Text
-	Status      string
-	IsPublic    bool
-	StartedAt   *time.Time
-	EndedAt     *time.Time
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	ID                  string
+	UserID              string
+	Title               string
+	Description         pgtype.Text
+	Category            pgtype.Text
+	Status              string
+	IsPublic            bool
+	StartedAt           *time.Time
+	EndedAt             *time.Time
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+	BroadcasterUsername string
 }
 
 // Flux favoris de l'utilisateur, tous statuts, non archivés. On ne renvoie que
@@ -79,6 +82,7 @@ func (q *Queries) ListFavoritesByUser(ctx context.Context, userID pgtype.UUID) (
 			&i.EndedAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.BroadcasterUsername,
 		); err != nil {
 			return nil, err
 		}

--- a/backend/internal/streaming/db/streams.sql.go
+++ b/backend/internal/streaming/db/streams.sql.go
@@ -175,11 +175,13 @@ func (q *Queries) GetStreamByID(ctx context.Context, id pgtype.UUID) (GetStreamB
 }
 
 const listPublicLiveStreams = `-- name: ListPublicLiveStreams :many
-SELECT id::text AS id, user_id::text AS user_id, title, description, category,
-       status, is_public, started_at, ended_at, created_at, updated_at
-FROM streams
-WHERE is_public = true AND status = 'live' AND archived_at IS NULL
-ORDER BY started_at DESC NULLS LAST, created_at DESC
+SELECT s.id::text AS id, s.user_id::text AS user_id, s.title, s.description, s.category,
+       s.status, s.is_public, s.started_at, s.ended_at, s.created_at, s.updated_at,
+       u.username AS broadcaster_username
+FROM streams s
+JOIN users u ON u.id = s.user_id
+WHERE s.is_public = true AND s.status = 'live' AND s.archived_at IS NULL
+ORDER BY s.started_at DESC NULLS LAST, s.created_at DESC
 LIMIT $2 OFFSET $1
 `
 
@@ -189,20 +191,22 @@ type ListPublicLiveStreamsParams struct {
 }
 
 type ListPublicLiveStreamsRow struct {
-	ID          string
-	UserID      string
-	Title       string
-	Description pgtype.Text
-	Category    pgtype.Text
-	Status      string
-	IsPublic    bool
-	StartedAt   *time.Time
-	EndedAt     *time.Time
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	ID                  string
+	UserID              string
+	Title               string
+	Description         pgtype.Text
+	Category            pgtype.Text
+	Status              string
+	IsPublic            bool
+	StartedAt           *time.Time
+	EndedAt             *time.Time
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+	BroadcasterUsername string
 }
 
 // Flux publics en direct, non archivés. Le stream_key n'est jamais exposé ici.
+// JOIN users pour exposer le username du diffuseur (affiché côté auditeur).
 func (q *Queries) ListPublicLiveStreams(ctx context.Context, arg ListPublicLiveStreamsParams) ([]ListPublicLiveStreamsRow, error) {
 	rows, err := q.db.Query(ctx, listPublicLiveStreams, arg.Off, arg.Lim)
 	if err != nil {
@@ -224,6 +228,7 @@ func (q *Queries) ListPublicLiveStreams(ctx context.Context, arg ListPublicLiveS
 			&i.EndedAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.BroadcasterUsername,
 		); err != nil {
 			return nil, err
 		}

--- a/backend/internal/streaming/handler.go
+++ b/backend/internal/streaming/handler.go
@@ -170,28 +170,30 @@ func (h *Handler) toResponse(s Stream, includeSecrets bool) streamResponse {
 // streamSummaryResponse est la vue publique d'un flux : aucun secret
 // (stream_key, stream_source_url) n'y figure.
 type streamSummaryResponse struct {
-	ID          string     `json:"id"`
-	UserID      string     `json:"user_id"`
-	Title       string     `json:"title"`
-	Description *string    `json:"description"`
-	Category    *string    `json:"category"`
-	Status      string     `json:"status"`
-	IsPublic    bool       `json:"is_public"`
-	StartedAt   *time.Time `json:"started_at"`
-	CreatedAt   time.Time  `json:"created_at"`
+	ID                  string     `json:"id"`
+	UserID              string     `json:"user_id"`
+	Title               string     `json:"title"`
+	Description         *string    `json:"description"`
+	Category            *string    `json:"category"`
+	Status              string     `json:"status"`
+	IsPublic            bool       `json:"is_public"`
+	StartedAt           *time.Time `json:"started_at"`
+	CreatedAt           time.Time  `json:"created_at"`
+	BroadcasterUsername string     `json:"broadcaster_username"`
 }
 
 func toSummary(s Stream) streamSummaryResponse {
 	return streamSummaryResponse{
-		ID:          s.ID,
-		UserID:      s.UserID,
-		Title:       s.Title,
-		Description: s.Description,
-		Category:    s.Category,
-		Status:      s.Status,
-		IsPublic:    s.IsPublic,
-		StartedAt:   s.StartedAt,
-		CreatedAt:   s.CreatedAt,
+		ID:                  s.ID,
+		UserID:              s.UserID,
+		Title:               s.Title,
+		Description:         s.Description,
+		Category:            s.Category,
+		Status:              s.Status,
+		IsPublic:            s.IsPublic,
+		StartedAt:           s.StartedAt,
+		CreatedAt:           s.CreatedAt,
+		BroadcasterUsername: s.BroadcasterUsername,
 	}
 }
 

--- a/backend/internal/streaming/queries/favorites.sql
+++ b/backend/internal/streaming/queries/favorites.sql
@@ -15,9 +15,11 @@ WHERE user_id = sqlc.arg(user_id)::uuid AND stream_id = sqlc.arg(stream_id)::uui
 -- flux passé en privé par un tiers après coup disparaît de la liste. Le
 -- stream_key n'est jamais exposé ici. Trié par date d'ajout du favori (desc).
 SELECT s.id::text AS id, s.user_id::text AS user_id, s.title, s.description, s.category,
-       s.status, s.is_public, s.started_at, s.ended_at, s.created_at, s.updated_at
+       s.status, s.is_public, s.started_at, s.ended_at, s.created_at, s.updated_at,
+       u.username AS broadcaster_username
 FROM favorites f
 JOIN streams s ON s.id = f.stream_id
+JOIN users u ON u.id = s.user_id
 WHERE f.user_id = sqlc.arg(user_id)::uuid
   AND s.archived_at IS NULL
   AND (s.is_public = true OR s.user_id = sqlc.arg(user_id)::uuid)

--- a/backend/internal/streaming/queries/streams.sql
+++ b/backend/internal/streaming/queries/streams.sql
@@ -14,11 +14,14 @@ RETURNING id::text AS id, user_id::text AS user_id, title, description, category
 
 -- name: ListPublicLiveStreams :many
 -- Flux publics en direct, non archivés. Le stream_key n'est jamais exposé ici.
-SELECT id::text AS id, user_id::text AS user_id, title, description, category,
-       status, is_public, started_at, ended_at, created_at, updated_at
-FROM streams
-WHERE is_public = true AND status = 'live' AND archived_at IS NULL
-ORDER BY started_at DESC NULLS LAST, created_at DESC
+-- JOIN users pour exposer le username du diffuseur (affiché côté auditeur).
+SELECT s.id::text AS id, s.user_id::text AS user_id, s.title, s.description, s.category,
+       s.status, s.is_public, s.started_at, s.ended_at, s.created_at, s.updated_at,
+       u.username AS broadcaster_username
+FROM streams s
+JOIN users u ON u.id = s.user_id
+WHERE s.is_public = true AND s.status = 'live' AND s.archived_at IS NULL
+ORDER BY s.started_at DESC NULLS LAST, s.created_at DESC
 LIMIT sqlc.arg(lim) OFFSET sqlc.arg(off);
 
 -- name: GetStreamByID :one

--- a/backend/internal/streaming/repository.go
+++ b/backend/internal/streaming/repository.go
@@ -70,17 +70,18 @@ func (r *pgRepository) ListPublicLive(ctx context.Context, limit, offset int32) 
 	streams := make([]Stream, 0, len(rows))
 	for _, row := range rows {
 		streams = append(streams, Stream{
-			ID:          row.ID,
-			UserID:      row.UserID,
-			Title:       row.Title,
-			Description: textValue(row.Description),
-			Category:    textValue(row.Category),
-			Status:      row.Status,
-			IsPublic:    row.IsPublic,
-			StartedAt:   row.StartedAt,
-			EndedAt:     row.EndedAt,
-			CreatedAt:   row.CreatedAt,
-			UpdatedAt:   row.UpdatedAt,
+			ID:                  row.ID,
+			UserID:              row.UserID,
+			Title:               row.Title,
+			Description:         textValue(row.Description),
+			Category:            textValue(row.Category),
+			Status:              row.Status,
+			IsPublic:            row.IsPublic,
+			StartedAt:           row.StartedAt,
+			EndedAt:             row.EndedAt,
+			CreatedAt:           row.CreatedAt,
+			UpdatedAt:           row.UpdatedAt,
+			BroadcasterUsername: row.BroadcasterUsername,
 		})
 	}
 	return streams, nil

--- a/backend/internal/streaming/repository.go
+++ b/backend/internal/streaming/repository.go
@@ -239,17 +239,18 @@ func (r *pgRepository) ListFavorites(ctx context.Context, userID string) ([]Stre
 	streams := make([]Stream, 0, len(rows))
 	for _, row := range rows {
 		streams = append(streams, Stream{
-			ID:          row.ID,
-			UserID:      row.UserID,
-			Title:       row.Title,
-			Description: textValue(row.Description),
-			Category:    textValue(row.Category),
-			Status:      row.Status,
-			IsPublic:    row.IsPublic,
-			StartedAt:   row.StartedAt,
-			EndedAt:     row.EndedAt,
-			CreatedAt:   row.CreatedAt,
-			UpdatedAt:   row.UpdatedAt,
+			ID:                  row.ID,
+			UserID:              row.UserID,
+			Title:               row.Title,
+			Description:         textValue(row.Description),
+			Category:            textValue(row.Category),
+			Status:              row.Status,
+			IsPublic:            row.IsPublic,
+			StartedAt:           row.StartedAt,
+			EndedAt:             row.EndedAt,
+			CreatedAt:           row.CreatedAt,
+			UpdatedAt:           row.UpdatedAt,
+			BroadcasterUsername: row.BroadcasterUsername,
 		})
 	}
 	return streams, nil

--- a/backend/internal/streaming/service.go
+++ b/backend/internal/streaming/service.go
@@ -57,6 +57,9 @@ type Stream struct {
 	EndedAt     *time.Time
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
+	// BroadcasterUsername : nom du diffuseur, renseigné seulement pour la liste
+	// publique (ListPublicLive) ; vide ailleurs.
+	BroadcasterUsername string
 }
 
 // CreateStreamInput porte les champs fournis par le diffuseur à la création.

--- a/docs/adr/022-lecteur-audio-hls-mobile.md
+++ b/docs/adr/022-lecteur-audio-hls-mobile.md
@@ -1,0 +1,88 @@
+# ADR 022 — Lecteur audio HLS mobile (just_audio)
+
+**Date** : 2026-07-27
+**Statut** : Accepté
+**Ticket** : [STR-108](https://linear.app/streampulse/issue/STR-108) (sous-issues STR-116 moteur, STR-117 UI, STR-118 erreurs, STR-119 tests)
+
+---
+
+## Contexte
+
+STR-108 (« US-04-02 : Lecteur audio HLS play/pause/volume ») : en tant qu'auditeur, écouter un flux
+live HLS avec des contrôles, démarrage < 3 s, rebuffering < 2 %. Le backend sert un **manifeste HLS
+public** (`GET /api/streams/{id}/playlist.m3u8` + segments), sans authentification pour les flux
+publics ([ADR 015](015-moteur-hls-segmentation-ffmpeg.md) révisé par STR-108). L'app Flutter a déjà
+`just_audio` + `audio_session` déclarés, la découverte des flux (STR-107) et une route
+`/stream/:id` vers un écran player (jusqu'ici un placeholder).
+
+---
+
+## Décision
+
+### 1. Lecture HLS déléguée à **just_audio**
+
+Le package `just_audio` s'appuie sur les players natifs (AVPlayer iOS / ExoPlayer Android) qui gèrent
+HLS nativement. Pas de moteur maison, pas de parsing manuel du `.m3u8`.
+
+### 2. URL du manifeste **passée directement** (pas le client généré)
+
+Le player reçoit `AudioSource.uri(Uri.parse('{baseUrl}/api/streams/{id}/playlist.m3u8'))` :
+
+- Le `streamPlaylist` **généré** (openapi-generator) renvoie `Future<Response<String>>` : il
+  **bufferise** la réponse → inutilisable pour du streaming. On construit donc l'URL à la main
+  (`ApiConstants.hlsPlaylist(id)`).
+- **Aucun en-tête `Authorization`** : la lecture est publique (ADR 015 révisé). Conséquence directe :
+  marche iOS **et** Android uniformément, et **pas d'expiration de token** en cours d'écoute (le player
+  natif ne saurait pas rafraîchir un JWT).
+
+### 3. `AudioPlayerController` (ChangeNotifier), scopé à l'écran
+
+Un `ChangeNotifier` enveloppe l'`AudioPlayer` et expose un état applicatif
+(`loading` / `buffering` / `playing` / `paused` / `ended` / `error`) + `play`/`pause`/`setVolume`/`retry`.
+Il est **créé et détruit avec l'écran player** (`dispose()` de l'`AudioPlayer` à la sortie) — pas de
+singleton global. Le passage en **service partagé** (lecture qui survit à la navigation) relève de la
+**lecture en arrière-plan, STR-109** (US-04-03) via `audio_service`, hors périmètre ici.
+
+### 4. Spécificités **live** dans l'UI (STR-117)
+
+Un flux live n'a **pas de durée fixe ni de seek** : on remplace la barre de progression du design par
+un **badge « EN DIRECT »** + le **temps écoulé** depuis `started_at`. Le **volume** est un **slider**
+(exigé par STR-117). L'esthétique du design (artwork rond + halo violet, fond sombre, accent violet
+`#6C5CE7`) est conservée.
+
+### 5. Fin de flux et erreurs (STR-118)
+
+Quand le diffuseur arrête, la session est récoltée côté backend → le manifeste passe en **409/404** →
+le player émet une erreur. Le contrôleur bascule en état **`error` / « flux terminé »** avec un
+bouton **réessayer** ; inutile d'écouter le SSE (qui exige un JWT) — la fin se détecte via le statut
+HTTP du manifeste.
+
+---
+
+## Alternatives considérées
+
+- **Réécrire un moteur HLS en Dart** : rejeté — `just_audio` + players natifs le font déjà, mieux.
+- **Utiliser le `streamPlaylist` généré** : rejeté — il bufferise la réponse (non-streaming).
+- **Token de lecture dans l'URL / en-tête `Bearer`** : rejeté — la lecture publique (ADR 015 révisé)
+  suffit et évite les soucis d'auth du player natif (iOS) et d'expiration.
+- **Contrôleur global singleton** : rejeté pour STR-108 — un player scopé à l'écran est plus simple et
+  correct pour la lecture au premier plan ; le partage sera introduit par STR-109.
+
+---
+
+## Conséquences
+
+- **Simple et uniforme** iOS/Android : une URL, aucun header, aucun rafraîchissement de token.
+- **Latence de démarrage** : dépend de la taille des segments backend (~10 s) — à valider (STR-119) ;
+  tuning du buffer just_audio, voire segments plus courts côté backend si le < 3 s n'est pas tenu.
+- **Compteur d'auditeurs** : non fourni par le backend aujourd'hui (`listenerCount` nul) → affiché
+  seulement s'il est renseigné ; sinon masqué (suivi backend éventuel).
+- Le contrôleur devra être **hissé en service** quand STR-109 (arrière-plan) arrivera.
+
+---
+
+## Références
+
+- [ADR 015](015-moteur-hls-segmentation-ffmpeg.md) — moteur HLS backend (révisé STR-108 : lecture publique).
+- [ADR 005](005-architecture-flutter-clean.md) — Clean Architecture Flutter. [ADR 009](009-authentification-flutter.md) — client Dio/auth.
+- STR-116 (moteur) · STR-117 (UI) · STR-118 (erreurs) · STR-119 (tests) — sous-issues de STR-108.

--- a/docs/adr/023-lecteur-audio-hls-mobile.md
+++ b/docs/adr/023-lecteur-audio-hls-mobile.md
@@ -1,4 +1,4 @@
-# ADR 022 — Lecteur audio HLS mobile (just_audio)
+# ADR 023 — Lecteur audio HLS mobile (just_audio)
 
 **Date** : 2026-07-27
 **Statut** : Accepté

--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -66,6 +66,10 @@
 			</array>
 		</dict>
 	</array>
+	<!-- Autorise le HTTP en clair vers le réseau local (localhost / LAN) en dev :
+	     l'API et le flux HLS tournent sur http://<ip-locale>:8080 sans TLS.
+	     N'ouvre PAS l'HTTP arbitraire vers Internet (NSAllowsArbitraryLoads reste
+	     absent) ; en prod l'API est servie en HTTPS (api.streampulse.win). -->
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsLocalNetworking</key>

--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -66,6 +66,11 @@
 			</array>
 		</dict>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>StreamPulse utilise le microphone pour diffuser des flux audio en direct.</string>
 	<key>UILaunchStoryboardName</key>

--- a/mobile/lib/core/constants/api_constants.dart
+++ b/mobile/lib/core/constants/api_constants.dart
@@ -22,6 +22,11 @@ class ApiConstants {
   // Streams
   static const String streams = '/api/streams';
 
+  /// URL du manifeste HLS d'un flux (lecture publique, ADR 022). Passée telle
+  /// quelle au player natif via `AudioSource.uri` — sans en-tête d'auth.
+  static String hlsPlaylist(String streamId) =>
+      '$baseUrl/api/streams/$streamId/playlist.m3u8';
+
   // Tracks
   static const String tracks = '/api/tracks';
 

--- a/mobile/lib/core/constants/api_constants.dart
+++ b/mobile/lib/core/constants/api_constants.dart
@@ -22,7 +22,7 @@ class ApiConstants {
   // Streams
   static const String streams = '/api/streams';
 
-  /// URL du manifeste HLS d'un flux (lecture publique, ADR 022). Passée telle
+  /// URL du manifeste HLS d'un flux (lecture publique, ADR 023). Passée telle
   /// quelle au player natif via `AudioSource.uri` — sans en-tête d'auth.
   static String hlsPlaylist(String streamId) =>
       '$baseUrl/api/streams/$streamId/playlist.m3u8';

--- a/mobile/lib/features/streams/data/datasources/stream_remote_data_source.dart
+++ b/mobile/lib/features/streams/data/datasources/stream_remote_data_source.dart
@@ -44,4 +44,18 @@ class StreamRemoteDataSource {
       throw mapDioException(e);
     }
   }
+
+  /// Sonde le manifeste HLS **public** du flux pour déterminer s'il est terminé.
+  /// 200 → toujours en direct (`false`) ; 404/409 → le manifeste n'est plus
+  /// servi, le direct est terminé (`true`) ; toute autre issue (réseau, 5xx…) →
+  /// indéterminé (`false`), on laisse la reconnexion réseau opérer (STR-118).
+  Future<bool> isStreamEnded(String streamId) async {
+    try {
+      await _api.streamPlaylist(id: streamId);
+      return false;
+    } on DioException catch (e) {
+      final code = e.response?.statusCode;
+      return code == 404 || code == 409;
+    }
+  }
 }

--- a/mobile/lib/features/streams/data/mappers/stream_dto_mappers.dart
+++ b/mobile/lib/features/streams/data/mappers/stream_dto_mappers.dart
@@ -9,6 +9,7 @@ extension StreamSummaryResponseMapper on StreamSummaryResponse {
         startedAt: startedAt,
         description: description,
         category: category,
+        broadcasterName: broadcasterUsername,
         listenerCount: null,
         status: status.value,
       );

--- a/mobile/lib/features/streams/data/repositories/stream_repository_impl.dart
+++ b/mobile/lib/features/streams/data/repositories/stream_repository_impl.dart
@@ -29,4 +29,8 @@ class StreamRepositoryImpl implements StreamRepository {
   @override
   Future<void> removeFavorite(String streamId) =>
       _remote.removeFavorite(streamId);
+
+  @override
+  Future<bool> isStreamEnded(String streamId) =>
+      _remote.isStreamEnded(streamId);
 }

--- a/mobile/lib/features/streams/domain/entities/live_stream.dart
+++ b/mobile/lib/features/streams/domain/entities/live_stream.dart
@@ -5,6 +5,7 @@ class LiveStream {
     required this.startedAt,
     this.description,
     this.category,
+    this.broadcasterName,
     this.listenerCount,
     this.status,
   });
@@ -14,6 +15,9 @@ class LiveStream {
   final DateTime? startedAt;
   final String? description;
   final String? category;
+
+  /// Nom (username) du diffuseur, affiché sous le titre côté auditeur.
+  final String? broadcasterName;
   final int? listenerCount;
 
   /// Statut du flux : 'idle', 'live' ou 'ended' (null si non renseigné).

--- a/mobile/lib/features/streams/domain/repositories/stream_repository.dart
+++ b/mobile/lib/features/streams/domain/repositories/stream_repository.dart
@@ -11,4 +11,9 @@ abstract class StreamRepository {
 
   /// Retire le flux des favoris (idempotent côté serveur).
   Future<void> removeFavorite(String streamId);
+
+  /// `true` si le direct est terminé (manifeste HLS public 404/409), `false`
+  /// sinon. Sert à distinguer une fin de direct d'une coupure réseau côté
+  /// lecteur (STR-118).
+  Future<bool> isStreamEnded(String streamId);
 }

--- a/mobile/lib/features/streams/presentation/providers/audio_player_controller.dart
+++ b/mobile/lib/features/streams/presentation/providers/audio_player_controller.dart
@@ -156,10 +156,14 @@ class AudioPlayerController extends PlaybackController {
   }
 
   void _onPlayerState(PlayerState state) {
-    // Pendant l'attente d'une reconnexion ou en erreur définitive, on n'écrase
-    // pas l'état applicatif avec un état résiduel de l'ancien player.
+    // États applicatifs terminaux/transitoires : on n'écrase pas avec un état
+    // résiduel du player. `ended` en fait partie car _recover() est asynchrone
+    // (attente de la sonde HTTP) et le player peut émettre un `idle` juste après
+    // que la sonde a posé `ended` — sans ce garde, « Le direct est terminé »
+    // régresserait en « En pause » (course, non systématique).
     if (_status == PlaybackStatus.reconnecting ||
-        _status == PlaybackStatus.error) {
+        _status == PlaybackStatus.error ||
+        _status == PlaybackStatus.ended) {
       return;
     }
     switch (state.processingState) {

--- a/mobile/lib/features/streams/presentation/providers/audio_player_controller.dart
+++ b/mobile/lib/features/streams/presentation/providers/audio_player_controller.dart
@@ -1,0 +1,153 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:just_audio/just_audio.dart';
+
+import '../../../../core/constants/api_constants.dart';
+
+/// État applicatif du lecteur, mappé depuis just_audio et exposé à l'UI.
+enum PlaybackStatus { idle, loading, buffering, playing, paused, ended, error }
+
+/// Abstraction du lecteur exposée à l'UI (Dependency Inversion) : l'écran dépend
+/// de cette interface, jamais directement de just_audio — ce qui permet de la
+/// remplacer par un fake dans les widget tests. Implémentée par
+/// [AudioPlayerController].
+abstract class PlaybackController extends ChangeNotifier {
+  PlaybackStatus get status;
+  bool get isPlaying;
+  bool get isBusy;
+  bool get hasError;
+  bool get isEnded;
+  double get volume;
+
+  Future<void> load(String streamId);
+  Future<void> togglePlayPause();
+  Future<void> setVolume(double value);
+}
+
+/// Contrôleur du lecteur audio HLS (STR-116, cf. [ADR 022]). Enveloppe un
+/// [AudioPlayer] just_audio branché sur le manifeste **public** d'un flux et
+/// expose un état simple + play/pause/volume. Scopé à l'écran player : appeler
+/// [dispose] à la sortie (le partage inter-écrans = lecture arrière-plan, STR-109).
+class AudioPlayerController extends PlaybackController {
+  AudioPlayerController({AudioPlayer? player})
+      : _player = player ?? AudioPlayer() {
+    _stateSub = _player.playerStateStream.listen(_onPlayerState);
+    // Les erreurs de lecture (perte réseau, flux terminé → manifeste 404/409)
+    // arrivent via le flux d'événements, pas via playerStateStream.
+    _eventSub = _player.playbackEventStream.listen(
+      (_) {},
+      onError: (Object e, StackTrace _) => _fail(e),
+    );
+  }
+
+  final AudioPlayer _player;
+  StreamSubscription<PlayerState>? _stateSub;
+  StreamSubscription<PlaybackEvent>? _eventSub;
+
+  String? _streamId;
+  PlaybackStatus _status = PlaybackStatus.idle;
+  double _volume = 1;
+  Object? _error;
+
+  @override
+  PlaybackStatus get status => _status;
+  @override
+  bool get isPlaying => _status == PlaybackStatus.playing;
+  @override
+  bool get isBusy =>
+      _status == PlaybackStatus.loading || _status == PlaybackStatus.buffering;
+  @override
+  bool get hasError => _status == PlaybackStatus.error;
+  @override
+  bool get isEnded => _status == PlaybackStatus.ended;
+  @override
+  double get volume => _volume;
+  Object? get error => _error;
+
+  /// Charge le flux [streamId] (URL du manifeste public) et démarre la lecture
+  /// automatiquement (autoplay, STR-108).
+  @override
+  Future<void> load(String streamId) async {
+    _streamId = streamId;
+    _error = null;
+    _setStatus(PlaybackStatus.loading);
+    try {
+      await _player.setAudioSource(
+        AudioSource.uri(Uri.parse(ApiConstants.hlsPlaylist(streamId))),
+      );
+      await _player.setVolume(_volume);
+      await _player.play();
+    } catch (e) {
+      _fail(e);
+    }
+  }
+
+  /// Bascule lecture/pause ; relance le flux si on est en erreur ou terminé.
+  @override
+  Future<void> togglePlayPause() async {
+    if (hasError || isEnded) {
+      await retry();
+      return;
+    }
+    if (_player.playing) {
+      await _player.pause();
+    } else {
+      await _player.play();
+    }
+  }
+
+  @override
+  Future<void> setVolume(double value) async {
+    _volume = value.clamp(0.0, 1.0).toDouble();
+    await _player.setVolume(_volume);
+    notifyListeners();
+  }
+
+  /// Recharge le flux courant (bouton « réessayer »).
+  Future<void> retry() async {
+    final id = _streamId;
+    if (id != null) await load(id);
+  }
+
+  void _onPlayerState(PlayerState state) {
+    // Une erreur reste « collante » jusqu'à un retry explicite.
+    if (_status == PlaybackStatus.error) return;
+    switch (state.processingState) {
+      case ProcessingState.idle:
+        _setStatus(PlaybackStatus.idle);
+      case ProcessingState.loading:
+        _setStatus(PlaybackStatus.loading);
+      case ProcessingState.buffering:
+        _setStatus(PlaybackStatus.buffering);
+      case ProcessingState.ready:
+        _setStatus(
+          state.playing ? PlaybackStatus.playing : PlaybackStatus.paused,
+        );
+      case ProcessingState.completed:
+        _setStatus(PlaybackStatus.ended);
+    }
+  }
+
+  void _fail(Object e) {
+    _error = e;
+    if (kDebugMode) {
+      debugPrint('AudioPlayerController: erreur de lecture: $e');
+    }
+    _setStatus(PlaybackStatus.error);
+  }
+
+  void _setStatus(PlaybackStatus status) {
+    if (_status == status) return;
+    _status = status;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _stateSub?.cancel();
+    _eventSub?.cancel();
+    _player.dispose();
+    super.dispose();
+  }
+}

--- a/mobile/lib/features/streams/presentation/providers/audio_player_controller.dart
+++ b/mobile/lib/features/streams/presentation/providers/audio_player_controller.dart
@@ -6,7 +6,18 @@ import 'package:just_audio/just_audio.dart';
 import '../../../../core/constants/api_constants.dart';
 
 /// État applicatif du lecteur, mappé depuis just_audio et exposé à l'UI.
-enum PlaybackStatus { idle, loading, buffering, playing, paused, ended, error }
+/// `reconnecting` = une erreur transitoire est en cours de reprise automatique
+/// (STR-118) ; `error` = échec définitif (après épuisement des tentatives).
+enum PlaybackStatus {
+  idle,
+  loading,
+  buffering,
+  playing,
+  paused,
+  reconnecting,
+  ended,
+  error,
+}
 
 /// Abstraction du lecteur exposée à l'UI (Dependency Inversion) : l'écran dépend
 /// de cette interface, jamais directement de just_audio — ce qui permet de la
@@ -16,6 +27,7 @@ abstract class PlaybackController extends ChangeNotifier {
   PlaybackStatus get status;
   bool get isPlaying;
   bool get isBusy;
+  bool get isReconnecting;
   bool get hasError;
   bool get isEnded;
   double get volume;
@@ -25,10 +37,11 @@ abstract class PlaybackController extends ChangeNotifier {
   Future<void> setVolume(double value);
 }
 
-/// Contrôleur du lecteur audio HLS (STR-116, cf. [ADR 022]). Enveloppe un
+/// Contrôleur du lecteur audio HLS (STR-116/118, cf. [ADR 022]). Enveloppe un
 /// [AudioPlayer] just_audio branché sur le manifeste **public** d'un flux et
-/// expose un état simple + play/pause/volume. Scopé à l'écran player : appeler
-/// [dispose] à la sortie (le partage inter-écrans = lecture arrière-plan, STR-109).
+/// expose un état simple + play/pause/volume. Gère les erreurs (STR-118) par une
+/// **reconnexion automatique bornée** (perte réseau) puis un état d'erreur clair
+/// (flux indisponible). Scopé à l'écran player : appeler [dispose] à la sortie.
 class AudioPlayerController extends PlaybackController {
   AudioPlayerController({AudioPlayer? player})
       : _player = player ?? AudioPlayer() {
@@ -41,11 +54,16 @@ class AudioPlayerController extends PlaybackController {
     );
   }
 
+  /// Nombre de reconnexions automatiques avant d'abandonner (STR-118).
+  static const int _maxAutoRetries = 3;
+
   final AudioPlayer _player;
   StreamSubscription<PlayerState>? _stateSub;
   StreamSubscription<PlaybackEvent>? _eventSub;
+  Timer? _retryTimer;
 
   String? _streamId;
+  int _retryCount = 0;
   PlaybackStatus _status = PlaybackStatus.idle;
   double _volume = 1;
   Object? _error;
@@ -58,6 +76,8 @@ class AudioPlayerController extends PlaybackController {
   bool get isBusy =>
       _status == PlaybackStatus.loading || _status == PlaybackStatus.buffering;
   @override
+  bool get isReconnecting => _status == PlaybackStatus.reconnecting;
+  @override
   bool get hasError => _status == PlaybackStatus.error;
   @override
   bool get isEnded => _status == PlaybackStatus.ended;
@@ -65,11 +85,19 @@ class AudioPlayerController extends PlaybackController {
   double get volume => _volume;
   Object? get error => _error;
 
-  /// Charge le flux [streamId] (URL du manifeste public) et démarre la lecture
-  /// automatiquement (autoplay, STR-108).
+  /// Charge le flux [streamId] et démarre la lecture (autoplay, STR-108).
+  /// Réinitialise le compteur de reconnexions (action utilisateur).
   @override
   Future<void> load(String streamId) async {
     _streamId = streamId;
+    _retryCount = 0;
+    await _start(streamId);
+  }
+
+  /// (Re)démarre effectivement la lecture du flux — partagé par [load], le
+  /// retry automatique et [retry] (manuel). Ne touche pas au compteur.
+  Future<void> _start(String streamId) async {
+    _retryTimer?.cancel();
     _error = null;
     _setStatus(PlaybackStatus.loading);
     try {
@@ -83,13 +111,15 @@ class AudioPlayerController extends PlaybackController {
     }
   }
 
-  /// Bascule lecture/pause ; relance le flux si on est en erreur ou terminé.
+  /// Bascule lecture/pause ; relance le flux si on est en erreur ou terminé, et
+  /// ignore les taps pendant une transition (chargement / reconnexion).
   @override
   Future<void> togglePlayPause() async {
     if (hasError || isEnded) {
       await retry();
       return;
     }
+    if (isBusy || isReconnecting) return;
     if (_player.playing) {
       await _player.pause();
     } else {
@@ -104,15 +134,22 @@ class AudioPlayerController extends PlaybackController {
     notifyListeners();
   }
 
-  /// Recharge le flux courant (bouton « réessayer »).
+  /// Relance le flux courant à la demande de l'utilisateur (bouton « réessayer »),
+  /// en réarmant les reconnexions automatiques.
   Future<void> retry() async {
     final id = _streamId;
-    if (id != null) await load(id);
+    if (id == null) return;
+    _retryCount = 0;
+    await _start(id);
   }
 
   void _onPlayerState(PlayerState state) {
-    // Une erreur reste « collante » jusqu'à un retry explicite.
-    if (_status == PlaybackStatus.error) return;
+    // Pendant l'attente d'une reconnexion ou en erreur définitive, on n'écrase
+    // pas l'état applicatif avec un état résiduel de l'ancien player.
+    if (_status == PlaybackStatus.reconnecting ||
+        _status == PlaybackStatus.error) {
+      return;
+    }
     switch (state.processingState) {
       case ProcessingState.idle:
         _setStatus(PlaybackStatus.idle);
@@ -121,6 +158,7 @@ class AudioPlayerController extends PlaybackController {
       case ProcessingState.buffering:
         _setStatus(PlaybackStatus.buffering);
       case ProcessingState.ready:
+        _retryCount = 0; // lecture rétablie : on réarme les reconnexions futures
         _setStatus(
           state.playing ? PlaybackStatus.playing : PlaybackStatus.paused,
         );
@@ -129,12 +167,23 @@ class AudioPlayerController extends PlaybackController {
     }
   }
 
+  /// Échec de lecture : tente une reconnexion automatique avec backoff (perte
+  /// réseau), sinon bascule en erreur définitive (flux indisponible). STR-118.
   void _fail(Object e) {
     _error = e;
     if (kDebugMode) {
       debugPrint('AudioPlayerController: erreur de lecture: $e');
     }
-    _setStatus(PlaybackStatus.error);
+    final id = _streamId;
+    if (id != null && _retryCount < _maxAutoRetries) {
+      _retryCount++;
+      _setStatus(PlaybackStatus.reconnecting);
+      final delay = Duration(seconds: 1 << (_retryCount - 1)); // 1, 2, 4 s
+      _retryTimer?.cancel();
+      _retryTimer = Timer(delay, () => _start(id));
+    } else {
+      _setStatus(PlaybackStatus.error);
+    }
   }
 
   void _setStatus(PlaybackStatus status) {
@@ -145,6 +194,7 @@ class AudioPlayerController extends PlaybackController {
 
   @override
   void dispose() {
+    _retryTimer?.cancel();
     _stateSub?.cancel();
     _eventSub?.cancel();
     _player.dispose();

--- a/mobile/lib/features/streams/presentation/providers/audio_player_controller.dart
+++ b/mobile/lib/features/streams/presentation/providers/audio_player_controller.dart
@@ -37,14 +37,21 @@ abstract class PlaybackController extends ChangeNotifier {
   Future<void> setVolume(double value);
 }
 
-/// Contrôleur du lecteur audio HLS (STR-116/118, cf. [ADR 022]). Enveloppe un
+/// Sonde l'état d'un flux à partir de son manifeste HLS **public** : renvoie
+/// `true` si le direct est terminé (manifeste 404/409), `false` sinon (200 ou
+/// erreur réseau indéterminée). Injectée dans [AudioPlayerController] pour
+/// distinguer « le direct est terminé » d'une simple coupure réseau (STR-118).
+typedef StreamEndedProbe = Future<bool> Function(String streamId);
+
+/// Contrôleur du lecteur audio HLS (STR-116/118, cf. [ADR 023]). Enveloppe un
 /// [AudioPlayer] just_audio branché sur le manifeste **public** d'un flux et
 /// expose un état simple + play/pause/volume. Gère les erreurs (STR-118) par une
 /// **reconnexion automatique bornée** (perte réseau) puis un état d'erreur clair
 /// (flux indisponible). Scopé à l'écran player : appeler [dispose] à la sortie.
 class AudioPlayerController extends PlaybackController {
-  AudioPlayerController({AudioPlayer? player})
-      : _player = player ?? AudioPlayer() {
+  AudioPlayerController({AudioPlayer? player, StreamEndedProbe? isStreamEnded})
+      : _player = player ?? AudioPlayer(),
+        _isStreamEnded = isStreamEnded {
     _stateSub = _player.playerStateStream.listen(_onPlayerState);
     // Les erreurs de lecture (perte réseau, flux terminé → manifeste 404/409)
     // arrivent via le flux d'événements, pas via playerStateStream.
@@ -58,12 +65,15 @@ class AudioPlayerController extends PlaybackController {
   static const int _maxAutoRetries = 3;
 
   final AudioPlayer _player;
+  final StreamEndedProbe? _isStreamEnded;
   StreamSubscription<PlayerState>? _stateSub;
   StreamSubscription<PlaybackEvent>? _eventSub;
   Timer? _retryTimer;
 
   String? _streamId;
   int _retryCount = 0;
+  bool _recovering = false;
+  bool _disposed = false;
   PlaybackStatus _status = PlaybackStatus.idle;
   double _volume = 1;
   Object? _error;
@@ -97,6 +107,7 @@ class AudioPlayerController extends PlaybackController {
   /// (Re)démarre effectivement la lecture du flux — partagé par [load], le
   /// retry automatique et [retry] (manuel). Ne touche pas au compteur.
   Future<void> _start(String streamId) async {
+    if (_disposed) return;
     _retryTimer?.cancel();
     _error = null;
     _setStatus(PlaybackStatus.loading);
@@ -104,6 +115,7 @@ class AudioPlayerController extends PlaybackController {
       await _player.setAudioSource(
         AudioSource.uri(Uri.parse(ApiConstants.hlsPlaylist(streamId))),
       );
+      if (_disposed) return;
       await _player.setVolume(_volume);
       await _player.play();
     } catch (e) {
@@ -167,33 +179,63 @@ class AudioPlayerController extends PlaybackController {
     }
   }
 
-  /// Échec de lecture : tente une reconnexion automatique avec backoff (perte
-  /// réseau), sinon bascule en erreur définitive (flux indisponible). STR-118.
+  /// Échec de lecture : déclenche la reprise (au plus une à la fois). STR-118.
   void _fail(Object e) {
+    if (_disposed) return;
     _error = e;
     if (kDebugMode) {
       debugPrint('AudioPlayerController: erreur de lecture: $e');
     }
-    final id = _streamId;
-    if (id != null && _retryCount < _maxAutoRetries) {
-      _retryCount++;
-      _setStatus(PlaybackStatus.reconnecting);
-      final delay = Duration(seconds: 1 << (_retryCount - 1)); // 1, 2, 4 s
-      _retryTimer?.cancel();
-      _retryTimer = Timer(delay, () => _start(id));
-    } else {
-      _setStatus(PlaybackStatus.error);
+    _recover();
+  }
+
+  /// Décide de la suite après un échec : d'abord distinguer une **fin de direct**
+  /// (manifeste 404/409) d'une coupure réseau via la sonde, puis, si le flux est
+  /// toujours là, tenter une **reconnexion automatique bornée** avec backoff
+  /// (perte réseau), sinon basculer en erreur définitive (flux indisponible).
+  Future<void> _recover() async {
+    if (_recovering) return; // une seule reprise à la fois (échecs en rafale)
+    _recovering = true;
+    try {
+      final id = _streamId;
+      if (id == null) {
+        _setStatus(PlaybackStatus.error);
+        return;
+      }
+      // Fin de direct : le manifeste n'est plus servi (404/409) → pas de retry.
+      final probe = _isStreamEnded;
+      if (probe != null && await probe(id)) {
+        if (_disposed) return;
+        _setStatus(PlaybackStatus.ended);
+        return;
+      }
+      if (_disposed) return;
+      // Coupure réseau : reconnexion automatique bornée avec backoff (1, 2, 4 s).
+      if (_retryCount < _maxAutoRetries) {
+        _retryCount++;
+        _setStatus(PlaybackStatus.reconnecting);
+        final delay = Duration(seconds: 1 << (_retryCount - 1));
+        _retryTimer?.cancel();
+        _retryTimer = Timer(delay, () {
+          if (!_disposed) _start(id);
+        });
+      } else {
+        _setStatus(PlaybackStatus.error);
+      }
+    } finally {
+      _recovering = false;
     }
   }
 
   void _setStatus(PlaybackStatus status) {
-    if (_status == status) return;
+    if (_disposed || _status == status) return;
     _status = status;
     notifyListeners();
   }
 
   @override
   void dispose() {
+    _disposed = true;
     _retryTimer?.cancel();
     _stateSub?.cancel();
     _eventSub?.cancel();

--- a/mobile/lib/features/streams/presentation/screens/stream_player_screen.dart
+++ b/mobile/lib/features/streams/presentation/screens/stream_player_screen.dart
@@ -4,46 +4,63 @@ import 'package:provider/provider.dart';
 import '../../../../core/errors/exceptions.dart';
 import '../../../auth/presentation/widgets/auth_toasts.dart';
 import '../../domain/entities/live_stream.dart';
+import '../providers/audio_player_controller.dart';
 import '../providers/favorites_controller.dart';
 
+/// Lecteur audio HLS plein écran (STR-108/117, cf. ADR 022). L'audio est piloté
+/// par un [AudioPlayerController] scopé à cet écran (créé/détruit ici).
 class StreamPlayerScreen extends StatefulWidget {
   const StreamPlayerScreen({
     super.key,
     required this.streamId,
     this.stream,
+    @visibleForTesting this.controller,
   });
 
   final String streamId;
   final LiveStream? stream;
+
+  /// Injecté par les widget tests (fake sans just_audio) ; en production, un
+  /// [AudioPlayerController] réel est créé et détruit par l'écran.
+  final PlaybackController? controller;
 
   @override
   State<StreamPlayerScreen> createState() => _StreamPlayerScreenState();
 }
 
 class _StreamPlayerScreenState extends State<StreamPlayerScreen> {
+  late final PlaybackController _audio;
+  late final bool _ownsController;
+
   @override
   void initState() {
     super.initState();
-    // Charge l'état des favoris pour afficher le bon état initial du cœur.
+    _ownsController = widget.controller == null;
+    _audio = widget.controller ?? AudioPlayerController();
+    // Démarre la lecture du flux (autoplay). L'état des favoris est chargé pour
+    // afficher le bon état initial du cœur.
+    _audio.load(widget.streamId);
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
       context.read<FavoritesController>().ensureLoaded();
     });
   }
 
+  @override
+  void dispose() {
+    if (_ownsController) _audio.dispose();
+    super.dispose();
+  }
+
   Future<void> _toggleFavorite() async {
     final controller = context.read<FavoritesController>();
-    // Arrivée par deep-link : on n'a pas les métadonnées du flux, on ajoute
-    // donc un placeholder ('Flux' / statut inconnu) pour l'update optimiste.
+    // Arrivée par deep-link : pas de métadonnées → placeholder pour l'update optimiste.
     final isPlaceholder = widget.stream == null;
     final wasFavorited = controller.isFavorited(widget.streamId);
     final favorite = widget.stream ??
         LiveStream(id: widget.streamId, title: 'Flux', startedAt: null);
     try {
       await controller.toggle(favorite);
-      // Si l'action était un AJOUT avec placeholder, la section « Favoris »
-      // afficherait une tuile fantôme ('Flux' / '—') jusqu'au prochain load.
-      // On recharge depuis le serveur pour la remplacer par les vraies
-      // métadonnées du flux (retrait ou métadonnées déjà connues : inutile).
       if (isPlaceholder && !wasFavorited) {
         await controller.load();
       }
@@ -61,63 +78,258 @@ class _StreamPlayerScreenState extends State<StreamPlayerScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final text = Theme.of(context).textTheme;
     final colors = Theme.of(context).colorScheme;
+    final text = Theme.of(context).textTheme;
     final title = widget.stream?.title ?? 'Flux';
+    final subtitle = widget.stream?.category;
+    final listeners = widget.stream?.listenerCount;
     final isFavorited =
         context.watch<FavoritesController>().isFavorited(widget.streamId);
 
     return Scaffold(
-      appBar: AppBar(
-        title: Text(title),
-        actions: [
-          IconButton(
-            onPressed: _toggleFavorite,
-            icon: Icon(
-              isFavorited ? Icons.favorite : Icons.favorite_border,
+      body: SafeArea(
+        child: Column(
+          children: [
+            _header(colors),
+            Expanded(
+              child: ListenableBuilder(
+                listenable: _audio,
+                builder: (context, _) => SingleChildScrollView(
+                  padding: const EdgeInsets.symmetric(horizontal: 24),
+                  child: Column(
+                    children: [
+                      const SizedBox(height: 12),
+                      _artwork(colors),
+                      const SizedBox(height: 20),
+                      Icon(Icons.graphic_eq, size: 40, color: colors.primary),
+                      const SizedBox(height: 20),
+                      Text(
+                        title,
+                        textAlign: TextAlign.center,
+                        style: text.headlineSmall
+                            ?.copyWith(fontWeight: FontWeight.bold),
+                      ),
+                      if (subtitle != null) ...[
+                        const SizedBox(height: 6),
+                        Text(
+                          subtitle,
+                          style:
+                              text.titleMedium?.copyWith(color: colors.primary),
+                        ),
+                      ],
+                      if (listeners != null) ...[
+                        const SizedBox(height: 10),
+                        _listeners(colors, text, listeners),
+                      ],
+                      const SizedBox(height: 24),
+                      _statusLine(colors, text),
+                      const SizedBox(height: 16),
+                      _volume(colors),
+                      const SizedBox(height: 28),
+                      _controls(colors, isFavorited),
+                      const SizedBox(height: 24),
+                    ],
+                  ),
+                ),
+              ),
             ),
-            color: isFavorited ? colors.primary : null,
-            tooltip: isFavorited ? 'Retirer des favoris' : 'Ajouter aux favoris',
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _header(ColorScheme colors) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      child: Row(
+        children: [
+          IconButton(
+            onPressed: () => Navigator.of(context).maybePop(),
+            icon: const Icon(Icons.keyboard_arrow_down),
+            tooltip: 'Réduire',
+          ),
+          const Spacer(),
+          _liveBadge(colors),
+          const Spacer(),
+          IconButton(
+            onPressed: () {}, // menu contextuel : hors périmètre STR-108
+            icon: const Icon(Icons.more_vert),
+            tooltip: 'Plus',
           ),
         ],
       ),
-      body: SafeArea(
-        child: Center(
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 24),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(
-                  Icons.graphic_eq,
-                  size: 72,
-                  color: colors.primary,
-                ),
-                const SizedBox(height: 16),
-                Text(
-                  title,
-                  textAlign: TextAlign.center,
-                  style: text.titleLarge,
-                ),
-                const SizedBox(height: 8),
-                Text(
-                  'Lecteur à venir',
-                  textAlign: TextAlign.center,
-                  style: text.bodyMedium?.copyWith(
-                    color: colors.onSurfaceVariant,
-                  ),
-                ),
-                const SizedBox(height: 4),
-                SelectableText(
-                  widget.streamId,
-                  textAlign: TextAlign.center,
-                  style: text.bodySmall?.copyWith(
-                    color: colors.onSurfaceVariant,
-                  ),
-                ),
-              ],
-            ),
+    );
+  }
+
+  Widget _liveBadge(ColorScheme colors) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: 8,
+          height: 8,
+          decoration: BoxDecoration(
+            color: colors.error,
+            shape: BoxShape.circle,
           ),
+        ),
+        const SizedBox(width: 8),
+        Text(
+          'EN DIRECT',
+          style: TextStyle(
+            color: colors.onSurface,
+            fontWeight: FontWeight.w600,
+            letterSpacing: 1.5,
+            fontSize: 13,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _artwork(ColorScheme colors) {
+    return Container(
+      width: 180,
+      height: 180,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [colors.primary, colors.primary.withValues(alpha: 0.4)],
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: colors.primary.withValues(alpha: 0.5),
+            blurRadius: 40,
+            spreadRadius: 4,
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.all(4),
+      child: Container(
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          color: colors.surface,
+        ),
+        child: Icon(Icons.radio, size: 72, color: colors.onSurfaceVariant),
+      ),
+    );
+  }
+
+  Widget _listeners(ColorScheme colors, TextTheme text, int count) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(Icons.headphones, size: 16, color: colors.secondary),
+        const SizedBox(width: 6),
+        Text(
+          '$count auditeurs',
+          style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant),
+        ),
+      ],
+    );
+  }
+
+  /// Ligne d'état : chargement, erreur (flux indisponible / terminé), ou LIVE.
+  Widget _statusLine(ColorScheme colors, TextTheme text) {
+    if (_audio.isBusy) {
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox(
+            width: 14,
+            height: 14,
+            child: CircularProgressIndicator(strokeWidth: 2, color: colors.primary),
+          ),
+          const SizedBox(width: 10),
+          Text('Chargement…',
+              style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant)),
+        ],
+      );
+    }
+    if (_audio.hasError || _audio.isEnded) {
+      final msg = _audio.isEnded
+          ? 'Le direct est terminé'
+          : 'Lecture indisponible';
+      return Text(
+        msg,
+        textAlign: TextAlign.center,
+        style: text.bodyMedium?.copyWith(color: colors.error),
+      );
+    }
+    return Text(
+      _audio.isPlaying ? 'À l’écoute' : 'En pause',
+      style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant),
+    );
+  }
+
+  Widget _volume(ColorScheme colors) {
+    return Row(
+      children: [
+        Icon(Icons.volume_down, color: colors.onSurfaceVariant),
+        Expanded(
+          child: Slider(
+            value: _audio.volume,
+            onChanged: _audio.setVolume,
+          ),
+        ),
+        Icon(Icons.volume_up, color: colors.onSurfaceVariant),
+      ],
+    );
+  }
+
+  Widget _controls(ColorScheme colors, bool isFavorited) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      children: [
+        IconButton(
+          onPressed: _toggleFavorite,
+          iconSize: 28,
+          color: isFavorited ? colors.primary : colors.onSurfaceVariant,
+          icon: Icon(isFavorited ? Icons.favorite : Icons.favorite_border),
+          tooltip: isFavorited ? 'Retirer des favoris' : 'Ajouter aux favoris',
+        ),
+        _playPauseButton(colors),
+        IconButton(
+          onPressed: () {}, // partage : hors périmètre STR-108
+          iconSize: 26,
+          color: colors.onSurfaceVariant,
+          icon: const Icon(Icons.share_outlined),
+          tooltip: 'Partager',
+        ),
+      ],
+    );
+  }
+
+  Widget _playPauseButton(ColorScheme colors) {
+    final Widget icon;
+    if (_audio.isBusy) {
+      icon = SizedBox(
+        width: 28,
+        height: 28,
+        child: CircularProgressIndicator(strokeWidth: 3, color: colors.onPrimary),
+      );
+    } else if (_audio.hasError || _audio.isEnded) {
+      icon = Icon(Icons.replay, size: 36, color: colors.onPrimary);
+    } else if (_audio.isPlaying) {
+      icon = Icon(Icons.pause, size: 40, color: colors.onPrimary);
+    } else {
+      icon = Icon(Icons.play_arrow, size: 40, color: colors.onPrimary);
+    }
+
+    return Material(
+      color: colors.primary,
+      shape: const CircleBorder(),
+      elevation: 4,
+      child: InkWell(
+        customBorder: const CircleBorder(),
+        onTap: _audio.togglePlayPause,
+        child: SizedBox(
+          width: 76,
+          height: 76,
+          child: Center(child: icon),
         ),
       ),
     );

--- a/mobile/lib/features/streams/presentation/screens/stream_player_screen.dart
+++ b/mobile/lib/features/streams/presentation/screens/stream_player_screen.dart
@@ -81,7 +81,7 @@ class _StreamPlayerScreenState extends State<StreamPlayerScreen> {
     final colors = Theme.of(context).colorScheme;
     final text = Theme.of(context).textTheme;
     final title = widget.stream?.title ?? 'Flux';
-    final subtitle = widget.stream?.category;
+    final subtitle = widget.stream?.broadcasterName; // nom du diffuseur (design)
     final listeners = widget.stream?.listenerCount;
     final isFavorited =
         context.watch<FavoritesController>().isFavorited(widget.streamId);
@@ -232,27 +232,18 @@ class _StreamPlayerScreenState extends State<StreamPlayerScreen> {
     );
   }
 
-  /// Ligne d'état : chargement, erreur (flux indisponible / terminé), ou LIVE.
+  /// Ligne d'état : reconnexion (STR-118), chargement, erreur (flux indisponible
+  /// / terminé), ou lecture/pause.
   Widget _statusLine(ColorScheme colors, TextTheme text) {
+    if (_audio.isReconnecting) {
+      return _busyLine(colors, text, 'Reconnexion…');
+    }
     if (_audio.isBusy) {
-      return Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          SizedBox(
-            width: 14,
-            height: 14,
-            child: CircularProgressIndicator(strokeWidth: 2, color: colors.primary),
-          ),
-          const SizedBox(width: 10),
-          Text('Chargement…',
-              style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant)),
-        ],
-      );
+      return _busyLine(colors, text, 'Chargement…');
     }
     if (_audio.hasError || _audio.isEnded) {
-      final msg = _audio.isEnded
-          ? 'Le direct est terminé'
-          : 'Lecture indisponible';
+      final msg =
+          _audio.isEnded ? 'Le direct est terminé' : 'Flux indisponible';
       return Text(
         msg,
         textAlign: TextAlign.center,
@@ -262,6 +253,23 @@ class _StreamPlayerScreenState extends State<StreamPlayerScreen> {
     return Text(
       _audio.isPlaying ? 'À l’écoute' : 'En pause',
       style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant),
+    );
+  }
+
+  Widget _busyLine(ColorScheme colors, TextTheme text, String label) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SizedBox(
+          width: 14,
+          height: 14,
+          child:
+              CircularProgressIndicator(strokeWidth: 2, color: colors.primary),
+        ),
+        const SizedBox(width: 10),
+        Text(label,
+            style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant)),
+      ],
     );
   }
 
@@ -305,7 +313,7 @@ class _StreamPlayerScreenState extends State<StreamPlayerScreen> {
 
   Widget _playPauseButton(ColorScheme colors) {
     final Widget icon;
-    if (_audio.isBusy) {
+    if (_audio.isBusy || _audio.isReconnecting) {
       icon = SizedBox(
         width: 28,
         height: 28,

--- a/mobile/lib/features/streams/presentation/screens/stream_player_screen.dart
+++ b/mobile/lib/features/streams/presentation/screens/stream_player_screen.dart
@@ -4,10 +4,11 @@ import 'package:provider/provider.dart';
 import '../../../../core/errors/exceptions.dart';
 import '../../../auth/presentation/widgets/auth_toasts.dart';
 import '../../domain/entities/live_stream.dart';
+import '../../domain/repositories/stream_repository.dart';
 import '../providers/audio_player_controller.dart';
 import '../providers/favorites_controller.dart';
 
-/// Lecteur audio HLS plein écran (STR-108/117, cf. ADR 022). L'audio est piloté
+/// Lecteur audio HLS plein écran (STR-108/117, cf. ADR 023). L'audio est piloté
 /// par un [AudioPlayerController] scopé à cet écran (créé/détruit ici).
 class StreamPlayerScreen extends StatefulWidget {
   const StreamPlayerScreen({
@@ -36,7 +37,14 @@ class _StreamPlayerScreenState extends State<StreamPlayerScreen> {
   void initState() {
     super.initState();
     _ownsController = widget.controller == null;
-    _audio = widget.controller ?? AudioPlayerController();
+    // La sonde du manifeste public permet au lecteur de distinguer une fin de
+    // direct (404/409) d'une coupure réseau (STR-118). Injectée via le repo —
+    // uniquement quand l'écran crée le vrai contrôleur (les widget tests en
+    // injectent un fake et ne fournissent pas de StreamRepository).
+    _audio = widget.controller ??
+        AudioPlayerController(
+          isStreamEnded: context.read<StreamRepository>().isStreamEnded,
+        );
     // Démarre la lecture du flux (autoplay). L'état des favoris est chargé pour
     // afficher le bon état initial du cœur.
     _audio.load(widget.streamId);
@@ -109,7 +117,7 @@ class _StreamPlayerScreenState extends State<StreamPlayerScreen> {
                         style: text.headlineSmall
                             ?.copyWith(fontWeight: FontWeight.bold),
                       ),
-                      if (subtitle != null) ...[
+                      if (subtitle != null && subtitle.isNotEmpty) ...[
                         const SizedBox(height: 6),
                         Text(
                           subtitle,
@@ -150,7 +158,14 @@ class _StreamPlayerScreenState extends State<StreamPlayerScreen> {
             tooltip: 'Réduire',
           ),
           const Spacer(),
-          _liveBadge(colors),
+          // Le badge « EN DIRECT » disparaît quand le flux est terminé ou en
+          // erreur (il ne se rebuild pas avec le reste du header → listenable).
+          ListenableBuilder(
+            listenable: _audio,
+            builder: (context, _) => (_audio.isEnded || _audio.hasError)
+                ? const SizedBox.shrink()
+                : _liveBadge(colors),
+          ),
           const Spacer(),
           IconButton(
             onPressed: () {}, // menu contextuel : hors périmètre STR-108

--- a/mobile/packages/streampulse_api/lib/src/model/stream_summary_response.dart
+++ b/mobile/packages/streampulse_api/lib/src/model/stream_summary_response.dart
@@ -33,6 +33,8 @@ class StreamSummaryResponse {
     required this.startedAt,
 
     required this.createdAt,
+
+    required this.broadcasterUsername,
   });
 
   @JsonKey(name: r'id', required: true, includeIfNull: false)
@@ -62,6 +64,10 @@ class StreamSummaryResponse {
   @JsonKey(name: r'created_at', required: true, includeIfNull: false)
   final DateTime createdAt;
 
+  /// Username of the broadcaster (display name in the listener UI).
+  @JsonKey(name: r'broadcaster_username', required: true, includeIfNull: false)
+  final String broadcasterUsername;
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -74,7 +80,8 @@ class StreamSummaryResponse {
           other.status == status &&
           other.isPublic == isPublic &&
           other.startedAt == startedAt &&
-          other.createdAt == createdAt;
+          other.createdAt == createdAt &&
+          other.broadcasterUsername == broadcasterUsername;
 
   @override
   int get hashCode =>
@@ -86,7 +93,8 @@ class StreamSummaryResponse {
       status.hashCode +
       isPublic.hashCode +
       (startedAt == null ? 0 : startedAt.hashCode) +
-      createdAt.hashCode;
+      createdAt.hashCode +
+      broadcasterUsername.hashCode;
 
   factory StreamSummaryResponse.fromJson(Map<String, dynamic> json) =>
       _$StreamSummaryResponseFromJson(json);

--- a/mobile/packages/streampulse_api/lib/src/model/stream_summary_response.g.dart
+++ b/mobile/packages/streampulse_api/lib/src/model/stream_summary_response.g.dart
@@ -24,6 +24,7 @@ StreamSummaryResponse _$StreamSummaryResponseFromJson(
         'is_public',
         'started_at',
         'created_at',
+        'broadcaster_username',
       ],
     );
     final val = StreamSummaryResponse(
@@ -45,6 +46,10 @@ StreamSummaryResponse _$StreamSummaryResponseFromJson(
         'created_at',
         (v) => DateTime.parse(v as String),
       ),
+      broadcasterUsername: $checkedConvert(
+        'broadcaster_username',
+        (v) => v as String,
+      ),
     );
     return val;
   },
@@ -53,6 +58,7 @@ StreamSummaryResponse _$StreamSummaryResponseFromJson(
     'isPublic': 'is_public',
     'startedAt': 'started_at',
     'createdAt': 'created_at',
+    'broadcasterUsername': 'broadcaster_username',
   },
 );
 
@@ -68,6 +74,7 @@ Map<String, dynamic> _$StreamSummaryResponseToJson(
   'is_public': instance.isPublic,
   'started_at': instance.startedAt?.toIso8601String(),
   'created_at': instance.createdAt.toIso8601String(),
+  'broadcaster_username': instance.broadcasterUsername,
 };
 
 const _$StreamSummaryResponseStatusEnumEnumMap = {

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -234,7 +234,7 @@ packages:
     source: hosted
     version: "2.0.8"
   fake_async:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: fake_async
       sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -46,6 +46,9 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
+  # Contrôle du temps virtuel dans les tests (timers de backoff — STR-118)
+  fake_async: ^1.3.1
+
   # Génération de code
   build_runner: ^2.4.9
   freezed: ^2.5.2

--- a/mobile/test/features/profile/presentation/screens/profile_screen_test.dart
+++ b/mobile/test/features/profile/presentation/screens/profile_screen_test.dart
@@ -81,6 +81,9 @@ class _FakeStreamRepository implements StreamRepository {
     int offset = 0,
   }) async =>
       const [];
+
+  @override
+  Future<bool> isStreamEnded(String streamId) async => false;
 }
 
 class _FakeProfileRepository implements ProfileRepository {

--- a/mobile/test/features/streams/presentation/providers/audio_player_controller_test.dart
+++ b/mobile/test/features/streams/presentation/providers/audio_player_controller_test.dart
@@ -1,0 +1,179 @@
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:streampulse/features/streams/presentation/providers/audio_player_controller.dart';
+
+/// Fake AudioPlayer just_audio : n'implémente que les membres utilisés par
+/// [AudioPlayerController] (les autres passent par [noSuchMethod], jamais
+/// appelé ici). Permet de piloter les échecs de lecture sans plateforme ni
+/// device — la sonde [StreamEndedProbe] étant injectable, tout le cœur de
+/// STR-118 (`_recover`) devient testable unitairement.
+class _FakeAudioPlayer implements AudioPlayer {
+  final _stateCtrl = StreamController<PlayerState>.broadcast();
+  final _eventCtrl = StreamController<PlaybackEvent>.broadcast();
+
+  /// Si non nul, [setAudioSource] lève cette erreur (simule une source error).
+  Object? setAudioSourceError;
+  int setAudioSourceCalls = 0;
+  bool disposed = false;
+  bool _playing = false;
+
+  void emitState(PlayerState state) {
+    if (!_stateCtrl.isClosed) _stateCtrl.add(state);
+  }
+
+  @override
+  Stream<PlayerState> get playerStateStream => _stateCtrl.stream;
+  @override
+  Stream<PlaybackEvent> get playbackEventStream => _eventCtrl.stream;
+  @override
+  bool get playing => _playing;
+
+  @override
+  Future<Duration?> setAudioSource(
+    AudioSource source, {
+    bool preload = true,
+    int? initialIndex,
+    Duration? initialPosition,
+  }) async {
+    setAudioSourceCalls++;
+    final err = setAudioSourceError;
+    if (err != null) throw err;
+    return null;
+  }
+
+  @override
+  Future<void> setVolume(double volume) async {}
+  @override
+  Future<void> play() async => _playing = true;
+  @override
+  Future<void> pause() async => _playing = false;
+
+  @override
+  Future<void> dispose() async {
+    disposed = true;
+    await _stateCtrl.close();
+    await _eventCtrl.close();
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
+
+void main() {
+  group('AudioPlayerController._recover (STR-118)', () {
+    test('sonde vraie (fin de direct) → ended, aucun retry armé', () async {
+      final player = _FakeAudioPlayer()..setAudioSourceError = Exception('404');
+      final controller = AudioPlayerController(
+        player: player,
+        isStreamEnded: (_) async => true,
+      );
+      addTearDown(controller.dispose);
+
+      await controller.load('s1');
+      await pumpEventQueue(); // laisse _recover attendre la sonde puis poser l'état
+
+      expect(controller.status, PlaybackStatus.ended);
+      expect(controller.isEnded, isTrue);
+      // Fin de direct : on ne réarme pas de tentative → une seule source posée.
+      expect(player.setAudioSourceCalls, 1);
+    });
+
+    test(
+        'sonde vraie posée, puis état résiduel du player → ended non écrasé',
+        () async {
+      final player = _FakeAudioPlayer()..setAudioSourceError = Exception('409');
+      final controller = AudioPlayerController(
+        player: player,
+        isStreamEnded: (_) async => true,
+      );
+      addTearDown(controller.dispose);
+
+      await controller.load('s1');
+      await pumpEventQueue();
+      expect(controller.status, PlaybackStatus.ended);
+
+      // ExoPlayer émet un `idle` résiduel après la source error : ne doit pas
+      // faire régresser « terminé » en « en pause » (garde dans _onPlayerState).
+      player.emitState(PlayerState(false, ProcessingState.idle));
+      await pumpEventQueue();
+      expect(controller.status, PlaybackStatus.ended);
+    });
+
+    test(
+        'sonde fausse (coupure réseau) → reconnecting, puis error après 3 tentatives',
+        () {
+      fakeAsync((async) {
+        final player = _FakeAudioPlayer()
+          ..setAudioSourceError = Exception('network');
+        final controller = AudioPlayerController(
+          player: player,
+          isStreamEnded: (_) async => false,
+        );
+
+        controller.load('s1');
+        async.flushMicrotasks();
+        // 1re tentative initiale échouée → reconnexion programmée.
+        expect(controller.status, PlaybackStatus.reconnecting);
+        expect(player.setAudioSourceCalls, 1);
+
+        // Backoff 1s, 2s, 4s : chaque réveil relance _start (qui échoue encore).
+        async.elapse(const Duration(seconds: 1));
+        async.flushMicrotasks();
+        expect(player.setAudioSourceCalls, 2);
+        expect(controller.status, PlaybackStatus.reconnecting);
+
+        async.elapse(const Duration(seconds: 2));
+        async.flushMicrotasks();
+        expect(player.setAudioSourceCalls, 3);
+        expect(controller.status, PlaybackStatus.reconnecting);
+
+        async.elapse(const Duration(seconds: 4));
+        async.flushMicrotasks();
+        // 4e échec : tentatives épuisées → erreur définitive, plus de timer.
+        expect(player.setAudioSourceCalls, 4);
+        expect(controller.status, PlaybackStatus.error);
+
+        async.elapse(const Duration(seconds: 10));
+        async.flushMicrotasks();
+        expect(player.setAudioSourceCalls, 4); // aucun timer résiduel
+
+        controller.dispose();
+      });
+    });
+
+    test(
+        'dispose() pendant l\'attente de la sonde → aucune notification, aucun timer résiduel',
+        () async {
+      final player = _FakeAudioPlayer()..setAudioSourceError = Exception('x');
+      final probe = Completer<bool>();
+      final controller = AudioPlayerController(
+        player: player,
+        isStreamEnded: (_) => probe.future,
+      );
+
+      var notificationsAfterDispose = 0;
+      var disposed = false;
+      controller.addListener(() {
+        if (disposed) notificationsAfterDispose++;
+      });
+
+      await controller.load('s1');
+      await pumpEventQueue(); // _recover est maintenant bloqué sur la sonde
+
+      disposed = true;
+      controller.dispose();
+
+      // La sonde se résout après coup : le contrôleur détruit ne doit ni
+      // notifier ni armer de timer (garde _disposed).
+      probe.complete(true);
+      await pumpEventQueue();
+
+      expect(notificationsAfterDispose, 0);
+      expect(player.disposed, isTrue);
+    });
+  });
+}

--- a/mobile/test/features/streams/presentation/providers/favorites_controller_test.dart
+++ b/mobile/test/features/streams/presentation/providers/favorites_controller_test.dart
@@ -36,6 +36,9 @@ class _FakeRepository implements StreamRepository {
   @override
   Future<List<LiveStream>> listLiveStreams({int limit = 20, int offset = 0}) async =>
       const [];
+
+  @override
+  Future<bool> isStreamEnded(String streamId) async => false;
 }
 
 void main() {

--- a/mobile/test/features/streams/presentation/providers/stream_notifier_test.dart
+++ b/mobile/test/features/streams/presentation/providers/stream_notifier_test.dart
@@ -32,6 +32,9 @@ class _FakeRepository implements StreamRepository {
 
   @override
   Future<void> removeFavorite(String streamId) async {}
+
+  @override
+  Future<bool> isStreamEnded(String streamId) async => false;
 }
 
 class _PagingRepository implements StreamRepository {
@@ -54,6 +57,9 @@ class _PagingRepository implements StreamRepository {
 
   @override
   Future<void> removeFavorite(String streamId) async {}
+
+  @override
+  Future<bool> isStreamEnded(String streamId) async => false;
 }
 
 void main() {

--- a/mobile/test/features/streams/presentation/screens/stream_player_screen_test.dart
+++ b/mobile/test/features/streams/presentation/screens/stream_player_screen_test.dart
@@ -85,6 +85,9 @@ class _FakeStreamRepository implements StreamRepository {
     int offset = 0,
   }) async =>
       const [];
+
+  @override
+  Future<bool> isStreamEnded(String streamId) async => false;
 }
 
 Widget _harness({

--- a/mobile/test/features/streams/presentation/screens/stream_player_screen_test.dart
+++ b/mobile/test/features/streams/presentation/screens/stream_player_screen_test.dart
@@ -9,19 +9,26 @@ import 'package:streampulse/features/streams/presentation/providers/audio_player
 import 'package:streampulse/features/streams/presentation/providers/favorites_controller.dart';
 import 'package:streampulse/features/streams/presentation/screens/stream_player_screen.dart';
 
-/// Contrôleur de lecture fake (sans just_audio) : le player n'est pas testé ici,
-/// on isole la logique de favoris. État inerte (idle), méthodes no-op.
+/// Contrôleur de lecture fake (sans just_audio) : pilotable par [status] pour
+/// tester le rendu des états (STR-118), méthodes no-op.
 class _FakePlaybackController extends PlaybackController {
+  _FakePlaybackController([this._status = PlaybackStatus.idle]);
+
+  final PlaybackStatus _status;
+
   @override
-  PlaybackStatus get status => PlaybackStatus.idle;
+  PlaybackStatus get status => _status;
   @override
-  bool get isPlaying => false;
+  bool get isPlaying => _status == PlaybackStatus.playing;
   @override
-  bool get isBusy => false;
+  bool get isBusy =>
+      _status == PlaybackStatus.loading || _status == PlaybackStatus.buffering;
   @override
-  bool get hasError => false;
+  bool get isReconnecting => _status == PlaybackStatus.reconnecting;
   @override
-  bool get isEnded => false;
+  bool get hasError => _status == PlaybackStatus.error;
+  @override
+  bool get isEnded => _status == PlaybackStatus.ended;
   @override
   double get volume => 1;
   @override
@@ -85,6 +92,7 @@ Widget _harness({
   LiveStream? stream,
   required _FakeStreamRepository repo,
   required FavoritesController controller,
+  PlaybackStatus playbackStatus = PlaybackStatus.idle,
 }) {
   return ChangeNotifierProvider<FavoritesController>.value(
     value: controller,
@@ -93,7 +101,7 @@ Widget _harness({
         home: StreamPlayerScreen(
           streamId: streamId,
           stream: stream,
-          controller: _FakePlaybackController(),
+          controller: _FakePlaybackController(playbackStatus),
         ),
       ),
     ),
@@ -161,6 +169,49 @@ void main() {
 
       expect(repo.removed, ['s1']);
       expect(repo.listFavoritesCalls, 1); // aucune réconciliation sur un retrait
+    });
+  });
+
+  group('StreamPlayerScreen — états de lecture (STR-118)', () {
+    testWidgets('reconnexion : affiche « Reconnexion… »', (tester) async {
+      final repo = _FakeStreamRepository();
+      await tester.pumpWidget(_harness(
+        streamId: 's1',
+        repo: repo,
+        controller: FavoritesController(repo),
+        playbackStatus: PlaybackStatus.reconnecting,
+      ));
+      await tester.pump();
+
+      expect(find.text('Reconnexion…'), findsOneWidget);
+    });
+
+    testWidgets('erreur : « Flux indisponible » + bouton réessayer',
+        (tester) async {
+      final repo = _FakeStreamRepository();
+      await tester.pumpWidget(_harness(
+        streamId: 's1',
+        repo: repo,
+        controller: FavoritesController(repo),
+        playbackStatus: PlaybackStatus.error,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Flux indisponible'), findsOneWidget);
+      expect(find.byIcon(Icons.replay), findsOneWidget); // le play devient « réessayer »
+    });
+
+    testWidgets('flux terminé : « Le direct est terminé »', (tester) async {
+      final repo = _FakeStreamRepository();
+      await tester.pumpWidget(_harness(
+        streamId: 's1',
+        repo: repo,
+        controller: FavoritesController(repo),
+        playbackStatus: PlaybackStatus.ended,
+      ));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Le direct est terminé'), findsOneWidget);
     });
   });
 }

--- a/mobile/test/features/streams/presentation/screens/stream_player_screen_test.dart
+++ b/mobile/test/features/streams/presentation/screens/stream_player_screen_test.dart
@@ -5,8 +5,32 @@ import 'package:toastification/toastification.dart';
 
 import 'package:streampulse/features/streams/domain/entities/live_stream.dart';
 import 'package:streampulse/features/streams/domain/repositories/stream_repository.dart';
+import 'package:streampulse/features/streams/presentation/providers/audio_player_controller.dart';
 import 'package:streampulse/features/streams/presentation/providers/favorites_controller.dart';
 import 'package:streampulse/features/streams/presentation/screens/stream_player_screen.dart';
+
+/// Contrôleur de lecture fake (sans just_audio) : le player n'est pas testé ici,
+/// on isole la logique de favoris. État inerte (idle), méthodes no-op.
+class _FakePlaybackController extends PlaybackController {
+  @override
+  PlaybackStatus get status => PlaybackStatus.idle;
+  @override
+  bool get isPlaying => false;
+  @override
+  bool get isBusy => false;
+  @override
+  bool get hasError => false;
+  @override
+  bool get isEnded => false;
+  @override
+  double get volume => 1;
+  @override
+  Future<void> load(String streamId) async {}
+  @override
+  Future<void> togglePlayPause() async {}
+  @override
+  Future<void> setVolume(double value) async {}
+}
 
 /// Flux « réel » tel que renvoyé par le serveur (métadonnées complètes),
 /// par opposition au placeholder créé en arrivée deep-link.
@@ -66,7 +90,11 @@ Widget _harness({
     value: controller,
     child: ToastificationWrapper(
       child: MaterialApp(
-        home: StreamPlayerScreen(streamId: streamId, stream: stream),
+        home: StreamPlayerScreen(
+          streamId: streamId,
+          stream: stream,
+          controller: _FakePlaybackController(),
+        ),
       ),
     ),
   );


### PR DESCRIPTION
## STR-108 — US-04-02 : Lecteur audio HLS (play/pause/volume)

[STR-108](https://linear.app/streampulse/issue/STR-108) · milestone *Expérience Auditeur Mobile (Flutter)*. Couvre **STR-116** (moteur), **STR-117** (UI), **STR-118** (erreurs) ; STR-119 (tests device manuels) reste à valider sur téléphone.

En tant qu'auditeur, écouter un flux **live HLS** avec play/pause/volume. Le player natif consomme le manifeste HLS **public** ([ADR 015](docs/adr/015-moteur-hls-segmentation-ffmpeg.md) révisé par STR-108) directement — sans en-tête d'auth, iOS + Android uniformes.

### Contenu

- **STR-116 — moteur** : `AudioPlayerController` (just_audio) derrière une interface **`PlaybackController`** (DI/testabilité), branché sur `${baseUrl}/api/streams/{id}/playlist.m3u8`. Play/pause/volume, autoplay, états mappés. Scopé à l'écran (le partage inter-écrans = lecture arrière-plan, STR-109).
- **STR-117 — UI** : écran player plein écran d'après le Figma (header **EN DIRECT**, artwork rond à halo violet, waveform, titre, **nom du diffuseur**, slider volume, ❤️ / ⏯ / partage).
- **STR-118 — erreurs** : **reconnexion automatique bornée** (backoff 1/2/4 s) sur perte réseau → « Reconnexion… » ; échec définitif → « Flux indisponible » + réessayer ; fin de direct → « Le direct est terminé ».
- **Nom du diffuseur** (demandé) : backend `ListPublicLiveStreams` **JOIN `users`** → `broadcaster_username` (OpenAPI + **client Dart régénéré**), affiché en sous-titre du player.

### Décisions ([ADR 022](docs/adr/022-lecteur-audio-hls-mobile.md))

- **just_audio** (players natifs AVPlayer/ExoPlayer) ; **URL directe** (le `streamPlaylist` généré bufferise, inutilisable en streaming) ; **lecture publique** (pas de JWT côté player, ADR 015 révisé) ; **live** = pas de seek → badge LIVE ; **erreurs** = reconnexion auto + états clairs.

### Vérification

- **Backend** : `go build` · `vet` · `gofmt` · `go test` · `gosec` (Issues : 0) verts. `GET /api/streams` renvoie `broadcaster_username` (vérifié end-to-end).
- **Mobile** : `flutter analyze` clean · `flutter test` **167** OK (états STR-118 + réconciliation deep-link + player) · client Dart régénéré (`make generate-openapi-client`).
- **Rendu** vérifié visuellement sur Chrome (viewport mobile) : player conforme au design + contrôles interactifs.

### Hors périmètre / suivis

- **STR-119** — tests manuels **device** (démarrage < 3 s, rebuffering < 2 %) : à valider sur iOS/Android (Chrome web ne décode pas HLS). Le < 3 s pourra tendre avec des segments de 10 s → éventuelle coordination backend.
- **Compteur d'auditeurs** : nécessite un comptage dédié (HLS sans état) → **ticket séparé**.
- Lecture en **arrière-plan** (`audio_service`) = STR-109.
- ⚠️ Cette PR regroupe le mobile **et** un petit changement backend (`broadcaster_username`) — regroupés ici à la demande ; découpables si vous préférez.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
