### PR TITLE
feat(api): statistiques d'audience en temps réel du diffuseur (STR-154)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,15 @@ STREAM_INGEST_BASE_URL=http://localhost:8080
 # auditeurs — STR-88. 0 = illimité.
 HLS_MAX_CONCURRENT=256
 
+# Autorise la lecture de X-Forwarded-For pour identifier les auditeurs d'un flux
+# (comptage d'audience, STR-154 / ADR 025).
+#
+# À laisser à false en local : l'en-tête est falsifiable, et sans reverse proxy
+# devant, n'importe qui gonflerait le compteur d'un flux en variant sa valeur.
+# À passer à true UNIQUEMENT en production, derrière Caddy qui le réécrit —
+# sinon tous les auditeurs partagent l'adresse du proxy et le compteur sature à 1.
+TRUST_PROXY_HEADERS=false
+
 # Niveau minimal des logs structurés JSON (STR-163, ADR 018) :
 # trace | debug | info | warn | error | fatal | panic
 LOG_LEVEL=info

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,6 +238,7 @@ Domaine `internal/streaming/` (handler/service/repository). Détails dans [ADR 0
 | DELETE | `/api/streams/{id}/favorite` | `Handler.RemoveFavorite` | Oui (JWT) — retire des favoris ; idempotent → 204 (US-04-05) |
 | GET | `/api/users/me/favorites` | `Handler.ListFavorites` | Oui (JWT) — liste « mes favoris » (tous statuts, visibles, non archivés), sans secret (US-04-05) |
 | GET | `/api/users/me/streams` | `Handler.ListMine` | Oui (JWT) — tableau de bord diffuseur : **mes** flux (tous statuts, non archivés), **avec** `stream_key`/`stream_source_url` (le filtre porte sur le porteur du JWT) ; `[]` si aucun flux, jamais 403 (STR-153, ADR 024) |
+| GET | `/api/streams/{id}/stats` | `Handler.Stats` | Oui (JWT) — audience du flux : auditeurs **estimés**, pic, durée. Propriétaire uniquement → 404 sinon ; flux non live → 200 avec compteurs à zéro (STR-154, ADR 025) |
 | POST | `/api/streams/ingest/{stream_key}` | `Handler.Ingest` | **Non (JWT)** — auth par `stream_key` dans le path ; push audio AAC segmenté en HLS (STR-70/71) |
 | GET | `/api/streams/{id}/playlist.m3u8` | `Handler.Playlist` | **Public** (`OptionalAuth`) — flux publics servis à un anonyme, privé → 404 ; owner authentifié voit ses flux privés — manifeste HLS, 409 si pas live/pas prêt (STR-108) ; 503 si capacité atteinte (`HLS_MAX_CONCURRENT`, STR-88) |
 | GET | `/api/streams/{id}/segments/{segment}` | `Handler.Segment` | **Public** (`OptionalAuth`) — idem playlist — segment `.ts` (nom validé anti-traversal) (STR-108) ; 503 si capacité atteinte (`HLS_MAX_CONCURRENT`, STR-88) |
@@ -475,6 +476,7 @@ Copier `.env.example` en `.env` avant le premier lancement. Ne jamais committer 
 | `CORS_ALLOWED_ORIGINS` | Origines CORS autorisées, séparées par des virgules (en dev, localhost/127.0.0.1 autorisés d'office) | `https://app.streampulse.com` |
 | `STREAM_INGEST_BASE_URL` | Préfixe de l'URL de stream source du diffuseur (cf. ADR 013) : `{base}/api/streams/ingest/{stream_key}` | `http://localhost:8080` |
 | `HLS_MAX_CONCURRENT` | Nombre max de requêtes HLS simultanées servies aux auditeurs (0 = illimité) | `256` |
+| `TRUST_PROXY_HEADERS` | Lire `X-Forwarded-For` pour identifier les auditeurs (comptage d'audience, ADR 025). `false` en local ; `true` **uniquement** derrière un reverse proxy, sinon le compteur sature à 1 | `false` |
 | `LOG_LEVEL` | Niveau minimal des logs JSON (`trace`\|`debug`\|`info`\|`warn`\|`error`) — ADR 018 | `info` |
 | `LOG_PRETTY` | Sortie console lisible, réservée au `go run` local hors Docker (jamais en conteneur) | `true` |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Endpoint OTLP/HTTP Tempo pour les traces (vide = tracing désactivé) — ADR 020 | `http://tempo:4318` |
@@ -540,7 +542,7 @@ xcrun simctl openurl booted \
 | `docs/adr/012-openapi-source-de-verite.md` | Décision : OpenAPI source de vérité du contrat HTTP + client Dart/Dio généré |
 
 **Règle :** toute nouvelle décision d'architecture significative → nouvel ADR dans `docs/adr/`
-avec le numéro suivant (prochain : `025-...`). Référencer le ticket Linear correspondant.
+avec le numéro suivant (prochain : `026-...`). Référencer le ticket Linear correspondant.
 
 ## Principes SOLID
 

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -123,6 +123,7 @@ func run() error {
 	streamingMetrics := observability.NewStreamingMetrics(prometheus.DefaultRegisterer)
 	streamingSessions.SetMetrics(streamingMetrics)
 	streamingHandler.SetMetrics(streamingMetrics)
+	streamingHandler.SetTrustProxyHeaders(cfg.TrustProxyHeaders)
 	observability.RegisterLiveStreamsGauge(prometheus.DefaultRegisterer, streamingSessions.ActiveCount)
 
 	// Réconciliation : les sessions LiveSessions sont en mémoire et reparties
@@ -225,6 +226,9 @@ func run() error {
 	// un non-diffuseur ne possède aucun flux et reçoit [] (cf. ADR 024).
 	mux.Handle("GET /api/users/me/streams", auth.RequireAuth(cfg.JWTSecret,
 		http.HandlerFunc(streamingHandler.ListMine)))
+	// Statistiques d'audience du flux, propriétaire uniquement (STR-154).
+	mux.Handle("GET /api/streams/{id}/stats", auth.RequireAuth(cfg.JWTSecret,
+		http.HandlerFunc(streamingHandler.Stats)))
 	// Événements SSE du direct (STR-85) : notif d'arrêt aux auditeurs authentifiés.
 	mux.Handle("GET /api/streams/{id}/events", auth.RequireAuth(cfg.JWTSecret,
 		http.HandlerFunc(streamingHandler.Events)))

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -69,6 +69,17 @@ type Config struct {
 	// servies simultanément — STR-88. <= 0 désactive la borne.
 	HLSMaxConcurrent int `mapstructure:"HLS_MAX_CONCURRENT"`
 
+	// TrustProxyHeaders autorise la lecture de X-Forwarded-For pour identifier
+	// l'auditeur d'un flux (comptage d'audience, STR-154).
+	//
+	// Faux par défaut, et c'est volontaire : l'en-tête est falsifiable par le
+	// client, l'activer sans reverse proxy devant laisserait n'importe qui
+	// gonfler le compteur d'un flux en variant sa valeur. À passer à true
+	// **uniquement** derrière un proxy qui réécrit l'en-tête (Caddy le fait).
+	// Sans lui, tous les auditeurs derrière le proxy partagent une adresse et
+	// le compteur sature à 1.
+	TrustProxyHeaders bool `mapstructure:"TRUST_PROXY_HEADERS"`
+
 	// CORSAllowedOrigins : origines autorisées par CORS (CSV dans CORS_ALLOWED_ORIGINS).
 	CORSAllowedOrigins []string `mapstructure:"-"`
 
@@ -97,6 +108,7 @@ func Load() (*Config, error) {
 	v.SetDefault("DB_PORT", defaultDBPort)
 	v.SetDefault("STREAM_INGEST_BASE_URL", defaultStreamIngestBaseURL)
 	v.SetDefault("HLS_MAX_CONCURRENT", defaultHLSMaxConcurrent)
+	v.SetDefault("TRUST_PROXY_HEADERS", false)
 	v.SetDefault("LOG_LEVEL", defaultLogLevel)
 	v.SetDefault("LOG_PRETTY", false)
 

--- a/backend/internal/openapi/openapi.yaml
+++ b/backend/internal/openapi/openapi.yaml
@@ -977,6 +977,46 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "500":
           $ref: "#/components/responses/InternalError"
+  /api/streams/{id}/stats:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Streaming
+      operationId: getStreamStats
+      summary: Live audience statistics for the caller's own stream.
+      description: >-
+        Returns the current audience of a stream the caller owns. A stream that
+        is not live answers 200 with zeroed counters rather than an error, so a
+        polling client has no special case to handle. A stream owned by someone
+        else answers 404, never 403 — its very existence stays private.
+
+
+        `listeners` and `peak_listeners` are ESTIMATES. HLS has no persistent
+        connection, so a client counts as a listener while it has fetched the
+        manifest recently; two players behind one public address count as one.
+        Both values live in memory: they reset when the process restarts and do
+        not survive the end of the broadcast.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Current audience and broadcast duration.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StreamStatsResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
   /api/users/me/streams:
     get:
       tags:
@@ -1615,6 +1655,44 @@ components:
         is_public:
           type: boolean
           example: true
+    StreamStatsResponse:
+      type: object
+      required:
+        - stream_id
+        - status
+        - listeners
+        - peak_listeners
+        - duration_seconds
+      properties:
+        stream_id:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: [idle, live, ended]
+        listeners:
+          type: integer
+          description: >-
+            Estimated number of distinct clients that fetched the manifest
+            recently. Zero when the stream is not live.
+          example: 12
+        peak_listeners:
+          type: integer
+          description: >-
+            Highest `listeners` value observed since the broadcast started.
+            In-memory only: reset on process restart, lost when the stream ends.
+          example: 27
+        started_at:
+          type: string
+          format: date-time
+          nullable: true
+        duration_seconds:
+          type: integer
+          format: int64
+          description: >-
+            Seconds since `started_at` — up to now while live, up to `ended_at`
+            once the broadcast is over. Zero if the stream never started.
+          example: 3725
     StreamSummaryResponse:
       type: object
       required:

--- a/backend/internal/streaming/handler.go
+++ b/backend/internal/streaming/handler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"mime"
+	"net"
 	"net/http"
 
 	"os"
@@ -53,6 +54,39 @@ type StreamSessions interface {
 	AttachIngest(streamKey string) (io.Writer, func(), error)
 	Playlist(streamID string) (string, bool)
 	Segment(streamID, name string) (string, bool)
+	TouchListener(streamID, clientKey string)
+	Stats(streamID string) (SessionStats, bool)
+}
+
+// clientKey identifie un lecteur HLS pour le comptage d'auditeurs (STR-154).
+//
+// L'adresse réseau est le seul discriminant disponible : les lecteurs natifs
+// (AVPlayer/ExoPlayer) ne portent pas le Bearer, et rien d'autre dans la
+// requête n'est stable. Conséquences assumées : deux lecteurs derrière la même
+// IP publique comptent pour un, et un client qui change d'adresse compte
+// double le temps que sa fenêtre expire.
+//
+// X-Forwarded-For n'est lu que si `TRUST_PROXY_HEADERS` est activé. L'en-tête
+// est falsifiable : sans reverse proxy qui le réécrit, le lire laisserait
+// n'importe qui gonfler le compteur d'un flux en variant sa valeur. Sans lui
+// en revanche, tous les auditeurs derrière le proxy de production partagent
+// l'adresse de ce dernier et le compteur sature à 1 — d'où le drapeau.
+func (h *Handler) clientKey(r *http.Request) string {
+	if h.trustProxyHeaders {
+		// Premier maillon = client d'origine ; les suivants sont les proxies
+		// traversés. Caddy réécrit l'en-tête, la valeur est donc fiable ici.
+		if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
+			if first, _, found := strings.Cut(fwd, ","); found {
+				return strings.TrimSpace(first)
+			}
+			return strings.TrimSpace(fwd)
+		}
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
 }
 
 // Handler expose le domaine streaming en HTTP. ingestBaseURL sert à construire
@@ -62,6 +96,10 @@ type Handler struct {
 	ingestBaseURL string
 	sessions      StreamSessions
 	metrics       MetricsRecorder // jamais nil : noopRecorder par défaut (STR-166)
+
+	// trustProxyHeaders : cf. clientKey. Faux par défaut, activé par
+	// SetTrustProxyHeaders au démarrage quand un reverse proxy est devant.
+	trustProxyHeaders bool
 }
 
 func NewHandler(svc StreamService, ingestBaseURL string, sessions StreamSessions) *Handler {
@@ -72,6 +110,11 @@ func NewHandler(svc StreamService, ingestBaseURL string, sessions StreamSessions
 		metrics:       noopRecorder{},
 	}
 }
+
+// SetTrustProxyHeaders autorise la lecture de X-Forwarded-For pour identifier
+// les auditeurs (STR-154). Setter plutôt que paramètre de constructeur : même
+// motif que SetMetrics — c'est une donnée de déploiement, pas du domaine.
+func (h *Handler) SetTrustProxyHeaders(trust bool) { h.trustProxyHeaders = trust }
 
 // SetMetrics injecte le collecteur de métriques métier (STR-166, ADR 022).
 // Setter plutôt que paramètre de constructeur : l'observabilité est optionnelle
@@ -459,6 +502,79 @@ func (h *Handler) ListMine(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// streamStatsResponse est l'instantané d'audience d'un flux (STR-154).
+//
+// `listeners` et `peak_listeners` sont des **estimations** issues d'un suivi en
+// mémoire des requêtes de manifeste (cf. listeners.go) : elles repartent de
+// zéro au redémarrage du process et ne survivent pas à l'arrêt du flux.
+type streamStatsResponse struct {
+	StreamID        string     `json:"stream_id"`
+	Status          string     `json:"status"`
+	Listeners       int        `json:"listeners"`
+	PeakListeners   int        `json:"peak_listeners"`
+	StartedAt       *time.Time `json:"started_at"`
+	DurationSeconds int64      `json:"duration_seconds"`
+}
+
+// Stats gère GET /api/streams/{id}/stats : audience et durée d'un flux, pour
+// son tableau de bord (STR-154). Propriétaire uniquement — 404 sinon, comme
+// partout ailleurs, pour ne pas divulguer l'existence du flux.
+//
+// Un flux qui n'est pas en direct répond 200 avec des compteurs à zéro plutôt
+// qu'une erreur : le client poll pendant toute la vie de l'écran et n'a pas à
+// distinguer « pas encore démarré » de « échec ».
+func (h *Handler) Stats(w http.ResponseWriter, r *http.Request) {
+	requesterID, ok := auth.UserIDFromContext(r.Context())
+	if !ok {
+		httpjson.WriteError(w, r, apperror.Unauthorized("unauthenticated"))
+		return
+	}
+	id := r.PathValue("id")
+
+	stream, isOwner, err := h.svc.GetStream(r.Context(), id, requesterID)
+	if err != nil {
+		httpjson.WriteError(w, r, err)
+		return
+	}
+	if !isOwner {
+		httpjson.WriteError(w, r, apperror.NotFound("stream not found"))
+		return
+	}
+
+	// Absence de session = flux pas en direct : compteurs à zéro.
+	stats, _ := h.sessions.Stats(id)
+
+	if err := httpjson.Write(w, http.StatusOK, streamStatsResponse{
+		StreamID:        stream.ID,
+		Status:          stream.Status,
+		Listeners:       stats.Listeners,
+		PeakListeners:   stats.Peak,
+		StartedAt:       stream.StartedAt,
+		DurationSeconds: broadcastDuration(stream, time.Now()),
+	}); err != nil {
+		zerolog.Ctx(r.Context()).Error().Err(err).Msg("streaming: encode stats")
+	}
+}
+
+// broadcastDuration retourne la durée de diffusion en secondes : depuis
+// started_at jusqu'à maintenant si le flux est en direct, jusqu'à ended_at
+// sinon. Zéro si le flux n'a jamais démarré, ou si l'horloge donne un écart
+// négatif (started_at dans le futur).
+func broadcastDuration(s Stream, now time.Time) int64 {
+	if s.StartedAt == nil {
+		return 0
+	}
+	end := now
+	if s.Status != StatusLive && s.EndedAt != nil {
+		end = *s.EndedAt
+	}
+	elapsed := end.Sub(*s.StartedAt)
+	if elapsed < 0 {
+		return 0
+	}
+	return int64(elapsed.Seconds())
+}
+
 // Events gère GET /api/streams/{id}/events : flux SSE d'événements du direct.
 // L'abonné reçoit un event "ended" quand le diffuseur arrête le flux.
 func (h *Handler) Events(w http.ResponseWriter, r *http.Request) {
@@ -640,7 +756,17 @@ func (h *Handler) serveHLSFile(w http.ResponseWriter, r *http.Request, kind, con
 	// réellement rendu — http.ServeFile écrit l'en-tête lui-même.
 	sr := &hlsStatusRecorder{ResponseWriter: w}
 	w = sr
-	defer func() { h.metrics.RecordHLSRequest(id, kind, sr.statusText()) }()
+	defer func() {
+		h.metrics.RecordHLSRequest(id, kind, sr.statusText())
+		// Un manifeste servi = un lecteur vivant (STR-154). Seules les
+		// playlists comptent : un lecteur en récupère une régulièrement tant
+		// qu'il écoute, alors que les segments arrivent par rafales et
+		// gonfleraient le compte. Les réponses non-200 ne comptent pas : une
+		// requête refusée n'est pas un auditeur.
+		if kind == HLSKindPlaylist && sr.statusText() == "200" {
+			h.sessions.TouchListener(id, h.clientKey(r))
+		}
+	}()
 
 	// Le fichier peut ne pas exister encore (fenêtre entre le start et le premier
 	// segment, ou push dont ffmpeg n'a encore rien produit) ou avoir été retiré

--- a/backend/internal/streaming/handler.go
+++ b/backend/internal/streaming/handler.go
@@ -564,11 +564,25 @@ func broadcastDuration(s Stream, now time.Time) int64 {
 	if s.StartedAt == nil {
 		return 0
 	}
-	end := now
-	if s.Status != StatusLive && s.EndedAt != nil {
-		end = *s.EndedAt
+	if s.Status != StatusLive {
+		// Diffusion terminée sans `ended_at` : la borne manque. Compter jusqu'à
+		// maintenant ferait croître indéfiniment la durée d'un flux pourtant
+		// arrêté, à chaque poll. `ArchiveStream` pose justement `status='ended'`
+		// sans renseigner `ended_at` — inatteignable ici aujourd'hui (les flux
+		// archivés sont exclus par GetStreamByID), mais on ne s'appuie pas
+		// là-dessus.
+		if s.EndedAt == nil {
+			return 0
+		}
+		return durationBetween(*s.StartedAt, *s.EndedAt)
 	}
-	elapsed := end.Sub(*s.StartedAt)
+	return durationBetween(*s.StartedAt, now)
+}
+
+// durationBetween retourne l'écart en secondes, borné à zéro : une horloge en
+// avance (started_at dans le futur) ne doit pas produire de durée négative.
+func durationBetween(from, to time.Time) int64 {
+	elapsed := to.Sub(from)
 	if elapsed < 0 {
 		return 0
 	}

--- a/backend/internal/streaming/handler_test.go
+++ b/backend/internal/streaming/handler_test.go
@@ -853,6 +853,112 @@ func TestHandler_ListFavorites_OK(t *testing.T) {
 	}
 }
 
+func TestHandler_Stats_OwnerOK(t *testing.T) {
+	started := time.Now().Add(-2 * time.Minute)
+	stub := &stubService{
+		getOwner: true,
+		getRet: Stream{
+			ID: "s1", UserID: testUserID, Title: "Mon flux",
+			Status: StatusLive, StartedAt: &started,
+		},
+	}
+	sessions := NewLiveSessions(t.Context())
+	h := NewHandler(stub, testIngestURL, sessions)
+
+	rec := doID(t, http.MethodGet, "s1", "", http.HandlerFunc(h.Stats), true)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body)
+	}
+	body := rec.Body.String()
+	// Aucune session active : compteurs à zéro, mais la durée reste calculée
+	// depuis started_at.
+	if !strings.Contains(body, `"listeners":0`) || !strings.Contains(body, `"peak_listeners":0`) {
+		t.Errorf("compteurs attendus à zéro sans session: %s", body)
+	}
+	if !strings.Contains(body, `"duration_seconds":12`) {
+		t.Errorf("durée attendue autour de 120 s: %s", body)
+	}
+}
+
+func TestHandler_Stats_CountsListeners(t *testing.T) {
+	started := time.Now().Add(-time.Minute)
+	stub := &stubService{
+		getOwner: true,
+		getRet: Stream{
+			ID: "s1", UserID: testUserID, Status: StatusLive, StartedAt: &started,
+		},
+	}
+	sessions := NewLiveSessions(t.Context())
+	sessions.Start("s1", "KEY")
+	t.Cleanup(func() { sessions.Stop("s1") })
+	sessions.TouchListener("s1", "10.0.0.1")
+	sessions.TouchListener("s1", "10.0.0.2")
+
+	h := NewHandler(stub, testIngestURL, sessions)
+	rec := doID(t, http.MethodGet, "s1", "", http.HandlerFunc(h.Stats), true)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `"listeners":2`) || !strings.Contains(body, `"peak_listeners":2`) {
+		t.Errorf("deux auditeurs distincts attendus: %s", body)
+	}
+}
+
+func TestHandler_Stats_NotOwnerIs404(t *testing.T) {
+	// Un tiers ne doit pas apprendre l'audience d'un flux, ni même son
+	// existence : 404 et non 403.
+	stub := &stubService{
+		getOwner: false,
+		getRet:   Stream{ID: "s1", UserID: "autre", Status: StatusLive},
+	}
+	h := NewHandler(stub, testIngestURL, NewLiveSessions(t.Context()))
+
+	rec := doID(t, http.MethodGet, "s1", "", http.HandlerFunc(h.Stats), true)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d: %s", rec.Code, rec.Body)
+	}
+}
+
+func TestHandler_Stats_Unauthenticated(t *testing.T) {
+	h := NewHandler(&stubService{}, testIngestURL, NewLiveSessions(t.Context()))
+
+	rec := doID(t, http.MethodGet, "s1", "", http.HandlerFunc(h.Stats), false)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d: %s", rec.Code, rec.Body)
+	}
+}
+
+func TestHandler_ClientKey_IgnoresForwardedForByDefault(t *testing.T) {
+	// X-Forwarded-For est falsifiable : sans reverse proxy devant, le lire
+	// laisserait n'importe qui gonfler le compteur en variant sa valeur.
+	h := NewHandler(&stubService{}, testIngestURL, NewLiveSessions(t.Context()))
+	req := httptest.NewRequest(http.MethodGet, "/api/streams/s1/playlist.m3u8", nil)
+	req.RemoteAddr = "192.0.2.10:54321"
+	req.Header.Set("X-Forwarded-For", "1.2.3.4")
+
+	if got := h.clientKey(req); got != "192.0.2.10" {
+		t.Errorf("clientKey = %q, want %q", got, "192.0.2.10")
+	}
+}
+
+func TestHandler_ClientKey_UsesFirstForwardedHopWhenTrusted(t *testing.T) {
+	h := NewHandler(&stubService{}, testIngestURL, NewLiveSessions(t.Context()))
+	h.SetTrustProxyHeaders(true)
+	req := httptest.NewRequest(http.MethodGet, "/api/streams/s1/playlist.m3u8", nil)
+	req.RemoteAddr = "192.0.2.10:54321"
+	// Premier maillon = client d'origine, les suivants sont les proxies.
+	req.Header.Set("X-Forwarded-For", "1.2.3.4, 10.0.0.1")
+
+	if got := h.clientKey(req); got != "1.2.3.4" {
+		t.Errorf("clientKey = %q, want %q", got, "1.2.3.4")
+	}
+}
+
 func TestHandler_ListMine_OK(t *testing.T) {
 	stub := &stubService{listMineRet: []Stream{
 		{ID: "s1", UserID: testUserID, Title: "En direct", Status: StatusLive, IsPublic: true, StreamKey: "SECRET1"},

--- a/backend/internal/streaming/listeners.go
+++ b/backend/internal/streaming/listeners.go
@@ -1,0 +1,72 @@
+package streaming
+
+import "time"
+
+// listenerWindow est la fenêtre pendant laquelle un client reste compté comme
+// auditeur après sa dernière requête de playlist.
+//
+// HLS est sans connexion persistante : un lecteur récupère le manifeste, puis
+// les segments, et rien ne signale son départ. On ne peut donc qu'estimer
+// l'audience à partir de la fraîcheur des requêtes. La fenêtre est calée sur
+// ~3x la durée d'un segment (hlsSegmentSeconds) : un lecteur sain redemande le
+// manifeste bien plus souvent, et un lecteur parti sort du compte en une
+// demi-minute.
+const listenerWindow = 3 * hlsSegmentSeconds * time.Second
+
+// maxTrackedListeners borne la mémoire du suivi par flux. Au-delà, les
+// nouveaux clients ne sont plus enregistrés : le compteur sature au lieu de
+// laisser une diffusion très suivie — ou un attaquant qui ferait varier son
+// adresse — faire enfler la map sans limite. Le limiteur HLS_MAX_CONCURRENT
+// (STR-88) borne déjà les requêtes simultanées, ce plafond n'est qu'un filet.
+const maxTrackedListeners = 10_000
+
+// SessionStats est l'instantané d'audience d'une diffusion en cours.
+type SessionStats struct {
+	// Listeners est le nombre de clients distincts ayant demandé le manifeste
+	// dans la dernière [listenerWindow]. C'est une **estimation** : deux
+	// lecteurs derrière la même adresse comptent pour un, et un lecteur qui
+	// vient de fermer reste compté jusqu'à l'expiration de sa fenêtre.
+	Listeners int
+
+	// Peak est le maximum de [Listeners] observé depuis le début de la
+	// diffusion. Vit en mémoire : remis à zéro au redémarrage du process et
+	// perdu à l'arrêt du flux (l'historique persistant est STR-162).
+	Peak int
+}
+
+// touchListener enregistre une requête de manifeste et met à jour le pic.
+// Appelé sous le mutex de la session.
+func (s *session) touchListener(key string, now time.Time) {
+	if s.listeners == nil {
+		s.listeners = make(map[string]time.Time)
+	}
+	// Un client déjà connu est toujours rafraîchi : le plafond ne doit pas
+	// figer la fenêtre de ceux qu'on suit déjà.
+	if _, known := s.listeners[key]; !known && len(s.listeners) >= maxTrackedListeners {
+		return
+	}
+	s.listeners[key] = now
+	s.pruneListeners(now)
+	if n := len(s.listeners); n > s.peakListeners {
+		s.peakListeners = n
+	}
+}
+
+// pruneListeners retire les clients dont la dernière requête est trop ancienne.
+// Appelé sous le mutex de la session.
+func (s *session) pruneListeners(now time.Time) {
+	cutoff := now.Add(-listenerWindow)
+	for key, seen := range s.listeners {
+		if seen.Before(cutoff) {
+			delete(s.listeners, key)
+		}
+	}
+}
+
+// stats retourne l'instantané courant, après purge des clients expirés — sans
+// quoi un flux abandonné afficherait éternellement ses derniers auditeurs.
+// Appelé sous le mutex de la session.
+func (s *session) stats(now time.Time) SessionStats {
+	s.pruneListeners(now)
+	return SessionStats{Listeners: len(s.listeners), Peak: s.peakListeners}
+}

--- a/backend/internal/streaming/listeners.go
+++ b/backend/internal/streaming/listeners.go
@@ -34,8 +34,14 @@ type SessionStats struct {
 	Peak int
 }
 
-// touchListener enregistre une requête de manifeste et met à jour le pic.
-// Appelé sous le mutex de la session.
+// touchListener enregistre une requête de manifeste. Appelé sous le mutex de la
+// session, sur le chemin chaud HLS : l'opération doit rester O(1).
+//
+// La purge n'a donc PAS lieu ici. Elle coûte un balayage de toute la map, et la
+// faire à chaque manifeste sérialiserait derrière `s.mu` toutes les requêtes
+// concurrentes d'un flux très suivi. Elle est repoussée dans [stats], appelé
+// toutes les 5 s par un seul lecteur — et déclenchée en dernier recours quand le
+// plafond est atteint.
 func (s *session) touchListener(key string, now time.Time) {
 	if s.listeners == nil {
 		s.listeners = make(map[string]time.Time)
@@ -43,13 +49,15 @@ func (s *session) touchListener(key string, now time.Time) {
 	// Un client déjà connu est toujours rafraîchi : le plafond ne doit pas
 	// figer la fenêtre de ceux qu'on suit déjà.
 	if _, known := s.listeners[key]; !known && len(s.listeners) >= maxTrackedListeners {
-		return
+		// Purger AVANT d'appliquer le plafond : une map saturée d'entrées déjà
+		// expirées (churn d'adresses) rejetterait sinon un auditeur légitime,
+		// et sous-compterait l'audience jusqu'au prochain stats().
+		s.pruneListeners(now)
+		if len(s.listeners) >= maxTrackedListeners {
+			return // réellement plein : le compteur sature
+		}
 	}
 	s.listeners[key] = now
-	s.pruneListeners(now)
-	if n := len(s.listeners); n > s.peakListeners {
-		s.peakListeners = n
-	}
 }
 
 // pruneListeners retire les clients dont la dernière requête est trop ancienne.
@@ -63,10 +71,18 @@ func (s *session) pruneListeners(now time.Time) {
 	}
 }
 
-// stats retourne l'instantané courant, après purge des clients expirés — sans
-// quoi un flux abandonné afficherait éternellement ses derniers auditeurs.
+// stats purge les clients expirés puis retourne l'instantané courant — sans la
+// purge, un flux abandonné afficherait éternellement ses derniers auditeurs.
 // Appelé sous le mutex de la session.
+//
+// C'est aussi ici que le pic est mis à jour : le compte n'est exact qu'après
+// purge, et le faire à l'insertion imposerait un balayage par requête (cf.
+// [touchListener]). Conséquence assumée : le pic est celui **observé** aux
+// instants de lecture, à 5 s près, pas un maximum instantané continu.
 func (s *session) stats(now time.Time) SessionStats {
 	s.pruneListeners(now)
+	if n := len(s.listeners); n > s.peakListeners {
+		s.peakListeners = n
+	}
 	return SessionStats{Listeners: len(s.listeners), Peak: s.peakListeners}
 }

--- a/backend/internal/streaming/listeners_test.go
+++ b/backend/internal/streaming/listeners_test.go
@@ -1,6 +1,7 @@
 package streaming
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -48,6 +49,13 @@ func TestSession_Peak_SurvivesDepartures(t *testing.T) {
 	s.touchListener("b", start)
 	s.touchListener("c", start)
 
+	// Le pic est celui OBSERVÉ aux instants de lecture : il se fige au moment
+	// où l'audience est mesurée, pas à l'insertion — sans quoi chaque requête
+	// de manifeste devrait balayer toute la map (cf. touchListener).
+	if got := s.stats(start); got.Peak != 3 {
+		t.Fatalf("Peak à la mesure = %d, want 3", got.Peak)
+	}
+
 	// Tout le monde part : le compte courant retombe, le pic reste.
 	later := start.Add(listenerWindow + time.Second)
 	got := s.stats(later)
@@ -60,12 +68,68 @@ func TestSession_Peak_SurvivesDepartures(t *testing.T) {
 	}
 }
 
+func TestSession_TouchListener_DoesNotScanOnHotPath(t *testing.T) {
+	// Le chemin chaud HLS ne doit pas purger : la purge est un balayage complet
+	// sous le mutex de session, et toutes les requêtes de playlist d'un flux
+	// s'y sérialiseraient. Vérifié par l'observable : une entrée expirée reste
+	// présente tant que personne n'a lu les stats.
+	s := &session{}
+	start := time.Now()
+	s.touchListener("parti", start)
+
+	later := start.Add(listenerWindow + time.Second)
+	s.touchListener("nouveau", later)
+
+	if _, still := s.listeners["parti"]; !still {
+		t.Error("touchListener a purgé sur le chemin chaud")
+	}
+	// La lecture, elle, purge.
+	if got := s.stats(later); got.Listeners != 1 {
+		t.Errorf("après stats: Listeners = %d, want 1", got.Listeners)
+	}
+}
+
+func TestSession_CapPurgesExpiredBeforeRejecting(t *testing.T) {
+	// Une map saturée d'entrées EXPIRÉES ne doit pas faire rejeter un auditeur
+	// légitime : purger d'abord libère les créneaux morts.
+	s := &session{listeners: make(map[string]time.Time)}
+	start := time.Now()
+	for i := 0; i < maxTrackedListeners; i++ {
+		s.listeners[fmt.Sprintf("vieux-%d", i)] = start
+	}
+
+	later := start.Add(listenerWindow + time.Second)
+	s.touchListener("legitime", later)
+
+	if _, ok := s.listeners["legitime"]; !ok {
+		t.Error("auditeur légitime rejeté alors que la map était pleine d'expirés")
+	}
+}
+
+func TestSession_CapStillSaturatesWhenGenuinelyFull(t *testing.T) {
+	// Plafond atteint par des clients TOUS actifs : là, on sature pour de bon.
+	s := &session{listeners: make(map[string]time.Time)}
+	now := time.Now()
+	for i := 0; i < maxTrackedListeners; i++ {
+		s.listeners[fmt.Sprintf("actif-%d", i)] = now
+	}
+
+	s.touchListener("de-trop", now)
+
+	if _, ok := s.listeners["de-trop"]; ok {
+		t.Error("le plafond doit tenir quand tous les clients suivis sont actifs")
+	}
+	if got := len(s.listeners); got > maxTrackedListeners {
+		t.Errorf("len = %d, dépasse le plafond %d", got, maxTrackedListeners)
+	}
+}
+
 func TestSession_Listeners_Capped(t *testing.T) {
 	s := &session{}
 	now := time.Now()
 
 	for i := 0; i < maxTrackedListeners+50; i++ {
-		s.touchListener(string(rune(i))+"-client", now)
+		s.touchListener(fmt.Sprintf("client-%d", i), now)
 	}
 
 	if got := s.stats(now).Listeners; got > maxTrackedListeners {
@@ -74,16 +138,16 @@ func TestSession_Listeners_Capped(t *testing.T) {
 }
 
 func TestSession_Listeners_CapDoesNotFreezeKnownClients(t *testing.T) {
-	s := &session{}
+	s := &session{listeners: make(map[string]time.Time)}
 	start := time.Now()
-	s.listeners = make(map[string]time.Time)
 
-	// Saturer la map, puis rafraîchir un client déjà suivi : son horodatage
-	// doit être mis à jour malgré le plafond, sinon il expirerait à tort.
+	// Saturer la map de clients ACTIFS, puis rafraîchir l'un d'eux : son
+	// horodatage doit être mis à jour malgré le plafond, sinon il expirerait
+	// à tort alors qu'il écoute toujours.
 	for i := 0; i < maxTrackedListeners; i++ {
-		s.listeners[string(rune(i))+"-x"] = start
+		s.listeners[fmt.Sprintf("x-%d", i)] = start
 	}
-	known := string(rune(0)) + "-x"
+	const known = "x-0"
 
 	later := start.Add(10 * time.Second)
 	s.touchListener(known, later)

--- a/backend/internal/streaming/listeners_test.go
+++ b/backend/internal/streaming/listeners_test.go
@@ -1,0 +1,157 @@
+package streaming
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSession_TouchListener_CountsDistinctClients(t *testing.T) {
+	s := &session{}
+	now := time.Now()
+
+	s.touchListener("10.0.0.1", now)
+	s.touchListener("10.0.0.2", now)
+	s.touchListener("10.0.0.1", now) // même client : ne compte pas deux fois
+
+	got := s.stats(now)
+	if got.Listeners != 2 {
+		t.Errorf("Listeners = %d, want 2", got.Listeners)
+	}
+	if got.Peak != 2 {
+		t.Errorf("Peak = %d, want 2", got.Peak)
+	}
+}
+
+func TestSession_Listeners_ExpireAfterWindow(t *testing.T) {
+	s := &session{}
+	start := time.Now()
+
+	s.touchListener("10.0.0.1", start)
+	s.touchListener("10.0.0.2", start)
+
+	// Un seul des deux redemande le manifeste plus tard : l'autre doit sortir
+	// du compte, sans quoi un flux abandonné afficherait ses auditeurs à vie.
+	later := start.Add(listenerWindow + time.Second)
+	s.touchListener("10.0.0.1", later)
+
+	got := s.stats(later)
+	if got.Listeners != 1 {
+		t.Errorf("Listeners = %d, want 1", got.Listeners)
+	}
+}
+
+func TestSession_Peak_SurvivesDepartures(t *testing.T) {
+	s := &session{}
+	start := time.Now()
+
+	s.touchListener("a", start)
+	s.touchListener("b", start)
+	s.touchListener("c", start)
+
+	// Tout le monde part : le compte courant retombe, le pic reste.
+	later := start.Add(listenerWindow + time.Second)
+	got := s.stats(later)
+
+	if got.Listeners != 0 {
+		t.Errorf("Listeners = %d, want 0", got.Listeners)
+	}
+	if got.Peak != 3 {
+		t.Errorf("Peak = %d, want 3", got.Peak)
+	}
+}
+
+func TestSession_Listeners_Capped(t *testing.T) {
+	s := &session{}
+	now := time.Now()
+
+	for i := 0; i < maxTrackedListeners+50; i++ {
+		s.touchListener(string(rune(i))+"-client", now)
+	}
+
+	if got := s.stats(now).Listeners; got > maxTrackedListeners {
+		t.Errorf("Listeners = %d, dépasse le plafond %d", got, maxTrackedListeners)
+	}
+}
+
+func TestSession_Listeners_CapDoesNotFreezeKnownClients(t *testing.T) {
+	s := &session{}
+	start := time.Now()
+	s.listeners = make(map[string]time.Time)
+
+	// Saturer la map, puis rafraîchir un client déjà suivi : son horodatage
+	// doit être mis à jour malgré le plafond, sinon il expirerait à tort.
+	for i := 0; i < maxTrackedListeners; i++ {
+		s.listeners[string(rune(i))+"-x"] = start
+	}
+	known := string(rune(0)) + "-x"
+
+	later := start.Add(10 * time.Second)
+	s.touchListener(known, later)
+
+	if got := s.listeners[known]; !got.Equal(later) {
+		t.Errorf("client connu non rafraîchi : %v, want %v", got, later)
+	}
+}
+
+func TestLiveSessions_Stats_NoSession(t *testing.T) {
+	ls := NewLiveSessions(t.Context())
+
+	if _, ok := ls.Stats("inconnu"); ok {
+		t.Error("un flux sans session ne doit pas rapporter de stats")
+	}
+}
+
+func TestLiveSessions_TouchListener_UnknownStreamIsNoop(t *testing.T) {
+	ls := NewLiveSessions(t.Context())
+
+	// Ne doit pas paniquer ni créer d'entrée fantôme.
+	ls.TouchListener("inconnu", "10.0.0.1")
+
+	if _, ok := ls.Stats("inconnu"); ok {
+		t.Error("TouchListener ne doit pas créer de session")
+	}
+}
+
+func TestBroadcastDuration(t *testing.T) {
+	start := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	end := start.Add(90 * time.Second)
+	now := start.Add(5 * time.Minute)
+
+	tests := []struct {
+		name   string
+		stream Stream
+		want   int64
+	}{
+		{
+			name:   "jamais démarré",
+			stream: Stream{Status: StatusIdle},
+			want:   0,
+		},
+		{
+			name:   "en direct : compté jusqu'à maintenant",
+			stream: Stream{Status: StatusLive, StartedAt: &start},
+			want:   300,
+		},
+		{
+			name:   "terminé : compté jusqu'à ended_at",
+			stream: Stream{Status: StatusEnded, StartedAt: &start, EndedAt: &end},
+			want:   90,
+		},
+		{
+			name: "horloge en avance : borné à zéro",
+			stream: Stream{
+				Status:    StatusLive,
+				StartedAt: func() *time.Time { t := now.Add(time.Minute); return &t }(),
+			},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := broadcastDuration(tt.stream, now); got != tt.want {
+				t.Errorf("broadcastDuration = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/streaming/session.go
+++ b/backend/internal/streaming/session.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"sync"
+	"time"
 
 	"github.com/rs/zerolog/log"
 )
@@ -25,6 +26,11 @@ type session struct {
 	ingesting   bool          // un seul push audio à la fois
 	hls         *hlsSegmenter // publié après le spawn ; protégé par mu
 	subscribers map[chan SessionEvent]struct{}
+
+	// Suivi d'audience (STR-154) : dernière requête de manifeste par client, et
+	// pic observé. Détail du raisonnement dans listeners.go.
+	listeners     map[string]time.Time
+	peakListeners int
 }
 
 // segmenter retourne le segmenteur si la session est exploitable (segmenteur
@@ -309,6 +315,39 @@ func (ls *LiveSessions) IsLive(streamID string) bool {
 	defer ls.mu.Unlock()
 	_, ok := ls.byID[streamID]
 	return ok
+}
+
+// TouchListener enregistre qu'un client vient de demander le manifeste d'un
+// flux (STR-154). No-op si le flux n'est plus en direct.
+//
+// clientKey identifie le lecteur : HLS n'ouvre pas de connexion persistante et
+// les lecteurs natifs ne portent pas le Bearer (cf. serveHLSFile), on ne peut
+// donc pas s'appuyer sur l'identité authentifiée.
+func (ls *LiveSessions) TouchListener(streamID, clientKey string) {
+	ls.mu.Lock()
+	s, ok := ls.byID[streamID]
+	ls.mu.Unlock()
+	if !ok {
+		return
+	}
+	s.mu.Lock()
+	s.touchListener(clientKey, time.Now())
+	s.mu.Unlock()
+}
+
+// Stats retourne l'audience courante d'un flux en direct. Le second retour est
+// faux si le flux n'a pas de session active — l'appelant décide alors quoi
+// afficher (zéro plutôt qu'une erreur, cf. handler).
+func (ls *LiveSessions) Stats(streamID string) (SessionStats, bool) {
+	ls.mu.Lock()
+	s, ok := ls.byID[streamID]
+	ls.mu.Unlock()
+	if !ok {
+		return SessionStats{}, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.stats(time.Now()), true
 }
 
 // StopAll annule toutes les sessions (arrêt serveur) et libère les goroutines

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,10 @@ services:
       APP_BASE_URL: ${APP_BASE_URL:-http://localhost:8080}
       CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
       STREAM_INGEST_BASE_URL: ${STREAM_INGEST_BASE_URL:-http://localhost:8080}
+      # Comptage d'audience derrière un reverse proxy (STR-154, ADR 025).
+      # false en local ; true uniquement quand Caddy est devant, sinon le
+      # compteur d'auditeurs sature à 1.
+      TRUST_PROXY_HEADERS: ${TRUST_PROXY_HEADERS:-false}
       # LOG_PRETTY volontairement absent : en conteneur la sortie doit rester
       # du JSON pour la collecte Loki (STR-172, ADR 018).
       LOG_LEVEL: ${LOG_LEVEL:-info}

--- a/docs/adr/025-statistiques-daudience-en-temps-reel.md
+++ b/docs/adr/025-statistiques-daudience-en-temps-reel.md
@@ -39,14 +39,25 @@ souvent ; un lecteur parti sort du compte en une demi-minute.
 gonfleraient artificiellement le chiffre. Seules les réponses `200` comptent :
 une requête refusée n'est pas un auditeur.
 
-Le pic (`peak_listeners`) est le maximum observé depuis le début de la
-diffusion. Il survit aux départs mais pas à l'arrêt du flux ni au redémarrage
-du process — l'historique persistant est [STR-162](https://linear.app/streampulse/issue/STR-162).
+**La purge n'a pas lieu sur le chemin chaud.** Elle balaie toute la map, et la
+déclencher à chaque manifeste sérialiserait derrière le mutex de session toutes
+les requêtes concurrentes d'un flux très suivi — jusqu'à 10 000 entrées
+parcourues par requête. `touchListener` est donc O(1) ; la purge vit dans
+`stats()`, appelé toutes les 5 s par un seul lecteur, et en dernier recours
+quand le plafond est atteint.
 
-La map est purgée à chaque lecture et plafonnée à `maxTrackedListeners` = 10 000
-entrées : une diffusion très suivie — ou un client qui ferait varier son
-identité — ne doit pas faire enfler la mémoire sans limite. Un client déjà suivi
-reste rafraîchi malgré le plafond, sinon il expirerait à tort.
+Le pic (`peak_listeners`) est par conséquent le maximum **observé aux instants
+de lecture**, à 5 s près, et non un maximum instantané continu : le compte n'est
+exact qu'après purge. Il survit aux départs mais pas à l'arrêt du flux ni au
+redémarrage du process — l'historique persistant est
+[STR-162](https://linear.app/streampulse/issue/STR-162).
+
+La map est plafonnée à `maxTrackedListeners` = 10 000 entrées : une diffusion
+très suivie — ou un client qui ferait varier son identité — ne doit pas faire
+enfler la mémoire sans limite. Le plafond purge **avant** de rejeter : une map
+saturée d'entrées déjà expirées écarterait sinon un auditeur légitime et
+sous-compterait l'audience. Un client déjà suivi reste rafraîchi malgré le
+plafond, sinon il expirerait à tort.
 
 ### 2. Identification par adresse réseau, et le drapeau qui va avec
 
@@ -102,6 +113,17 @@ arrière-plan, comme la souscription SSE.
 d'appoint : une coupure réseau ne doit pas faire clignoter une erreur sur un
 tableau de bord par ailleurs fonctionnel. La dernière valeur connue reste
 affichée, et l'erreur de chargement de la liste garde son propre canal.
+
+La ligne d'audience est rendue **dès que le flux est en direct**, avec des
+tirets tant qu'aucune mesure n'est arrivée. La faire apparaître au premier
+relevé ferait sauter la mise en page, et elle disparaîtrait au passage en
+arrière-plan — là où la durée, elle, se contente de figer. C'est la métrique
+cœur de l'US : elle garde sa place.
+
+`duration_seconds` n'est pas repris côté mobile. Le tableau de bord affiche déjà
+la durée via un compteur local rafraîchi chaque seconde ; la valeur serveur
+n'arriverait que toutes les 5 s et ferait sauter le chronomètre. Le champ reste
+dans le contrat HTTP, où l'historique en aura besoin.
 
 ## Alternatives écartées
 

--- a/docs/adr/025-statistiques-daudience-en-temps-reel.md
+++ b/docs/adr/025-statistiques-daudience-en-temps-reel.md
@@ -1,0 +1,126 @@
+# ADR 025 — Statistiques d'audience en temps réel
+
+**Date** : 2026-08-03
+**Statut** : Accepté
+**Ticket** : [STR-154](https://linear.app/streampulse/issue/STR-154) (sous-issues [STR-158](https://linear.app/streampulse/issue/STR-158), [STR-160](https://linear.app/streampulse/issue/STR-160), [STR-161](https://linear.app/streampulse/issue/STR-161))
+
+---
+
+## Contexte
+
+US-06-02 : le diffuseur veut voir combien de personnes l'écoutent. Le tableau de
+bord livré par [ADR 024](024-tableau-de-bord-diffuseur-lancer-et-arreter-un-flux.md)
+affiche l'état et la durée d'un direct, mais aucun chiffre d'audience — le
+compteur avait été explicitement sorti du périmètre faute de source de données.
+
+Deux obstacles à lever :
+
+1. **HLS n'a pas de connexion persistante.** Un lecteur récupère un manifeste,
+   puis des segments, en requêtes HTTP indépendantes. Rien ne signale son
+   arrivée, rien ne signale son départ. Il n'existe donc pas de « nombre
+   d'auditeurs connectés » à lire quelque part — seulement à estimer.
+2. **La seule mesure existante vit dans Prometheus.**
+   [ADR 022](022-metriques-metier-streaming-et-panel-live.md) dérive une
+   estimation (`rate(playlist 200)[2m] × 10`) pour un panel Grafana, mais
+   `/metrics` est bloqué par Caddy en production et coupler le client mobile à
+   la stack d'observabilité serait une inversion de dépendance.
+
+## Décision
+
+### 1. Fenêtre glissante en mémoire, dans la session
+
+Chaque session live tient une map `clientKey → dernière requête de manifeste`.
+Un client compte comme auditeur tant que sa dernière requête a moins de
+`listenerWindow` = **30 s**, soit trois fois la durée d'un segment
+(`hlsSegmentSeconds = 10`). Un lecteur sain redemande le manifeste bien plus
+souvent ; un lecteur parti sort du compte en une demi-minute.
+
+**Seules les playlists comptent.** Les segments arrivent par rafales et
+gonfleraient artificiellement le chiffre. Seules les réponses `200` comptent :
+une requête refusée n'est pas un auditeur.
+
+Le pic (`peak_listeners`) est le maximum observé depuis le début de la
+diffusion. Il survit aux départs mais pas à l'arrêt du flux ni au redémarrage
+du process — l'historique persistant est [STR-162](https://linear.app/streampulse/issue/STR-162).
+
+La map est purgée à chaque lecture et plafonnée à `maxTrackedListeners` = 10 000
+entrées : une diffusion très suivie — ou un client qui ferait varier son
+identité — ne doit pas faire enfler la mémoire sans limite. Un client déjà suivi
+reste rafraîchi malgré le plafond, sinon il expirerait à tort.
+
+### 2. Identification par adresse réseau, et le drapeau qui va avec
+
+`clientKey` est l'adresse du client. C'est le seul discriminant disponible : les
+lecteurs natifs (AVPlayer, ExoPlayer) ne portent pas le `Bearer` — c'est déjà
+pourquoi les routes HLS sont en `OptionalAuth` — et rien d'autre dans la requête
+n'est stable.
+
+Conséquences assumées : deux lecteurs derrière la même IP publique comptent pour
+un, et un client qui change d'adresse compte double le temps que sa fenêtre
+expire. D'où le vocabulaire retenu partout, jusque dans l'interface :
+**« auditeurs estimés »**, jamais « connectés ».
+
+Le point délicat est `X-Forwarded-For`. L'en-tête est falsifiable : le lire sans
+condition laisserait n'importe qui gonfler le compteur d'un flux en variant sa
+valeur. Mais l'ignorer rend la fonctionnalité vide de sens en production, où
+tous les auditeurs traversent Caddy et partagent donc son adresse — le compteur
+saturerait à 1.
+
+Retenu : un drapeau `TRUST_PROXY_HEADERS`, **faux par défaut**. Activé, le
+premier maillon de `X-Forwarded-For` fait foi ; désactivé, on s'en tient à
+`RemoteAddr`. C'est une donnée de déploiement, pas de domaine, injectée par
+`SetTrustProxyHeaders` au démarrage — même motif que `SetMetrics`.
+
+> **À faire au déploiement** : poser `TRUST_PROXY_HEADERS=true` sur le VPS.
+> Sans lui, la statistique affichera 1 auditeur quoi qu'il arrive.
+
+### 3. `GET /api/streams/{id}/stats`, propriétaire uniquement
+
+Réservé au propriétaire du flux, **404 pour un tiers** — jamais 403 : l'audience
+d'un flux ne doit pas être devinable, ni même son existence. Cohérent avec le
+reste du domaine.
+
+Un flux qui n'est pas en direct répond `200` avec des compteurs à zéro plutôt
+qu'une erreur : le client interroge l'endpoint pendant toute la vie de l'écran
+et n'a pas à distinguer « pas encore démarré » de « échec ».
+
+`duration_seconds` est calculée côté serveur — depuis `started_at` jusqu'à
+maintenant tant que le flux est live, jusqu'à `ended_at` ensuite — et bornée à
+zéro : une horloge en avance ne doit pas produire de durée négative.
+
+### 4. Interrogation toutes les 5 secondes, échecs silencieux
+
+Le mobile interroge l'endpoint toutes les **5 s** tant qu'un flux est en direct,
+cadence imposée par l'AC. La première mesure part immédiatement à l'armement :
+attendre 5 s laisserait la carte sans chiffre juste après le démarrage, au
+moment précis où le diffuseur la regarde.
+
+Les mesures s'arrêtent quand le direct s'arrête et quand l'écran passe en
+arrière-plan, comme la souscription SSE.
+
+**Un échec de mesure est ignoré volontairement.** L'audience est une information
+d'appoint : une coupure réseau ne doit pas faire clignoter une erreur sur un
+tableau de bord par ailleurs fonctionnel. La dernière valeur connue reste
+affichée, et l'erreur de chargement de la liste garde son propre canal.
+
+## Alternatives écartées
+
+- **Interroger l'API Prometheus depuis le mobile** : `/metrics` est bloqué en
+  production, et cela coupleraient le client à la stack d'observabilité.
+- **Compter les segments plutôt que les manifestes** : les segments arrivent par
+  rafales, le chiffre suivrait le débit, pas l'audience.
+- **Identifiant de lecture généré par le client** (query sur la playlist) :
+  indépendant du réseau et insensible au NAT, mais ne compterait aucun lecteur
+  tiers (VLC, ffplay, navigateur) et se falsifie tout aussi facilement.
+- **Persister l'audience en base** : nécessaire pour l'historique
+  ([STR-162](https://linear.app/streampulse/issue/STR-162)), inutile pour du
+  temps réel, et coûteux en écritures à 5 s d'intervalle.
+
+## Conséquences
+
+- L'audience est **une estimation**, et le mot apparaît dans l'interface. Y
+  attacher un engagement chiffré serait une erreur.
+- Les compteurs repartent de zéro à chaque redémarrage de l'API et à chaque
+  arrêt de flux : ce ne sont pas des données d'analytique.
+- Derrière un reverse proxy sans `TRUST_PROXY_HEADERS`, le chiffre est
+  inexploitable. C'est la seule configuration à ne pas oublier.

--- a/mobile/lib/features/broadcast/data/datasources/broadcast_remote_data_source.dart
+++ b/mobile/lib/features/broadcast/data/datasources/broadcast_remote_data_source.dart
@@ -77,4 +77,14 @@ class BroadcastRemoteDataSource {
       throw mapDioException(e);
     }
   }
+
+  /// `GET /api/streams/{id}/stats` — audience courante, propriétaire seul.
+  Future<StreamStatsResponse> streamStats(String id) async {
+    try {
+      final response = await _api.getStreamStats(id: id);
+      return response.data ?? (throw const ServerException(_emptyBody));
+    } on DioException catch (e) {
+      throw mapDioException(e);
+    }
+  }
 }

--- a/mobile/lib/features/broadcast/data/mappers/broadcast_dto_mappers.dart
+++ b/mobile/lib/features/broadcast/data/mappers/broadcast_dto_mappers.dart
@@ -1,5 +1,6 @@
 import 'package:streampulse_api/streampulse_api.dart';
 
+import '../../domain/entities/broadcast_stats.dart';
 import '../../domain/entities/broadcast_stream.dart';
 
 /// Conversion du DTO généré vers l'entité domaine : le type généré ne franchit
@@ -16,6 +17,15 @@ extension StreamResponseBroadcastMapper on StreamResponse {
         startedAt: startedAt,
         streamKey: streamKey,
         streamSourceUrl: streamSourceUrl,
+      );
+}
+
+extension StreamStatsResponseMapper on StreamStatsResponse {
+  BroadcastStats toEntity() => BroadcastStats(
+        streamId: streamId,
+        listeners: listeners,
+        peak: peakListeners,
+        duration: Duration(seconds: durationSeconds),
       );
 }
 

--- a/mobile/lib/features/broadcast/data/mappers/broadcast_dto_mappers.dart
+++ b/mobile/lib/features/broadcast/data/mappers/broadcast_dto_mappers.dart
@@ -21,11 +21,11 @@ extension StreamResponseBroadcastMapper on StreamResponse {
 }
 
 extension StreamStatsResponseMapper on StreamStatsResponse {
+  /// `durationSeconds` du DTO n'est pas repris : cf. [BroadcastStats].
   BroadcastStats toEntity() => BroadcastStats(
         streamId: streamId,
         listeners: listeners,
         peak: peakListeners,
-        duration: Duration(seconds: durationSeconds),
       );
 }
 

--- a/mobile/lib/features/broadcast/data/repositories/broadcast_repository_impl.dart
+++ b/mobile/lib/features/broadcast/data/repositories/broadcast_repository_impl.dart
@@ -1,3 +1,4 @@
+import '../../domain/entities/broadcast_stats.dart';
 import '../../domain/entities/broadcast_stream.dart';
 import '../../domain/repositories/broadcast_repository.dart';
 import '../datasources/broadcast_remote_data_source.dart';
@@ -47,4 +48,10 @@ class BroadcastRepositoryImpl implements BroadcastRepository {
 
   @override
   Future<void> deleteStream(String id) => _remote.deleteStream(id);
+
+  @override
+  Future<BroadcastStats> streamStats(String id) async {
+    final dto = await _remote.streamStats(id);
+    return dto.toEntity();
+  }
 }

--- a/mobile/lib/features/broadcast/domain/entities/broadcast_stats.dart
+++ b/mobile/lib/features/broadcast/domain/entities/broadcast_stats.dart
@@ -12,22 +12,28 @@ class BroadcastStats {
     required this.streamId,
     required this.listeners,
     required this.peak,
-    required this.duration,
   });
 
   final String streamId;
   final int listeners;
+
+  /// Maximum d'auditeurs observé depuis le début de la diffusion. **Tout aussi
+  /// estimé** que [listeners] : il dérive exactement des mêmes mesures.
   final int peak;
 
-  /// Durée de diffusion : depuis le démarrage jusqu'à maintenant tant que le
-  /// flux est en direct, jusqu'à son arrêt ensuite.
-  final Duration duration;
+  /// `duration_seconds` de l'API n'est volontairement pas repris ici : le
+  /// tableau de bord affiche déjà la durée du direct via un compteur local
+  /// rafraîchi chaque seconde, alors que la valeur serveur n'arriverait que
+  /// toutes les 5 s et ferait sauter le chronomètre. Le champ reste dans le
+  /// contrat HTTP, où l'historique (STR-162) en aura besoin.
 
-  /// Instantané vide, affiché tant qu'aucune mesure n'est arrivée.
-  static const empty = BroadcastStats(
-    streamId: '',
-    listeners: 0,
-    peak: 0,
-    duration: Duration.zero,
-  );
+  @override
+  bool operator ==(Object other) =>
+      other is BroadcastStats &&
+      other.streamId == streamId &&
+      other.listeners == listeners &&
+      other.peak == peak;
+
+  @override
+  int get hashCode => Object.hash(streamId, listeners, peak);
 }

--- a/mobile/lib/features/broadcast/domain/entities/broadcast_stats.dart
+++ b/mobile/lib/features/broadcast/domain/entities/broadcast_stats.dart
@@ -1,0 +1,33 @@
+/// Audience d'une diffusion, telle que rendue par `GET /api/streams/{id}/stats`
+/// (US-06-02, STR-154).
+///
+/// [listeners] et [peak] sont des **estimations** : HLS n'ouvre pas de connexion
+/// persistante, le serveur compte donc les clients ayant demandé le manifeste
+/// récemment. Deux lecteurs derrière la même adresse publique comptent pour un,
+/// et un lecteur qui vient de fermer reste compté quelques dizaines de secondes.
+/// Les deux valeurs vivent en mémoire côté serveur : elles repartent de zéro au
+/// redémarrage et ne survivent pas à la fin de la diffusion.
+class BroadcastStats {
+  const BroadcastStats({
+    required this.streamId,
+    required this.listeners,
+    required this.peak,
+    required this.duration,
+  });
+
+  final String streamId;
+  final int listeners;
+  final int peak;
+
+  /// Durée de diffusion : depuis le démarrage jusqu'à maintenant tant que le
+  /// flux est en direct, jusqu'à son arrêt ensuite.
+  final Duration duration;
+
+  /// Instantané vide, affiché tant qu'aucune mesure n'est arrivée.
+  static const empty = BroadcastStats(
+    streamId: '',
+    listeners: 0,
+    peak: 0,
+    duration: Duration.zero,
+  );
+}

--- a/mobile/lib/features/broadcast/domain/repositories/broadcast_repository.dart
+++ b/mobile/lib/features/broadcast/domain/repositories/broadcast_repository.dart
@@ -1,3 +1,4 @@
+import '../entities/broadcast_stats.dart';
 import '../entities/broadcast_stream.dart';
 
 /// Contrat de la couche données du tableau de bord diffuseur (US-06-01).
@@ -34,4 +35,8 @@ abstract class BroadcastRepository {
   /// en direct est terminé au passage par le backend — l'écran doit donc
   /// prévenir l'utilisateur avant d'appeler ceci sur un direct.
   Future<void> deleteStream(String id);
+
+  /// Audience courante du flux (US-06-02). Un flux qui n'est pas en direct
+  /// répond avec des compteurs à zéro, pas une erreur.
+  Future<BroadcastStats> streamStats(String id);
 }

--- a/mobile/lib/features/broadcast/presentation/providers/broadcast_notifier.dart
+++ b/mobile/lib/features/broadcast/presentation/providers/broadcast_notifier.dart
@@ -308,6 +308,10 @@ class BroadcastNotifier extends ChangeNotifier {
     try {
       final stats = await _repository.streamStats(id);
       if (_disposed || _statsStreamId != id) return; // flux changé entre-temps
+      // Ne notifier que sur changement réel : l'audience bouge rarement entre
+      // deux mesures, inutile de reconstruire l'écran toutes les 5 s pour
+      // réafficher les mêmes chiffres.
+      if (_stats == stats) return;
       _stats = stats;
       _safeNotify();
     } catch (_) {

--- a/mobile/lib/features/broadcast/presentation/providers/broadcast_notifier.dart
+++ b/mobile/lib/features/broadcast/presentation/providers/broadcast_notifier.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import '../../../../core/constants/api_constants.dart';
 import '../../../../core/errors/exceptions.dart';
 import '../../../../core/network/sse_client.dart';
+import '../../domain/entities/broadcast_stats.dart';
 import '../../domain/entities/broadcast_stream.dart';
 import '../../domain/repositories/broadcast_repository.dart';
 
@@ -30,9 +31,11 @@ class BroadcastNotifier extends ChangeNotifier {
     SseConnector? sse,
     Duration Function(int attempt)? backoff,
     Duration pollInterval = const Duration(seconds: 15),
+    Duration statsInterval = const Duration(seconds: 5),
   })  : _sse = sse,
         _backoff = backoff ?? _defaultBackoff,
-        _pollInterval = pollInterval;
+        _pollInterval = pollInterval,
+        _statsInterval = statsInterval;
 
   final BroadcastRepository _repository;
 
@@ -43,6 +46,10 @@ class BroadcastNotifier extends ChangeNotifier {
   final SseConnector? _sse;
   final Duration Function(int attempt) _backoff;
   final Duration _pollInterval;
+
+  /// Cadence des statistiques d'audience. 5 s : c'est la fréquence de mise à
+  /// jour demandée par l'AC de l'US-06-02.
+  final Duration _statsInterval;
 
   List<BroadcastStream> _streams = const [];
   bool _loading = false;
@@ -64,6 +71,9 @@ class BroadcastNotifier extends ChangeNotifier {
   StreamSubscription<SseEvent>? _sseSubscription;
   Timer? _reconnectTimer;
   Timer? _pollTimer;
+  Timer? _statsTimer;
+  BroadcastStats? _stats;
+  String? _statsStreamId;
   String? _sseStreamId;
   int _reconnectAttempt = 0;
 
@@ -99,6 +109,10 @@ class BroadcastNotifier extends ChangeNotifier {
   }
 
   bool get hasLiveStream => liveStream != null;
+
+  /// Audience du direct en cours, ou null tant qu'aucune mesure n'est arrivée
+  /// (ou si aucun flux n'est en direct). Rafraîchie toutes les [_statsInterval].
+  BroadcastStats? get stats => _stats;
 
   /// (Re)charge les flux du diffuseur.
   /// `reset: true` vide la liste avant le fetch ; `reset: false` la conserve
@@ -235,6 +249,7 @@ class BroadcastNotifier extends ChangeNotifier {
   /// sens que sur un flux en direct (l'endpoint SSE répond 409 sinon).
   void _syncSubscription() {
     final live = liveStream;
+    _syncStats(live);
     if (!_active || live == null) {
       _cancelSubscription();
       _cancelPolling();
@@ -263,6 +278,51 @@ class BroadcastNotifier extends ChangeNotifier {
   void _cancelPolling() {
     _pollTimer?.cancel();
     _pollTimer = null;
+  }
+
+  /// Arme, réarme ou coupe la remontée d'audience selon le direct en cours.
+  /// Distincte du repli SSE : elle tourne sur toutes les plateformes, et à une
+  /// cadence propre (5 s) imposée par l'AC.
+  void _syncStats(BroadcastStream? live) {
+    if (!_active || live == null) {
+      _cancelStats();
+      return;
+    }
+    if (_statsStreamId == live.id && _statsTimer != null) return;
+    _cancelStats();
+    _statsStreamId = live.id;
+    // Première mesure tout de suite : attendre 5 s laisserait la carte sans
+    // chiffre juste après le démarrage, au moment où on la regarde le plus.
+    unawaited(_fetchStats());
+    _statsTimer =
+        Timer.periodic(_statsInterval, (_) => unawaited(_fetchStats()));
+  }
+
+  /// Récupère l'audience. Un échec est ignoré volontairement : l'audience est
+  /// une information d'appoint, une coupure réseau ne doit pas faire clignoter
+  /// une erreur sur un tableau de bord par ailleurs fonctionnel. La dernière
+  /// valeur connue reste affichée.
+  Future<void> _fetchStats() async {
+    final id = _statsStreamId;
+    if (id == null) return;
+    try {
+      final stats = await _repository.streamStats(id);
+      if (_disposed || _statsStreamId != id) return; // flux changé entre-temps
+      _stats = stats;
+      _safeNotify();
+    } catch (_) {
+      // Silencieux : cf. doc ci-dessus.
+    }
+  }
+
+  void _cancelStats() {
+    _statsTimer?.cancel();
+    _statsTimer = null;
+    _statsStreamId = null;
+    if (_stats != null) {
+      _stats = null;
+      _safeNotify();
+    }
   }
 
   void _openSubscription() {
@@ -368,6 +428,7 @@ class BroadcastNotifier extends ChangeNotifier {
     _disposed = true;
     _cancelSubscription();
     _cancelPolling();
+    _statsTimer?.cancel();
     super.dispose();
   }
 }

--- a/mobile/lib/features/broadcast/presentation/screens/dashboard_screen.dart
+++ b/mobile/lib/features/broadcast/presentation/screens/dashboard_screen.dart
@@ -14,6 +14,7 @@ import '../../../auth/presentation/widgets/auth_toasts.dart';
 import '../../../profile/presentation/providers/profile_controller.dart';
 import '../../data/datasources/broadcast_remote_data_source.dart';
 import '../../data/repositories/broadcast_repository_impl.dart';
+import '../../domain/entities/broadcast_stats.dart';
 import '../../domain/entities/broadcast_stream.dart';
 import '../../domain/repositories/broadcast_repository.dart';
 import '../providers/broadcast_notifier.dart';
@@ -400,6 +401,8 @@ class _DashboardBodyState extends State<_DashboardBody>
           // partirait sur un état périmé.
           otherMutationInFlight:
               notifier.isMutating && notifier.mutatingId != stream.id,
+          // L'audience ne concerne que le direct en cours.
+          stats: stream.isLive ? notifier.stats : null,
           onStart: () => _onStart(stream),
           onStop: () => _onStop(stream),
           onDelete: () => _onDelete(stream),
@@ -415,6 +418,7 @@ class _StreamCard extends StatelessWidget {
     required this.blockedByOtherLive,
     required this.mutating,
     required this.otherMutationInFlight,
+    required this.stats,
     required this.onStart,
     required this.onStop,
     required this.onDelete,
@@ -424,6 +428,10 @@ class _StreamCard extends StatelessWidget {
   final bool blockedByOtherLive;
   final bool mutating;
   final bool otherMutationInFlight;
+
+  /// Audience du direct, ou null si le flux n'est pas en direct ou si aucune
+  /// mesure n'est encore arrivée.
+  final BroadcastStats? stats;
   final VoidCallback onStart;
   final VoidCallback onStop;
   final VoidCallback onDelete;
@@ -511,6 +519,10 @@ class _StreamCard extends StatelessWidget {
                 ],
               ],
             ),
+            if (stats != null) ...[
+              const SizedBox(height: 12),
+              _AudienceRow(streamId: stream.id, stats: stats!),
+            ],
             // Rien à pousser sur un flux terminé : la clé y est inutilisable
             // (le backend n'autorise que idle -> live). L'afficher n'apporterait
             // que du bruit et exposerait un secret pour rien.
@@ -565,6 +577,55 @@ class _StreamCard extends StatelessWidget {
             ],
           ],
         ),
+      ),
+    );
+  }
+}
+
+/// Audience du direct : auditeurs connectés et pic depuis le démarrage.
+///
+/// Le libellé reste volontairement prudent — « estimé » — parce que le compte
+/// l'est réellement : HLS n'a pas de connexion persistante, deux lecteurs
+/// derrière la même adresse publique comptent pour un, et un auditeur parti met
+/// quelques dizaines de secondes à disparaître (cf. ADR 025).
+class _AudienceRow extends StatelessWidget {
+  const _AudienceRow({required this.streamId, required this.stats});
+
+  final String streamId;
+  final BroadcastStats stats;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    final text = Theme.of(context).textTheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: colors.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.headphones_outlined, size: 18, color: colors.primary),
+          const SizedBox(width: 8),
+          Text(
+            key: Key('dashboard_listeners_$streamId'),
+            '${stats.listeners}',
+            style: text.titleMedium?.copyWith(color: colors.primary),
+          ),
+          const SizedBox(width: 6),
+          Text(
+            stats.listeners > 1 ? 'auditeurs estimés' : 'auditeur estimé',
+            style: text.bodySmall?.copyWith(color: colors.onSurfaceVariant),
+          ),
+          const Spacer(),
+          Text(
+            key: Key('dashboard_peak_$streamId'),
+            'pic ${stats.peak}',
+            style: text.bodySmall?.copyWith(color: colors.onSurfaceVariant),
+          ),
+        ],
       ),
     );
   }

--- a/mobile/lib/features/broadcast/presentation/screens/dashboard_screen.dart
+++ b/mobile/lib/features/broadcast/presentation/screens/dashboard_screen.dart
@@ -519,9 +519,14 @@ class _StreamCard extends StatelessWidget {
                 ],
               ],
             ),
-            if (stats != null) ...[
+            // Présente dès que le flux est en direct, même sans mesure : la
+            // faire apparaître au premier fetch ferait sauter la mise en page,
+            // et `_cancelStats()` la ferait disparaître au passage en
+            // arrière-plan. C'est la métrique cœur de l'US, elle reste à sa
+            // place et affiche « — » en attendant.
+            if (stream.isLive) ...[
               const SizedBox(height: 12),
-              _AudienceRow(streamId: stream.id, stats: stats!),
+              _AudienceRow(streamId: stream.id, stats: stats),
             ],
             // Rien à pousser sur un flux terminé : la clé y est inutilisable
             // (le backend n'autorise que idle -> live). L'afficher n'apporterait
@@ -592,40 +597,62 @@ class _AudienceRow extends StatelessWidget {
   const _AudienceRow({required this.streamId, required this.stats});
 
   final String streamId;
-  final BroadcastStats stats;
+
+  /// Null tant qu'aucune mesure n'est arrivée, ou pendant un passage en
+  /// arrière-plan : la ligne reste alors affichée avec des tirets.
+  final BroadcastStats? stats;
+
+  static const String _explanation =
+      'Estimation basée sur les requêtes récentes : deux auditeurs derrière '
+      'la même connexion comptent pour un, et un auditeur parti met une '
+      'demi-minute à disparaître.';
 
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).colorScheme;
     final text = Theme.of(context).textTheme;
+    final measured = stats;
 
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-      decoration: BoxDecoration(
-        color: colors.surfaceContainerHighest,
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Row(
-        children: [
-          Icon(Icons.headphones_outlined, size: 18, color: colors.primary),
-          const SizedBox(width: 8),
-          Text(
-            key: Key('dashboard_listeners_$streamId'),
-            '${stats.listeners}',
-            style: text.titleMedium?.copyWith(color: colors.primary),
-          ),
-          const SizedBox(width: 6),
-          Text(
-            stats.listeners > 1 ? 'auditeurs estimés' : 'auditeur estimé',
-            style: text.bodySmall?.copyWith(color: colors.onSurfaceVariant),
-          ),
-          const Spacer(),
-          Text(
-            key: Key('dashboard_peak_$streamId'),
-            'pic ${stats.peak}',
-            style: text.bodySmall?.copyWith(color: colors.onSurfaceVariant),
-          ),
-        ],
+    // Le pic dérive exactement des mêmes mesures que le compteur courant : il
+    // est tout aussi estimé, et le libellé ne doit pas laisser croire l'inverse.
+    return Tooltip(
+      message: _explanation,
+      triggerMode: TooltipTriggerMode.tap,
+      showDuration: const Duration(seconds: 6),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        decoration: BoxDecoration(
+          color: colors.surfaceContainerHighest,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Row(
+          children: [
+            Icon(Icons.headphones_outlined, size: 18, color: colors.primary),
+            const SizedBox(width: 8),
+            Text(
+              key: Key('dashboard_listeners_$streamId'),
+              measured == null ? '—' : '${measured.listeners}',
+              style: text.titleMedium?.copyWith(color: colors.primary),
+            ),
+            const SizedBox(width: 6),
+            Text(
+              measured != null && measured.listeners > 1
+                  ? 'auditeurs estimés'
+                  : 'auditeur estimé',
+              style: text.bodySmall?.copyWith(color: colors.onSurfaceVariant),
+            ),
+            const Spacer(),
+            Icon(Icons.trending_up, size: 14, color: colors.onSurfaceVariant),
+            const SizedBox(width: 4),
+            Text(
+              key: Key('dashboard_peak_$streamId'),
+              measured == null ? 'Pic : —' : 'Pic : ${measured.peak}',
+              style: text.bodySmall?.copyWith(color: colors.onSurfaceVariant),
+            ),
+            const SizedBox(width: 6),
+            Icon(Icons.info_outline, size: 14, color: colors.onSurfaceVariant),
+          ],
+        ),
       ),
     );
   }

--- a/mobile/packages/streampulse_api/.openapi-generator/FILES
+++ b/mobile/packages/streampulse_api/.openapi-generator/FILES
@@ -41,6 +41,7 @@ lib/src/model/reset_password_request.dart
 lib/src/model/review_request_input.dart
 lib/src/model/set_user_active_request.dart
 lib/src/model/stream_response.dart
+lib/src/model/stream_stats_response.dart
 lib/src/model/stream_summary_response.dart
 lib/src/model/token_pair_response.dart
 lib/src/model/update_profile_request.dart

--- a/mobile/packages/streampulse_api/README.md
+++ b/mobile/packages/streampulse_api/README.md
@@ -90,6 +90,7 @@ Class | Method | HTTP request | Description
 [*StreamingApi*](doc/StreamingApi.md) | [**createStream**](doc/StreamingApi.md#createstream) | **POST** /api/streams | Create and configure a new live stream (broadcaster only).
 [*StreamingApi*](doc/StreamingApi.md) | [**deleteStream**](doc/StreamingApi.md#deletestream) | **DELETE** /api/streams/{id} | Delete (archive) a stream (owner only).
 [*StreamingApi*](doc/StreamingApi.md) | [**getStream**](doc/StreamingApi.md#getstream) | **GET** /api/streams/{id} | Get a stream by id.
+[*StreamingApi*](doc/StreamingApi.md) | [**getStreamStats**](doc/StreamingApi.md#getstreamstats) | **GET** /api/streams/{id}/stats | Live audience statistics for the caller&#39;s own stream.
 [*StreamingApi*](doc/StreamingApi.md) | [**ingestStream**](doc/StreamingApi.md#ingeststream) | **POST** /api/streams/ingest/{stream_key} | Push a live audio stream (broadcaster ingest).
 [*StreamingApi*](doc/StreamingApi.md) | [**listMyFavorites**](doc/StreamingApi.md#listmyfavorites) | **GET** /api/users/me/favorites | List the authenticated user&#39;s favorite streams.
 [*StreamingApi*](doc/StreamingApi.md) | [**listMyStreams**](doc/StreamingApi.md#listmystreams) | **GET** /api/users/me/streams | List the authenticated user&#39;s own streams (broadcaster dashboard).
@@ -129,6 +130,7 @@ Class | Method | HTTP request | Description
  - [ReviewRequestInput](doc/ReviewRequestInput.md)
  - [SetUserActiveRequest](doc/SetUserActiveRequest.md)
  - [StreamResponse](doc/StreamResponse.md)
+ - [StreamStatsResponse](doc/StreamStatsResponse.md)
  - [StreamSummaryResponse](doc/StreamSummaryResponse.md)
  - [TokenPairResponse](doc/TokenPairResponse.md)
  - [UpdateProfileRequest](doc/UpdateProfileRequest.md)

--- a/mobile/packages/streampulse_api/lib/src/api/streaming_api.dart
+++ b/mobile/packages/streampulse_api/lib/src/api/streaming_api.dart
@@ -13,6 +13,7 @@ import 'dart:typed_data';
 import 'package:streampulse_api/src/model/create_stream_request.dart';
 import 'package:streampulse_api/src/model/error_response.dart';
 import 'package:streampulse_api/src/model/stream_response.dart';
+import 'package:streampulse_api/src/model/stream_stats_response.dart';
 import 'package:streampulse_api/src/model/stream_summary_response.dart';
 
 class StreamingApi {
@@ -287,6 +288,88 @@ class StreamingApi {
     }
 
     return Response<StreamResponse>(
+      data: _responseData,
+      headers: _response.headers,
+      isRedirect: _response.isRedirect,
+      requestOptions: _response.requestOptions,
+      redirects: _response.redirects,
+      statusCode: _response.statusCode,
+      statusMessage: _response.statusMessage,
+      extra: _response.extra,
+    );
+  }
+
+  /// Live audience statistics for the caller&#39;s own stream.
+  /// Returns the current audience of a stream the caller owns. A stream that is not live answers 200 with zeroed counters rather than an error, so a polling client has no special case to handle. A stream owned by someone else answers 404, never 403 — its very existence stays private.  &#x60;listeners&#x60; and &#x60;peak_listeners&#x60; are ESTIMATES. HLS has no persistent connection, so a client counts as a listener while it has fetched the manifest recently; two players behind one public address count as one. Both values live in memory: they reset when the process restarts and do not survive the end of the broadcast.
+  ///
+  /// Parameters:
+  /// * [id]
+  /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
+  /// * [headers] - Can be used to add additional headers to the request
+  /// * [extras] - Can be used to add flags to the request
+  /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
+  /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
+  /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
+  ///
+  /// Returns a [Future] containing a [Response] with a [StreamStatsResponse] as data
+  /// Throws [DioException] if API call or serialization fails
+  Future<Response<StreamStatsResponse>> getStreamStats({
+    required String id,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    final _path = r'/api/streams/{id}/stats'.replaceAll(
+      '{'
+      r'id'
+      '}',
+      id.toString(),
+    );
+    final _options = Options(
+      method: r'GET',
+      headers: <String, dynamic>{...?headers},
+      extra: <String, dynamic>{
+        'secure': <Map<String, String>>[
+          {'type': 'http', 'scheme': 'bearer', 'name': 'bearerAuth'},
+        ],
+        ...?extra,
+      },
+      validateStatus: validateStatus,
+    );
+
+    final _response = await _dio.request<Object>(
+      _path,
+      options: _options,
+      cancelToken: cancelToken,
+      onSendProgress: onSendProgress,
+      onReceiveProgress: onReceiveProgress,
+    );
+
+    StreamStatsResponse? _responseData;
+
+    try {
+      final rawData = _response.data;
+      _responseData = rawData == null
+          ? null
+          : deserialize<StreamStatsResponse, StreamStatsResponse>(
+              rawData,
+              'StreamStatsResponse',
+              growable: true,
+            );
+    } catch (error, stackTrace) {
+      throw DioException(
+        requestOptions: _response.requestOptions,
+        response: _response,
+        type: DioExceptionType.unknown,
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+
+    return Response<StreamStatsResponse>(
       data: _responseData,
       headers: _response.headers,
       isRedirect: _response.isRedirect,

--- a/mobile/packages/streampulse_api/lib/src/deserialize.dart
+++ b/mobile/packages/streampulse_api/lib/src/deserialize.dart
@@ -22,6 +22,7 @@ import 'package:streampulse_api/src/model/reset_password_request.dart';
 import 'package:streampulse_api/src/model/review_request_input.dart';
 import 'package:streampulse_api/src/model/set_user_active_request.dart';
 import 'package:streampulse_api/src/model/stream_response.dart';
+import 'package:streampulse_api/src/model/stream_stats_response.dart';
 import 'package:streampulse_api/src/model/stream_summary_response.dart';
 import 'package:streampulse_api/src/model/token_pair_response.dart';
 import 'package:streampulse_api/src/model/update_profile_request.dart';
@@ -120,6 +121,9 @@ ReturnType deserialize<ReturnType, BaseType>(
           as ReturnType;
     case 'StreamResponse':
       return StreamResponse.fromJson(value as Map<String, dynamic>)
+          as ReturnType;
+    case 'StreamStatsResponse':
+      return StreamStatsResponse.fromJson(value as Map<String, dynamic>)
           as ReturnType;
     case 'StreamSummaryResponse':
       return StreamSummaryResponse.fromJson(value as Map<String, dynamic>)

--- a/mobile/packages/streampulse_api/lib/src/model/stream_stats_response.dart
+++ b/mobile/packages/streampulse_api/lib/src/model/stream_stats_response.dart
@@ -1,0 +1,98 @@
+//
+// AUTO-GENERATED FILE, DO NOT MODIFY!
+//
+
+// ignore_for_file: unused_element
+import 'package:json_annotation/json_annotation.dart';
+
+part 'stream_stats_response.g.dart';
+
+@JsonSerializable(
+  checked: true,
+  createToJson: true,
+  disallowUnrecognizedKeys: false,
+  explicitToJson: true,
+)
+class StreamStatsResponse {
+  /// Returns a new [StreamStatsResponse] instance.
+  StreamStatsResponse({
+    required this.streamId,
+
+    required this.status,
+
+    required this.listeners,
+
+    required this.peakListeners,
+
+    this.startedAt,
+
+    required this.durationSeconds,
+  });
+
+  @JsonKey(name: r'stream_id', required: true, includeIfNull: false)
+  final String streamId;
+
+  @JsonKey(name: r'status', required: true, includeIfNull: false)
+  final StreamStatsResponseStatusEnum status;
+
+  /// Estimated number of distinct clients that fetched the manifest recently. Zero when the stream is not live.
+  @JsonKey(name: r'listeners', required: true, includeIfNull: false)
+  final int listeners;
+
+  /// Highest `listeners` value observed since the broadcast started. In-memory only: reset on process restart, lost when the stream ends.
+  @JsonKey(name: r'peak_listeners', required: true, includeIfNull: false)
+  final int peakListeners;
+
+  @JsonKey(name: r'started_at', required: false, includeIfNull: false)
+  final DateTime? startedAt;
+
+  /// Seconds since `started_at` — up to now while live, up to `ended_at` once the broadcast is over. Zero if the stream never started.
+  @JsonKey(name: r'duration_seconds', required: true, includeIfNull: false)
+  final int durationSeconds;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is StreamStatsResponse &&
+          other.streamId == streamId &&
+          other.status == status &&
+          other.listeners == listeners &&
+          other.peakListeners == peakListeners &&
+          other.startedAt == startedAt &&
+          other.durationSeconds == durationSeconds;
+
+  @override
+  int get hashCode =>
+      streamId.hashCode +
+      status.hashCode +
+      listeners.hashCode +
+      peakListeners.hashCode +
+      (startedAt == null ? 0 : startedAt.hashCode) +
+      durationSeconds.hashCode;
+
+  factory StreamStatsResponse.fromJson(Map<String, dynamic> json) =>
+      _$StreamStatsResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$StreamStatsResponseToJson(this);
+
+  @override
+  String toString() {
+    return toJson().toString();
+  }
+}
+
+enum StreamStatsResponseStatusEnum {
+  @JsonValue(r'idle')
+  idle(r'idle'),
+  @JsonValue(r'live')
+  live(r'live'),
+  @JsonValue(r'ended')
+  ended(r'ended');
+
+  const StreamStatsResponseStatusEnum(this.value);
+
+  final String value;
+
+  @override
+  String toString() => value;
+}

--- a/mobile/packages/streampulse_api/lib/src/model/stream_stats_response.g.dart
+++ b/mobile/packages/streampulse_api/lib/src/model/stream_stats_response.g.dart
@@ -1,0 +1,77 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'stream_stats_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+StreamStatsResponse _$StreamStatsResponseFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(
+      'StreamStatsResponse',
+      json,
+      ($checkedConvert) {
+        $checkKeys(
+          json,
+          requiredKeys: const [
+            'stream_id',
+            'status',
+            'listeners',
+            'peak_listeners',
+            'duration_seconds',
+          ],
+        );
+        final val = StreamStatsResponse(
+          streamId: $checkedConvert('stream_id', (v) => v as String),
+          status: $checkedConvert(
+            'status',
+            (v) => $enumDecode(_$StreamStatsResponseStatusEnumEnumMap, v),
+          ),
+          listeners: $checkedConvert('listeners', (v) => (v as num).toInt()),
+          peakListeners: $checkedConvert(
+            'peak_listeners',
+            (v) => (v as num).toInt(),
+          ),
+          startedAt: $checkedConvert(
+            'started_at',
+            (v) => v == null ? null : DateTime.parse(v as String),
+          ),
+          durationSeconds: $checkedConvert(
+            'duration_seconds',
+            (v) => (v as num).toInt(),
+          ),
+        );
+        return val;
+      },
+      fieldKeyMap: const {
+        'streamId': 'stream_id',
+        'peakListeners': 'peak_listeners',
+        'startedAt': 'started_at',
+        'durationSeconds': 'duration_seconds',
+      },
+    );
+
+Map<String, dynamic> _$StreamStatsResponseToJson(StreamStatsResponse instance) {
+  final val = <String, dynamic>{
+    'stream_id': instance.streamId,
+    'status': _$StreamStatsResponseStatusEnumEnumMap[instance.status]!,
+    'listeners': instance.listeners,
+    'peak_listeners': instance.peakListeners,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('started_at', instance.startedAt?.toIso8601String());
+  val['duration_seconds'] = instance.durationSeconds;
+  return val;
+}
+
+const _$StreamStatsResponseStatusEnumEnumMap = {
+  StreamStatsResponseStatusEnum.idle: 'idle',
+  StreamStatsResponseStatusEnum.live: 'live',
+  StreamStatsResponseStatusEnum.ended: 'ended',
+};

--- a/mobile/packages/streampulse_api/lib/streampulse_api.dart
+++ b/mobile/packages/streampulse_api/lib/streampulse_api.dart
@@ -40,6 +40,7 @@ export 'package:streampulse_api/src/model/reset_password_request.dart';
 export 'package:streampulse_api/src/model/review_request_input.dart';
 export 'package:streampulse_api/src/model/set_user_active_request.dart';
 export 'package:streampulse_api/src/model/stream_response.dart';
+export 'package:streampulse_api/src/model/stream_stats_response.dart';
 export 'package:streampulse_api/src/model/stream_summary_response.dart';
 export 'package:streampulse_api/src/model/token_pair_response.dart';
 export 'package:streampulse_api/src/model/update_profile_request.dart';

--- a/mobile/test/features/broadcast/presentation/broadcast_notifier_test.dart
+++ b/mobile/test/features/broadcast/presentation/broadcast_notifier_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:streampulse/core/errors/exceptions.dart';
 import 'package:streampulse/core/network/sse_client.dart';
+import 'package:streampulse/features/broadcast/domain/entities/broadcast_stats.dart';
 import 'package:streampulse/features/broadcast/domain/entities/broadcast_stream.dart';
 import 'package:streampulse/features/broadcast/domain/repositories/broadcast_repository.dart';
 import 'package:streampulse/features/broadcast/presentation/providers/broadcast_notifier.dart';
@@ -87,7 +88,22 @@ class _FakeBroadcastRepository implements BroadcastRepository {
     if (mutationError != null) throw mutationError!;
   }
 
+  @override
+  Future<BroadcastStats> streamStats(String id) async {
+    statsCalls++;
+    if (statsError != null) throw statsError!;
+    return BroadcastStats(
+      streamId: id,
+      listeners: listeners,
+      peak: listeners,
+      duration: const Duration(minutes: 2),
+    );
+  }
+
   final List<String> deletedIds = [];
+  int statsCalls = 0;
+  int listeners = 3;
+  Object? statsError;
 }
 
 /// Repository dont chaque `listMyStreams` reste en vol tant que le test n'a
@@ -120,6 +136,9 @@ class _DeferredRepository implements BroadcastRepository {
 
   @override
   Future<void> deleteStream(String id) => throw UnimplementedError();
+
+  @override
+  Future<BroadcastStats> streamStats(String id) => throw UnimplementedError();
 }
 
 /// Repository dont `startStream` reste en vol jusqu'à résolution manuelle :
@@ -151,6 +170,9 @@ class _DeferredMutationRepository implements BroadcastRepository {
 
   @override
   Future<void> deleteStream(String id) => throw UnimplementedError();
+
+  @override
+  Future<BroadcastStats> streamStats(String id) => throw UnimplementedError();
 }
 
 /// Connecteur SSE piloté par le test : chaque `connect` ouvre un
@@ -339,6 +361,125 @@ void main() {
       await expectLater(notifier.delete('a'), throwsA(isA<ServerException>()));
       expect(notifier.mutatingId, isNull);
       expect(notifier.streams, hasLength(1));
+    });
+  });
+
+  group('BroadcastNotifier — audience (STR-154)', () {
+    test('un direct déclenche une première mesure immédiate', () async {
+      // Attendre 5 s laisserait la carte sans chiffre juste après le
+      // démarrage, au moment où le diffuseur la regarde le plus.
+      final repository = _FakeBroadcastRepository(
+        streams: [_stream('a', status: 'live')],
+      );
+      final notifier = BroadcastNotifier(
+        repository,
+        statsInterval: const Duration(milliseconds: 20),
+      );
+      notifier.setActive(true);
+
+      await notifier.load();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(repository.statsCalls, greaterThanOrEqualTo(1));
+      expect(notifier.stats?.listeners, 3);
+      notifier.dispose();
+    });
+
+    test('les mesures se répètent à la cadence demandée', () async {
+      final repository = _FakeBroadcastRepository(
+        streams: [_stream('a', status: 'live')],
+      );
+      final notifier = BroadcastNotifier(
+        repository,
+        statsInterval: const Duration(milliseconds: 20),
+      );
+      notifier.setActive(true);
+      await notifier.load();
+      final callsAfterLoad = repository.statsCalls;
+
+      await Future<void>.delayed(const Duration(milliseconds: 80));
+
+      expect(repository.statsCalls, greaterThan(callsAfterLoad));
+      notifier.dispose();
+    });
+
+    test('aucune mesure sans flux en direct', () async {
+      final repository = _FakeBroadcastRepository(streams: [_stream('a')]);
+      final notifier = BroadcastNotifier(
+        repository,
+        statsInterval: const Duration(milliseconds: 20),
+      );
+      notifier.setActive(true);
+
+      await notifier.load();
+      await Future<void>.delayed(const Duration(milliseconds: 60));
+
+      expect(repository.statsCalls, 0);
+      expect(notifier.stats, isNull);
+      notifier.dispose();
+    });
+
+    test('l\'arrêt du direct coupe les mesures et efface l\'audience',
+        () async {
+      final repository = _FakeBroadcastRepository(
+        streams: [_stream('a', status: 'live')],
+      );
+      final notifier = BroadcastNotifier(
+        repository,
+        statsInterval: const Duration(milliseconds: 20),
+      );
+      notifier.setActive(true);
+      await notifier.load();
+      await Future<void>.delayed(Duration.zero);
+      expect(notifier.stats, isNotNull);
+
+      await notifier.stop('a');
+      final callsAfterStop = repository.statsCalls;
+      await Future<void>.delayed(const Duration(milliseconds: 60));
+
+      expect(notifier.stats, isNull);
+      expect(repository.statsCalls, callsAfterStop);
+      notifier.dispose();
+    });
+
+    test('les mesures s\'arrêtent en arrière-plan', () async {
+      final repository = _FakeBroadcastRepository(
+        streams: [_stream('a', status: 'live')],
+      );
+      final notifier = BroadcastNotifier(
+        repository,
+        statsInterval: const Duration(milliseconds: 20),
+      );
+      notifier.setActive(true);
+      await notifier.load();
+
+      notifier.setActive(false);
+      final callsAfterPause = repository.statsCalls;
+      await Future<void>.delayed(const Duration(milliseconds: 80));
+
+      expect(repository.statsCalls, callsAfterPause);
+      notifier.dispose();
+    });
+
+    test('un échec de mesure ne casse pas l\'écran', () async {
+      // L'audience est une information d'appoint : une coupure réseau ne doit
+      // pas faire clignoter une erreur sur un dashboard par ailleurs sain.
+      final repository = _FakeBroadcastRepository(
+        streams: [_stream('a', status: 'live')],
+      )..statsError = const NetworkException();
+      final notifier = BroadcastNotifier(
+        repository,
+        statsInterval: const Duration(milliseconds: 20),
+      );
+      notifier.setActive(true);
+
+      await notifier.load();
+      await Future<void>.delayed(const Duration(milliseconds: 40));
+
+      expect(notifier.stats, isNull);
+      expect(notifier.error, isNull, reason: 'pas d\'erreur remontée à l\'écran');
+      expect(notifier.streams, hasLength(1));
+      notifier.dispose();
     });
   });
 

--- a/mobile/test/features/broadcast/presentation/broadcast_notifier_test.dart
+++ b/mobile/test/features/broadcast/presentation/broadcast_notifier_test.dart
@@ -96,7 +96,6 @@ class _FakeBroadcastRepository implements BroadcastRepository {
       streamId: id,
       listeners: listeners,
       peak: listeners,
-      duration: const Duration(minutes: 2),
     );
   }
 
@@ -458,6 +457,51 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 80));
 
       expect(repository.statsCalls, callsAfterPause);
+      notifier.dispose();
+    });
+
+    test('une mesure identique ne notifie pas', () async {
+      // L'audience bouge rarement entre deux relevés : reconstruire l'écran
+      // toutes les 5 s pour réafficher les mêmes chiffres est du gaspillage.
+      final repository = _FakeBroadcastRepository(
+        streams: [_stream('a', status: 'live')],
+      );
+      final notifier = BroadcastNotifier(
+        repository,
+        statsInterval: const Duration(milliseconds: 20),
+      );
+      notifier.setActive(true);
+      await notifier.load();
+      await Future<void>.delayed(Duration.zero);
+
+      var notifications = 0;
+      notifier.addListener(() => notifications++);
+      await Future<void>.delayed(const Duration(milliseconds: 80));
+
+      expect(repository.statsCalls, greaterThan(1), reason: 'les mesures tournent');
+      expect(notifications, 0, reason: 'valeurs inchangées : aucun rebuild');
+      notifier.dispose();
+    });
+
+    test('une mesure différente notifie', () async {
+      final repository = _FakeBroadcastRepository(
+        streams: [_stream('a', status: 'live')],
+      );
+      final notifier = BroadcastNotifier(
+        repository,
+        statsInterval: const Duration(milliseconds: 20),
+      );
+      notifier.setActive(true);
+      await notifier.load();
+      await Future<void>.delayed(Duration.zero);
+
+      var notifications = 0;
+      notifier.addListener(() => notifications++);
+      repository.listeners = 12;
+      await Future<void>.delayed(const Duration(milliseconds: 60));
+
+      expect(notifications, greaterThan(0));
+      expect(notifier.stats?.listeners, 12);
       notifier.dispose();
     });
 

--- a/mobile/test/features/broadcast/presentation/screens/dashboard_screen_test.dart
+++ b/mobile/test/features/broadcast/presentation/screens/dashboard_screen_test.dart
@@ -7,6 +7,7 @@ import 'package:toastification/toastification.dart';
 
 import 'package:streampulse/core/errors/exceptions.dart';
 import 'package:streampulse/core/network/sse_client.dart';
+import 'package:streampulse/features/broadcast/domain/entities/broadcast_stats.dart';
 import 'package:streampulse/features/broadcast/domain/entities/broadcast_stream.dart';
 import 'package:streampulse/features/broadcast/domain/repositories/broadcast_repository.dart';
 import 'package:streampulse/features/broadcast/presentation/screens/dashboard_screen.dart';
@@ -80,7 +81,17 @@ class _FakeBroadcastRepository implements BroadcastRepository {
     deletedIds.add(id);
   }
 
+  @override
+  Future<BroadcastStats> streamStats(String id) async => BroadcastStats(
+        streamId: id,
+        listeners: listeners,
+        peak: peak,
+        duration: const Duration(minutes: 2),
+      );
+
   final List<String> deletedIds = [];
+  int listeners = 4;
+  int peak = 9;
 }
 
 class _FakeProfileRepository implements ProfileRepository {
@@ -257,6 +268,54 @@ void main() {
         find.byKey(const Key('dashboard_stop_button_a')),
       );
       expect(stopA.onPressed, isNotNull);
+    });
+  });
+
+  group('DashboardScreen — audience (STR-154)', () {
+    testWidgets('le direct affiche les auditeurs estimés et le pic',
+        (tester) async {
+      final repository = _FakeBroadcastRepository(
+        streams: [_stream('a', status: 'live', startedAt: DateTime.now())],
+      )
+        ..listeners = 4
+        ..peak = 9;
+      await tester.pumpWidget(_harness(repository));
+      await _settle(tester);
+
+      expect(find.byKey(const Key('dashboard_listeners_a')), findsOneWidget);
+      expect(
+        tester.widget<Text>(find.byKey(const Key('dashboard_listeners_a'))).data,
+        '4',
+      );
+      expect(
+        tester.widget<Text>(find.byKey(const Key('dashboard_peak_a'))).data,
+        'pic 9',
+      );
+      // Le libellé reste prudent : le compte est une estimation, pas une
+      // mesure de connexions (HLS n'en a pas).
+      expect(find.text('auditeurs estimés'), findsOneWidget);
+    });
+
+    testWidgets('un seul auditeur : libellé au singulier', (tester) async {
+      final repository = _FakeBroadcastRepository(
+        streams: [_stream('a', status: 'live', startedAt: DateTime.now())],
+      )..listeners = 1;
+      await tester.pumpWidget(_harness(repository));
+      await _settle(tester);
+
+      expect(find.text('auditeur estimé'), findsOneWidget);
+    });
+
+    testWidgets('aucune audience affichée sur un flux qui n\'est pas en direct',
+        (tester) async {
+      final repository = _FakeBroadcastRepository(
+        streams: [_stream('a'), _stream('b', status: 'ended')],
+      );
+      await tester.pumpWidget(_harness(repository));
+      await _settle(tester);
+
+      expect(find.byKey(const Key('dashboard_listeners_a')), findsNothing);
+      expect(find.byKey(const Key('dashboard_listeners_b')), findsNothing);
     });
   });
 

--- a/mobile/test/features/broadcast/presentation/screens/dashboard_screen_test.dart
+++ b/mobile/test/features/broadcast/presentation/screens/dashboard_screen_test.dart
@@ -86,12 +86,21 @@ class _FakeBroadcastRepository implements BroadcastRepository {
         streamId: id,
         listeners: listeners,
         peak: peak,
-        duration: const Duration(minutes: 2),
       );
 
   final List<String> deletedIds = [];
   int listeners = 4;
   int peak = 9;
+}
+
+/// Repository dont `streamStats` ne répond jamais : reproduit la fenêtre entre
+/// le passage en direct et le premier relevé, ainsi que le retour
+/// d'arrière-plan où l'audience est repartie à null.
+class _DeferredStatsRepository extends _FakeBroadcastRepository {
+  _DeferredStatsRepository({super.streams});
+
+  @override
+  Future<BroadcastStats> streamStats(String id) => Completer<BroadcastStats>().future;
 }
 
 class _FakeProfileRepository implements ProfileRepository {
@@ -289,7 +298,7 @@ void main() {
       );
       expect(
         tester.widget<Text>(find.byKey(const Key('dashboard_peak_a'))).data,
-        'pic 9',
+        'Pic : 9',
       );
       // Le libellé reste prudent : le compte est une estimation, pas une
       // mesure de connexions (HLS n'en a pas).
@@ -304,6 +313,62 @@ void main() {
       await _settle(tester);
 
       expect(find.text('auditeur estimé'), findsOneWidget);
+    });
+
+    testWidgets('la ligne est présente dès le direct, avant toute mesure',
+        (tester) async {
+      // Sans ça, la ligne « apparaît » au premier relevé et pousse le contenu
+      // vers le bas ; et elle disparaît au passage en arrière-plan, quand
+      // `_cancelStats()` remet l'audience à null.
+      final repository = _DeferredStatsRepository(
+        streams: [_stream('a', status: 'live', startedAt: DateTime.now())],
+      );
+      await tester.pumpWidget(_harness(repository));
+      await _settle(tester);
+
+      expect(find.byKey(const Key('dashboard_listeners_a')), findsOneWidget);
+      expect(
+        tester.widget<Text>(find.byKey(const Key('dashboard_listeners_a'))).data,
+        '—',
+      );
+      expect(
+        tester.widget<Text>(find.byKey(const Key('dashboard_peak_a'))).data,
+        'Pic : —',
+      );
+    });
+
+    testWidgets('le pic est libellé explicitement', (tester) async {
+      final repository = _FakeBroadcastRepository(
+        streams: [_stream('a', status: 'live', startedAt: DateTime.now())],
+      )..peak = 9;
+      await tester.pumpWidget(_harness(repository));
+      await _settle(tester);
+
+      expect(
+        tester.widget<Text>(find.byKey(const Key('dashboard_peak_a'))).data,
+        'Pic : 9',
+      );
+    });
+
+    testWidgets('une info-bulle explique que le chiffre est une estimation',
+        (tester) async {
+      final repository = _FakeBroadcastRepository(
+        streams: [_stream('a', status: 'live', startedAt: DateTime.now())],
+      );
+      await tester.pumpWidget(_harness(repository));
+      await _settle(tester);
+
+      // Cibler l'info-bulle QUI ENTOURE la ligne d'audience : le menu ⋮ de la
+      // carte en porte une autre.
+      final tooltip = tester.widget<Tooltip>(
+        find
+            .ancestor(
+              of: find.byKey(const Key('dashboard_listeners_a')),
+              matching: find.byType(Tooltip),
+            )
+            .first,
+      );
+      expect(tooltip.message, contains('même connexion comptent pour un'));
     });
 
     testWidgets('aucune audience affichée sur un flux qui n\'est pas en direct',


### PR DESCRIPTION
Livre [STR-154](https://linear.app/streampulse/issue/STR-154) (US-06-02), backend et mobile. Décisions détaillées dans [ADR 025](docs/adr/025-statistiques-daudience-en-temps-reel.md).

Suite directe de [#274](https://github.com/LignacAntony/streampulse/pull/274) (STR-153), où le compteur d'auditeurs avait été explicitement sorti du périmètre faute de source de données.

## Le problème

HLS n'ouvre pas de connexion persistante : un lecteur récupère un manifeste puis des segments, en requêtes indépendantes. Rien ne signale son arrivée, rien ne signale son départ. Il n'existe donc **aucun « nombre d'auditeurs connectés » à lire** — seulement à estimer.

La seule mesure existante vivait dans Prometheus ([ADR 022](docs/adr/022-metriques-metier-streaming-et-panel-live.md)), mais `/metrics` est bloqué par Caddy en production et coupler le client mobile à la stack d'observabilité serait une inversion de dépendance.

## L'approche

Fenêtre glissante en mémoire, dans la session : un client compte comme auditeur tant qu'il a demandé le manifeste dans les **30 dernières secondes** (3× la durée d'un segment).

- **Seules les playlists comptent.** Les segments arrivent par rafales et suivraient le débit, pas l'audience.
- **Seuls les 200 comptent.** Une requête refusée n'est pas un auditeur.
- La map est purgée à chaque lecture et **plafonnée à 10 000 entrées** : un client qui ferait varier son identité ne doit pas la faire enfler sans limite. Un client déjà suivi reste rafraîchi malgré le plafond, sinon il expirerait à tort.
- Le pic survit aux départs, mais pas à l'arrêt du flux ni au redémarrage du process — l'historique persistant reste [STR-162](https://linear.app/streampulse/issue/STR-162).

## Point d'attention pour la revue — `TRUST_PROXY_HEADERS`

L'identification du lecteur se fait par adresse réseau : les lecteurs natifs (AVPlayer, ExoPlayer) ne portent pas le `Bearer`, c'est déjà pourquoi les routes HLS sont en `OptionalAuth`.

D'où un arbitrage qui mérite un regard :

- Lire `X-Forwarded-For` sans condition → l'en-tête est **falsifiable**, n'importe qui gonflerait le compteur d'un flux en variant sa valeur.
- Ne jamais le lire → en production tous les auditeurs traversent Caddy et partagent son adresse, le compteur **sature à 1** et la fonctionnalité est vide de sens.

Retenu : un drapeau `TRUST_PROXY_HEADERS`, **faux par défaut**, injecté par `SetTrustProxyHeaders` au démarrage (même motif que `SetMetrics` — c'est une donnée de déploiement, pas de domaine).

> ⚠️ **À faire au déploiement** : poser `TRUST_PROXY_HEADERS=true` sur le VPS, sinon la statistique affichera 1 auditeur quoi qu'il arrive.

## L'endpoint

`GET /api/streams/{id}/stats` — propriétaire uniquement, **404 pour un tiers et non 403** : l'audience d'un flux ne doit pas être devinable, ni son existence.

Un flux qui n'est pas en direct répond `200` avec des compteurs à zéro plutôt qu'une erreur : le client interroge pendant toute la vie de l'écran et n'a aucun cas particulier à traiter.

## Côté mobile

Interrogation toutes les **5 s** tant qu'un flux est en direct (cadence imposée par l'AC), première mesure immédiate à l'armement, arrêt avec le direct et en arrière-plan.

Un échec de mesure est **ignoré volontairement** : l'audience est une information d'appoint, une coupure réseau ne doit pas faire clignoter une erreur sur un tableau de bord par ailleurs sain.

Le libellé dit **« auditeurs estimés »**, jamais « connectés » — parce que le compte l'est : deux lecteurs derrière la même IP publique comptent pour un, et un auditeur parti met une demi-minute à disparaître.

## Tests

- **Go** : `go vet ./...` propre, `go test ./...` vert. 15 tests neufs — fenêtre d'expiration, pic qui survit aux départs, plafond mémoire, plafond qui ne fige pas un client connu, calcul de durée (live / terminé / horloge en avance), 404 pour un tiers, et les deux comportements de `clientKey` selon le drapeau.
- **Flutter** : `flutter analyze` sans problème, `flutter test` → **244 tests passent**. Mesure immédiate, cadence, arrêt avec le direct, arrêt en arrière-plan, échec silencieux, affichage singulier/pluriel, absence d'audience hors direct.

## Ce qui n'est pas couvert

**Rien n'a été vérifié sur device ni contre un vrai flux HLS.** Le comptage repose sur des requêtes de manifeste réelles ; les tests le simulent au niveau de la session. Un QA de bout en bout — pousser de l'audio, lancer deux lecteurs, regarder le compteur monter puis retomber — reste à faire.

[STR-161](https://linear.app/streampulse/issue/STR-161) (graphique) et [STR-162](https://linear.app/streampulse/issue/STR-162) (historique persistant) ne sont pas dans ce lot.
