### PR TITLE
feat(mobile): diffuse le microphone en AAC

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,7 +87,8 @@ HLS_MAX_CONCURRENT=256
 
 # Délai sans audio avant l'arrêt automatique d'un live et timeout de chaque
 # tentative d'arrêt persistant. Le premier doit dépasser le backoff mobile max
-# de 30 s afin de laisser une reconnexion aboutir.
+# de 30 s afin de laisser une reconnexion aboutir — l'API refuse de démarrer
+# avec une valeur inférieure ou égale.
 INGEST_RECONNECT_GRACE_SECONDS=45
 INGEST_STOP_TIMEOUT_SECONDS=10
 

--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,12 @@ STREAM_INGEST_BASE_URL=http://localhost:8080
 # auditeurs — STR-88. 0 = illimité.
 HLS_MAX_CONCURRENT=256
 
+# Délai sans audio avant l'arrêt automatique d'un live et timeout de chaque
+# tentative d'arrêt persistant. Le premier doit dépasser le backoff mobile max
+# de 30 s afin de laisser une reconnexion aboutir.
+INGEST_RECONNECT_GRACE_SECONDS=45
+INGEST_STOP_TIMEOUT_SECONDS=10
+
 # Autorise la lecture de X-Forwarded-For pour identifier les auditeurs d'un flux
 # (comptage d'audience, STR-154 / ADR 025).
 #

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Le projet suit la méthodologie [**12-Factor App**](https://12factor.net/fr/conf
 | `DB_USER` | Utilisateur PostgreSQL | — | **oui** | `streampulse` |
 | `DB_PASSWORD` | Mot de passe PostgreSQL | — | **oui** | `<mot de passe fort>` |
 | `DB_NAME` | Nom de la base PostgreSQL | — | **oui** | `streampulse_db` |
-| `INGEST_RECONNECT_GRACE_SECONDS` | Délai sans audio avant l'arrêt automatique d'un live | `45` | non | `45` |
+| `INGEST_RECONNECT_GRACE_SECONDS` | Délai sans audio avant l'arrêt automatique d'un live (doit dépasser 30 s, le backoff mobile max — refusé au démarrage sinon) | `45` | non | `45` |
 | `INGEST_STOP_TIMEOUT_SECONDS` | Timeout d'une tentative d'arrêt automatique en base | `10` | non | `10` |
 | `POSTGRES_USER` | Alias compose pour `DB_USER` (init du conteneur Postgres) | — | **oui (compose)** | `streampulse` |
 | `POSTGRES_PASSWORD` | Alias compose pour `DB_PASSWORD` | — | **oui (compose)** | `<mot de passe fort>` |

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Le projet suit la méthodologie [**12-Factor App**](https://12factor.net/fr/conf
 | `DB_USER` | Utilisateur PostgreSQL | — | **oui** | `streampulse` |
 | `DB_PASSWORD` | Mot de passe PostgreSQL | — | **oui** | `<mot de passe fort>` |
 | `DB_NAME` | Nom de la base PostgreSQL | — | **oui** | `streampulse_db` |
+| `INGEST_RECONNECT_GRACE_SECONDS` | Délai sans audio avant l'arrêt automatique d'un live | `45` | non | `45` |
+| `INGEST_STOP_TIMEOUT_SECONDS` | Timeout d'une tentative d'arrêt automatique en base | `10` | non | `10` |
 | `POSTGRES_USER` | Alias compose pour `DB_USER` (init du conteneur Postgres) | — | **oui (compose)** | `streampulse` |
 | `POSTGRES_PASSWORD` | Alias compose pour `DB_PASSWORD` | — | **oui (compose)** | `<mot de passe fort>` |
 | `POSTGRES_DB` | Alias compose pour `DB_NAME` | — | **oui (compose)** | `streampulse_db` |

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -117,6 +117,17 @@ func run() error {
 	streamingSessions := streaming.NewLiveSessions(ctx)
 	streamingSvc := streaming.NewService(streamingRepo, streamingKeys, streamingSessions)
 	streamingHandler := streaming.NewHandler(streamingSvc, cfg.StreamIngestBaseURL, streamingSessions)
+	streamingHandler.SetIngestReconnectGrace(cfg.IngestReconnectGrace())
+	streamingSessions.SetIngestDisconnectHandler(cfg.IngestReconnectGrace(), func(streamID string) error {
+		stopCtx, cancel := context.WithTimeout(context.Background(), cfg.IngestStopTimeout())
+		defer cancel()
+		if err := streamingSvc.EndDisconnectedStream(stopCtx, streamID); err != nil {
+			log.Error().Err(err).Str("stream_id", streamID).
+				Msg("streaming: échec de l'arrêt après expiration de l'ingest, nouvelle tentative planifiée")
+			return err
+		}
+		return nil
+	})
 
 	// Métriques métier du streaming (STR-166, ADR 022) : le domaine reçoit
 	// l'implémentation Prometheus via son interface étroite, et la gauge des

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -30,6 +30,12 @@ const (
 	defaultLogLevel                    = "info"
 
 	minJWTSecretLen = 32
+
+	// mobileMaxReconnectBackoffSeconds reprend le plafond du backoff de
+	// reconnexion du mobile (cappedExponentialBackoff, ADR 027 §3). Le bail
+	// d'ingest doit le dépasser, sinon le serveur couperait les directs pendant
+	// la fenêtre de reprise normale du téléphone.
+	mobileMaxReconnectBackoffSeconds = 30
 )
 
 // validLogLevels énumère les niveaux acceptés pour LOG_LEVEL
@@ -289,11 +295,14 @@ func (c *Config) validate() error {
 		return fmt.Errorf("config: LOG_LEVEL invalide %q (attendu: trace|debug|info|warn|error|fatal|panic)", c.LogLevel)
 	}
 
-	if c.IngestReconnectGraceSeconds <= 0 {
-		return fmt.Errorf("config: INGEST_RECONNECT_GRACE_SECONDS must be greater than 0")
+	if c.IngestReconnectGraceSeconds <= mobileMaxReconnectBackoffSeconds {
+		return fmt.Errorf(
+			"config: INGEST_RECONNECT_GRACE_SECONDS invalide %d (attendu: > %d, le backoff de reconnexion maximal du mobile)",
+			c.IngestReconnectGraceSeconds, mobileMaxReconnectBackoffSeconds,
+		)
 	}
 	if c.IngestStopTimeoutSeconds <= 0 {
-		return fmt.Errorf("config: INGEST_STOP_TIMEOUT_SECONDS must be greater than 0")
+		return fmt.Errorf("config: INGEST_STOP_TIMEOUT_SECONDS invalide %d (attendu: > 0)", c.IngestStopTimeoutSeconds)
 	}
 
 	return nil

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/spf13/viper"
 )
@@ -18,13 +19,15 @@ import (
 // constantes pour qu'elles soient à la fois passées à viper.SetDefault
 // et appliquées en post-processing si la variable est définie à "".
 const (
-	defaultGoEnv               = "development"
-	defaultAPIPort             = "8080"
-	defaultDBHost              = "localhost"
-	defaultDBPort              = "5432"
-	defaultStreamIngestBaseURL = "http://localhost:8080"
-	defaultHLSMaxConcurrent    = 256
-	defaultLogLevel            = "info"
+	defaultGoEnv                       = "development"
+	defaultAPIPort                     = "8080"
+	defaultDBHost                      = "localhost"
+	defaultDBPort                      = "5432"
+	defaultStreamIngestBaseURL         = "http://localhost:8080"
+	defaultHLSMaxConcurrent            = 256
+	defaultIngestReconnectGraceSeconds = 45
+	defaultIngestStopTimeoutSeconds    = 10
+	defaultLogLevel                    = "info"
 
 	minJWTSecretLen = 32
 )
@@ -69,6 +72,12 @@ type Config struct {
 	// servies simultanément — STR-88. <= 0 désactive la borne.
 	HLSMaxConcurrent int `mapstructure:"HLS_MAX_CONCURRENT"`
 
+	// IngestReconnectGraceSeconds est le bail sans audio accordé au diffuseur
+	// avant l'arrêt automatique du direct. IngestStopTimeoutSeconds borne chaque
+	// tentative de transition persistante live -> ended.
+	IngestReconnectGraceSeconds int `mapstructure:"INGEST_RECONNECT_GRACE_SECONDS"`
+	IngestStopTimeoutSeconds    int `mapstructure:"INGEST_STOP_TIMEOUT_SECONDS"`
+
 	// TrustProxyHeaders autorise la lecture de X-Forwarded-For pour identifier
 	// l'auditeur d'un flux (comptage d'audience, STR-154).
 	//
@@ -108,6 +117,8 @@ func Load() (*Config, error) {
 	v.SetDefault("DB_PORT", defaultDBPort)
 	v.SetDefault("STREAM_INGEST_BASE_URL", defaultStreamIngestBaseURL)
 	v.SetDefault("HLS_MAX_CONCURRENT", defaultHLSMaxConcurrent)
+	v.SetDefault("INGEST_RECONNECT_GRACE_SECONDS", defaultIngestReconnectGraceSeconds)
+	v.SetDefault("INGEST_STOP_TIMEOUT_SECONDS", defaultIngestStopTimeoutSeconds)
 	v.SetDefault("TRUST_PROXY_HEADERS", false)
 	v.SetDefault("LOG_LEVEL", defaultLogLevel)
 	v.SetDefault("LOG_PRETTY", false)
@@ -135,7 +146,8 @@ func Load() (*Config, error) {
 		"DB_HOST", "DB_PORT", "DB_USER", "DB_PASSWORD", "DB_NAME",
 		"SMTP_HOST", "SMTP_PORT", "SMTP_USERNAME", "SMTP_PASSWORD", "SMTP_FROM",
 		"APP_BASE_URL", "CORS_ALLOWED_ORIGINS", "STREAM_INGEST_BASE_URL",
-		"HLS_MAX_CONCURRENT", "LOG_LEVEL", "LOG_PRETTY",
+		"HLS_MAX_CONCURRENT", "INGEST_RECONNECT_GRACE_SECONDS",
+		"INGEST_STOP_TIMEOUT_SECONDS", "LOG_LEVEL", "LOG_PRETTY",
 		"OTEL_EXPORTER_OTLP_ENDPOINT",
 	} {
 		if err := v.BindEnv(key); err != nil {
@@ -163,6 +175,12 @@ func Load() (*Config, error) {
 	// déjà converti : seule une chaîne vide retombe sur le défaut.
 	if strings.TrimSpace(v.GetString("HLS_MAX_CONCURRENT")) == "" {
 		cfg.HLSMaxConcurrent = defaultHLSMaxConcurrent
+	}
+	if strings.TrimSpace(v.GetString("INGEST_RECONNECT_GRACE_SECONDS")) == "" {
+		cfg.IngestReconnectGraceSeconds = defaultIngestReconnectGraceSeconds
+	}
+	if strings.TrimSpace(v.GetString("INGEST_STOP_TIMEOUT_SECONDS")) == "" {
+		cfg.IngestStopTimeoutSeconds = defaultIngestStopTimeoutSeconds
 	}
 
 	if err := cfg.validate(); err != nil {
@@ -226,6 +244,16 @@ func (c *Config) HTTPAddr() string {
 	return ":" + c.APIPort
 }
 
+// IngestReconnectGrace retourne le bail sans audio configuré.
+func (c *Config) IngestReconnectGrace() time.Duration {
+	return time.Duration(c.IngestReconnectGraceSeconds) * time.Second
+}
+
+// IngestStopTimeout borne une tentative d'arrêt automatique en base.
+func (c *Config) IngestStopTimeout() time.Duration {
+	return time.Duration(c.IngestStopTimeoutSeconds) * time.Second
+}
+
 // DBDSN retourne la DSN PostgreSQL prête à passer à database/sql ou pgx.
 func (c *Config) DBDSN() string {
 	return fmt.Sprintf(
@@ -259,6 +287,13 @@ func (c *Config) validate() error {
 
 	if !validLogLevels[c.LogLevel] {
 		return fmt.Errorf("config: LOG_LEVEL invalide %q (attendu: trace|debug|info|warn|error|fatal|panic)", c.LogLevel)
+	}
+
+	if c.IngestReconnectGraceSeconds <= 0 {
+		return fmt.Errorf("config: INGEST_RECONNECT_GRACE_SECONDS must be greater than 0")
+	}
+	if c.IngestStopTimeoutSeconds <= 0 {
+		return fmt.Errorf("config: INGEST_STOP_TIMEOUT_SECONDS must be greater than 0")
 	}
 
 	return nil

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -213,6 +213,32 @@ func TestLoad_IngestTimeouts(t *testing.T) {
 			}
 		})
 	}
+
+	// Invariant de l'ADR 027 : un bail plus court que le backoff mobile
+	// couperait les directs pendant la fenêtre de reconnexion normale du
+	// téléphone. La borne est refusée au démarrage, pas seulement documentée.
+	for _, value := range []string{"20", "30"} {
+		t.Run("bail plus court que le backoff mobile ("+value+"s)", func(t *testing.T) {
+			setEnv(t, validVars())
+			t.Setenv("INGEST_RECONNECT_GRACE_SECONDS", value)
+			_, err := Load()
+			if err == nil || !strings.Contains(err.Error(), "INGEST_RECONNECT_GRACE_SECONDS") {
+				t.Fatalf("Load() error = %v, want refus du bail %ss", err, value)
+			}
+		})
+	}
+
+	t.Run("bail juste au-dessus du backoff mobile", func(t *testing.T) {
+		setEnv(t, validVars())
+		t.Setenv("INGEST_RECONNECT_GRACE_SECONDS", "31")
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() unexpected error: %v", err)
+		}
+		if cfg.IngestReconnectGrace() != 31*time.Second {
+			t.Errorf("IngestReconnectGrace() = %s, want 31s", cfg.IngestReconnectGrace())
+		}
+	})
 }
 
 func TestConfig_DBDSN(t *testing.T) {

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 // setEnv positionne plusieurs variables d'environnement pour la durée du test.
@@ -167,6 +168,48 @@ func TestLoad_HLSMaxConcurrent(t *testing.T) {
 			}
 			if cfg.HLSMaxConcurrent != tt.want {
 				t.Errorf("HLSMaxConcurrent = %d, want %d", cfg.HLSMaxConcurrent, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoad_IngestTimeouts(t *testing.T) {
+	t.Run("défauts", func(t *testing.T) {
+		setEnv(t, validVars())
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() unexpected error: %v", err)
+		}
+		if cfg.IngestReconnectGrace() != 45*time.Second {
+			t.Errorf("IngestReconnectGrace() = %s, want 45s", cfg.IngestReconnectGrace())
+		}
+		if cfg.IngestStopTimeout() != 10*time.Second {
+			t.Errorf("IngestStopTimeout() = %s, want 10s", cfg.IngestStopTimeout())
+		}
+	})
+
+	t.Run("personnalisés", func(t *testing.T) {
+		setEnv(t, validVars())
+		t.Setenv("INGEST_RECONNECT_GRACE_SECONDS", "60")
+		t.Setenv("INGEST_STOP_TIMEOUT_SECONDS", "15")
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() unexpected error: %v", err)
+		}
+		if cfg.IngestReconnectGrace() != time.Minute {
+			t.Errorf("IngestReconnectGrace() = %s, want 1m", cfg.IngestReconnectGrace())
+		}
+		if cfg.IngestStopTimeout() != 15*time.Second {
+			t.Errorf("IngestStopTimeout() = %s, want 15s", cfg.IngestStopTimeout())
+		}
+	})
+
+	for _, key := range []string{"INGEST_RECONNECT_GRACE_SECONDS", "INGEST_STOP_TIMEOUT_SECONDS"} {
+		t.Run(key+" invalide", func(t *testing.T) {
+			setEnv(t, validVars())
+			t.Setenv(key, "0")
+			if _, err := Load(); err == nil || !strings.Contains(err.Error(), key) {
+				t.Fatalf("Load() error = %v, want erreur pour %s", err, key)
 			}
 		})
 	}

--- a/backend/internal/streaming/handler.go
+++ b/backend/internal/streaming/handler.go
@@ -133,7 +133,9 @@ func NewHandler(svc StreamService, ingestBaseURL string, sessions StreamSessions
 func (h *Handler) SetTrustProxyHeaders(trust bool) { h.trustProxyHeaders = trust }
 
 // SetIngestReconnectGrace configure la deadline glissante d'un push audio.
-// Zéro désactive la deadline, notamment dans les tests unitaires du handler.
+// Zéro désactive toute deadline de lecture sur l'ingest — y compris celle
+// posée par le ReadTimeout d'http.Server, qui couperait un push après quelques
+// secondes. C'est le cas des tests unitaires du handler.
 func (h *Handler) SetIngestReconnectGrace(grace time.Duration) {
 	h.ingestReconnectGrace = grace
 }
@@ -714,6 +716,11 @@ func (h *Handler) Ingest(w http.ResponseWriter, r *http.Request) {
 	// de grâce pour laisser le mobile se reconnecter.
 	rc := http.NewResponseController(w)
 	_ = rc.SetWriteDeadline(time.Time{})
+	if h.ingestReconnectGrace <= 0 {
+		// Sans bail, il faut neutraliser explicitement la deadline de lecture :
+		// le ReadTimeout d'http.Server (5 s) couperait sinon tous les pushes.
+		_ = rc.SetReadDeadline(time.Time{})
+	}
 
 	// Copie bloquante jusqu'à la fin du push (EOF = diffuseur déconnecté). On ne
 	// ferme PAS l'entrée du segmenteur : la session reste live (fenêtre de

--- a/backend/internal/streaming/handler.go
+++ b/backend/internal/streaming/handler.go
@@ -31,6 +31,21 @@ const sseKeepAliveInterval = 15 * time.Second
 // pas pouvoir bloquer indéfiniment le Write (fuite de goroutine/connexion).
 const sseWriteTimeout = 10 * time.Second
 
+type ingestDeadlineReader struct {
+	body       io.Reader
+	controller *http.ResponseController
+	timeout    time.Duration
+}
+
+// Read renouvelle la deadline avant chaque attente d'octets. Une connexion TCP
+// half-open ne peut ainsi pas réserver indéfiniment l'unique slot d'ingest.
+func (r ingestDeadlineReader) Read(p []byte) (int, error) {
+	if r.timeout > 0 {
+		_ = r.controller.SetReadDeadline(time.Now().Add(r.timeout))
+	}
+	return r.body.Read(p)
+}
+
 // StreamService est l'interface requise par le handler (ISP) : *Service la satisfait.
 type StreamService interface {
 	CreateStream(ctx context.Context, in CreateStreamInput) (Stream, error)
@@ -99,7 +114,8 @@ type Handler struct {
 
 	// trustProxyHeaders : cf. clientKey. Faux par défaut, activé par
 	// SetTrustProxyHeaders au démarrage quand un reverse proxy est devant.
-	trustProxyHeaders bool
+	trustProxyHeaders    bool
+	ingestReconnectGrace time.Duration
 }
 
 func NewHandler(svc StreamService, ingestBaseURL string, sessions StreamSessions) *Handler {
@@ -115,6 +131,12 @@ func NewHandler(svc StreamService, ingestBaseURL string, sessions StreamSessions
 // les auditeurs (STR-154). Setter plutôt que paramètre de constructeur : même
 // motif que SetMetrics — c'est une donnée de déploiement, pas du domaine.
 func (h *Handler) SetTrustProxyHeaders(trust bool) { h.trustProxyHeaders = trust }
+
+// SetIngestReconnectGrace configure la deadline glissante d'un push audio.
+// Zéro désactive la deadline, notamment dans les tests unitaires du handler.
+func (h *Handler) SetIngestReconnectGrace(grace time.Duration) {
+	h.ingestReconnectGrace = grace
+}
 
 // SetMetrics injecte le collecteur de métriques métier (STR-166, ADR 022).
 // Setter plutôt que paramètre de constructeur : l'observabilité est optionnelle
@@ -686,16 +708,22 @@ func (h *Handler) Ingest(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Push long : neutraliser les deadlines read/write posées par http.Server
-	// (ReadTimeout/WriteTimeout couperaient une diffusion de plusieurs minutes).
+	// Push long : la deadline de lecture est glissante (renouvelée à chaque bloc
+	// audio) et la deadline d'écriture est neutralisée. Une connexion active peut
+	// durer des heures, mais une socket half-open libère l'ingest après le délai
+	// de grâce pour laisser le mobile se reconnecter.
 	rc := http.NewResponseController(w)
-	_ = rc.SetReadDeadline(time.Time{})
 	_ = rc.SetWriteDeadline(time.Time{})
 
 	// Copie bloquante jusqu'à la fin du push (EOF = diffuseur déconnecté). On ne
 	// ferme PAS l'entrée du segmenteur : la session reste live (fenêtre de
 	// segments disponible) jusqu'au stop explicite.
-	if _, err := io.Copy(writer, r.Body); err != nil {
+	reader := ingestDeadlineReader{
+		body:       r.Body,
+		controller: rc,
+		timeout:    h.ingestReconnectGrace,
+	}
+	if _, err := io.Copy(writer, reader); err != nil {
 		// Push interrompu par une erreur : refléter l'échec plutôt qu'un 204
 		// trompeur (un broadcast avorté ≠ déconnexion propre). Ne jamais logger le
 		// stream_key (secret). Si le client est déjà parti, l'écriture est un no-op.

--- a/backend/internal/streaming/handler_test.go
+++ b/backend/internal/streaming/handler_test.go
@@ -2,6 +2,7 @@ package streaming
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -643,6 +644,48 @@ func TestHandler_Ingest_AllowsAbsentContentType(t *testing.T) {
 
 	if rec.Code != http.StatusNoContent {
 		t.Fatalf("want 204 (content-type absent accepté), got %d: %s", rec.Code, rec.Body)
+	}
+}
+
+// Le push d'ingest dure tout le direct : il doit échapper au ReadTimeout court
+// d'http.Server. Sans bail configuré (grace = 0), la deadline de lecture doit
+// être explicitement neutralisée, sinon un push lent mais parfaitement sain se
+// ferait couper au bout de quelques secondes.
+func TestHandler_Ingest_SurvivesServerReadTimeoutWithoutGrace(t *testing.T) {
+	ls := sessionsWithFakeSeg(t)
+	ls.Start("sid-slow", "KEYSLOW")
+	defer ls.StopAll()
+	h := NewHandler(&stubService{}, testIngestURL, ls)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/streams/ingest/{stream_key}", h.Ingest)
+	srv := httptest.NewUnstartedServer(mux)
+	srv.Config.ReadTimeout = 100 * time.Millisecond
+	srv.Start()
+	defer srv.Close()
+
+	// Corps envoyé en deux morceaux séparés par plus que le ReadTimeout.
+	body, writer := io.Pipe()
+	go func() {
+		_, _ = writer.Write([]byte{0xff, 0xf1})
+		time.Sleep(300 * time.Millisecond)
+		_, _ = writer.Write([]byte{0x50, 0x80})
+		_ = writer.Close()
+	}()
+
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/streams/ingest/KEYSLOW", body)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "audio/aac")
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatalf("push interrompu par le ReadTimeout du serveur: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("want 204, got %d", resp.StatusCode)
 	}
 }
 

--- a/backend/internal/streaming/service.go
+++ b/backend/internal/streaming/service.go
@@ -338,6 +338,21 @@ func (s *Service) StopStream(ctx context.Context, id, requesterID string) (Strea
 	return stream, nil
 }
 
+// EndDisconnectedStream termine un direct dont le bail audio a expiré. La
+// transition est idempotente face à un stop utilisateur concurrent.
+func (s *Service) EndDisconnectedStream(ctx context.Context, id string) error {
+	endedID, err := s.repo.ForceStopLiveStream(ctx, id)
+	if err != nil {
+		if errors.Is(err, errNoRowAffected) {
+			s.sessions.Stop(id)
+			return nil
+		}
+		return err
+	}
+	s.sessions.Stop(endedID)
+	return nil
+}
+
 // classifyTransitionFailure traduit un échec de transition (0 ligne mise à jour)
 // en 404 (absent/archivé/pas propriétaire) ou 409 (mauvais statut, conflictMsg).
 func (s *Service) classifyTransitionFailure(ctx context.Context, id, requesterID, conflictMsg string) error {

--- a/backend/internal/streaming/service_test.go
+++ b/backend/internal/streaming/service_test.go
@@ -273,6 +273,22 @@ func (f *fakeSessions) Start(id, key string) {
 }
 func (f *fakeSessions) Stop(id string) { f.stopped = append(f.stopped, id) }
 
+func TestService_EndDisconnectedStream(t *testing.T) {
+	repo := &fakeRepo{forceStopRet: "s1"}
+	sessions := &fakeSessions{}
+	svc := NewService(repo, fakeKeys{}, sessions)
+
+	if err := svc.EndDisconnectedStream(context.Background(), "s1"); err != nil {
+		t.Fatalf("EndDisconnectedStream: %v", err)
+	}
+	if repo.gotForceStopID != "s1" {
+		t.Fatalf("repo id = %q, want s1", repo.gotForceStopID)
+	}
+	if len(sessions.stopped) != 1 || sessions.stopped[0] != "s1" {
+		t.Fatalf("sessions stopped = %v, want [s1]", sessions.stopped)
+	}
+}
+
 func TestService_CreateStream_Success(t *testing.T) {
 	repo := &fakeRepo{ret: Stream{ID: "s1", Title: "Mon flux"}}
 	svc := NewService(repo, fakeKeys{key: "SECRET_KEY"}, &fakeSessions{})

--- a/backend/internal/streaming/session.go
+++ b/backend/internal/streaming/session.go
@@ -25,6 +25,7 @@ type session struct {
 	closed       bool
 	dead         bool          // ffmpeg s'est arrêté seul : segmenteur inexploitable
 	ingesting    bool          // un seul push audio à la fois
+	expiring     bool          // bail expiré : arrêt en cours, plus aucun ingest accepté
 	ingestExpiry *time.Timer   // arrêt différé si aucun push ne revient
 	hls          *hlsSegmenter // publié après le spawn ; protégé par mu
 	subscribers  map[chan SessionEvent]struct{}
@@ -253,16 +254,25 @@ func (ls *LiveSessions) armIngestExpiry(s *session) {
 	var timer *time.Timer
 	timer = time.AfterFunc(grace, func() {
 		s.mu.Lock()
-		if s.ingestExpiry != timer || s.closed || s.dead || s.ingesting {
+		if s.ingestExpiry != timer || s.closed || s.dead || s.ingesting || s.expiring {
 			s.mu.Unlock()
 			return
 		}
 		s.ingestExpiry = nil
+		// Marquer l'arrêt AVANT de relâcher le verrou : le handler termine la
+		// session sans le tenir, et un diffuseur qui se reconnecterait dans cet
+		// intervalle passerait sinon tous les gardes d'AttachIngest pour
+		// obtenir un ingest aussitôt cassé par Stop.
+		s.expiring = true
 		s.mu.Unlock()
 		if err := handler(s.streamID); err != nil {
 			// Une indisponibilité transitoire de la base ne doit pas désarmer le
 			// garde-fou : tant que la session existe, une nouvelle tentative sera
-			// faite après le même délai de grâce.
+			// faite après le même délai de grâce — et l'ingest redevient
+			// acceptable entre-temps, la session n'ayant pas été terminée.
+			s.mu.Lock()
+			s.expiring = false
+			s.mu.Unlock()
 			ls.armIngestExpiry(s)
 		}
 	})
@@ -272,7 +282,8 @@ func (ls *LiveSessions) armIngestExpiry(s *session) {
 // AttachIngest réserve la session live identifiée par streamKey pour un unique
 // push audio, et retourne l'entrée où copier le flux + une fonction de
 // détachement. Erreurs : errNotLive (clé inconnue / flux pas en direct / segmenteur
-// mort), errSegmenterUnavailable, errIngestInProgress (un push est déjà en cours).
+// mort / bail d'ingest expiré), errSegmenterUnavailable, errIngestInProgress (un
+// push est déjà en cours).
 func (ls *LiveSessions) AttachIngest(streamKey string) (io.Writer, func(), error) {
 	ls.mu.Lock()
 	s, ok := ls.byKey[streamKey]
@@ -283,8 +294,9 @@ func (ls *LiveSessions) AttachIngest(streamKey string) (io.Writer, func(), error
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.closed || s.dead {
-		// Session arrêtée (entre la lecture de la map et ici) ou segmenteur mort.
+	if s.closed || s.dead || s.expiring {
+		// Session arrêtée (entre la lecture de la map et ici), segmenteur mort,
+		// ou bail expiré dont l'arrêt est déjà lancé.
 		return nil, nil, errNotLive
 	}
 	if s.hls == nil {

--- a/backend/internal/streaming/session.go
+++ b/backend/internal/streaming/session.go
@@ -17,15 +17,17 @@ type SessionEvent struct {
 // session représente une diffusion en cours : le context d'annulation de sa
 // goroutine, son segmenteur HLS (STR-70), et l'ensemble des abonnés SSE (STR-85).
 type session struct {
+	streamID  string
 	streamKey string // secret de push (index d'ingest) ; "" si non routable
 	cancel    context.CancelFunc
 
-	mu          sync.Mutex
-	closed      bool
-	dead        bool          // ffmpeg s'est arrêté seul : segmenteur inexploitable
-	ingesting   bool          // un seul push audio à la fois
-	hls         *hlsSegmenter // publié après le spawn ; protégé par mu
-	subscribers map[chan SessionEvent]struct{}
+	mu           sync.Mutex
+	closed       bool
+	dead         bool          // ffmpeg s'est arrêté seul : segmenteur inexploitable
+	ingesting    bool          // un seul push audio à la fois
+	ingestExpiry *time.Timer   // arrêt différé si aucun push ne revient
+	hls          *hlsSegmenter // publié après le spawn ; protégé par mu
+	subscribers  map[chan SessionEvent]struct{}
 
 	// Suivi d'audience (STR-154) : dernière requête de manifeste par client, et
 	// pic observé. Détail du raisonnement dans listeners.go.
@@ -56,6 +58,22 @@ type LiveSessions struct {
 	byKey   map[string]*session // stream_key secret -> session (ingest)
 	wg      sync.WaitGroup
 	metrics MetricsRecorder // jamais nil : noopRecorder par défaut (STR-166)
+
+	ingestGrace     time.Duration
+	onIngestExpired func(streamID string) error
+}
+
+// SetIngestDisconnectHandler arme le bail audio des directs. Un flux qui ne
+// reçoit aucun ingest pendant grace est confié au handler, qui termine son état
+// persistant. Appelé une fois au démarrage, avant les requêtes HTTP.
+func (ls *LiveSessions) SetIngestDisconnectHandler(
+	grace time.Duration,
+	handler func(streamID string) error,
+) {
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	ls.ingestGrace = grace
+	ls.onIngestExpired = handler
 }
 
 // NewLiveSessions construit le registre. base est le context de cycle de vie du
@@ -111,6 +129,7 @@ func (ls *LiveSessions) Start(streamID, streamKey string) {
 	}
 	ctx, cancel := context.WithCancel(ls.base)
 	s := &session{
+		streamID:    streamID,
 		streamKey:   streamKey,
 		cancel:      cancel,
 		subscribers: make(map[chan SessionEvent]struct{}),
@@ -135,6 +154,7 @@ func (ls *LiveSessions) Start(streamID, streamKey string) {
 	s.mu.Lock()
 	s.hls = seg
 	s.mu.Unlock()
+	ls.armIngestExpiry(s)
 
 	go func() {
 		defer ls.wg.Done()
@@ -210,6 +230,45 @@ func (ls *LiveSessions) Stop(streamID string) {
 	s.cancel()
 }
 
+// armIngestExpiry (ré)arme le délai de grâce d'une session sans ingest. Le
+// callback est appelé hors verrou ; il peut donc repasser par Service puis Stop
+// sans interblocage.
+func (ls *LiveSessions) armIngestExpiry(s *session) {
+	ls.mu.Lock()
+	grace := ls.ingestGrace
+	handler := ls.onIngestExpired
+	ls.mu.Unlock()
+	if grace <= 0 || handler == nil {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed || s.dead || s.ingesting {
+		return
+	}
+	if s.ingestExpiry != nil {
+		s.ingestExpiry.Stop()
+	}
+	var timer *time.Timer
+	timer = time.AfterFunc(grace, func() {
+		s.mu.Lock()
+		if s.ingestExpiry != timer || s.closed || s.dead || s.ingesting {
+			s.mu.Unlock()
+			return
+		}
+		s.ingestExpiry = nil
+		s.mu.Unlock()
+		if err := handler(s.streamID); err != nil {
+			// Une indisponibilité transitoire de la base ne doit pas désarmer le
+			// garde-fou : tant que la session existe, une nouvelle tentative sera
+			// faite après le même délai de grâce.
+			ls.armIngestExpiry(s)
+		}
+	})
+	s.ingestExpiry = timer
+}
+
 // AttachIngest réserve la session live identifiée par streamKey pour un unique
 // push audio, et retourne l'entrée où copier le flux + une fonction de
 // détachement. Erreurs : errNotLive (clé inconnue / flux pas en direct / segmenteur
@@ -234,11 +293,19 @@ func (ls *LiveSessions) AttachIngest(streamKey string) (io.Writer, func(), error
 	if s.ingesting {
 		return nil, nil, errIngestInProgress
 	}
+	if s.ingestExpiry != nil {
+		s.ingestExpiry.Stop()
+		s.ingestExpiry = nil
+	}
 	s.ingesting = true
+	var once sync.Once
 	release := func() {
-		s.mu.Lock()
-		s.ingesting = false
-		s.mu.Unlock()
+		once.Do(func() {
+			s.mu.Lock()
+			s.ingesting = false
+			s.mu.Unlock()
+			ls.armIngestExpiry(s)
+		})
 	}
 	return s.hls.input(), release, nil
 }
@@ -390,6 +457,10 @@ func (s *session) closeSubscribers() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.closed = true
+	if s.ingestExpiry != nil {
+		s.ingestExpiry.Stop()
+		s.ingestExpiry = nil
+	}
 	for ch := range s.subscribers {
 		close(ch)
 		delete(s.subscribers, ch)

--- a/backend/internal/streaming/session_test.go
+++ b/backend/internal/streaming/session_test.go
@@ -2,6 +2,7 @@ package streaming
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -39,6 +40,101 @@ func TestLiveSessions_StartIdempotent(t *testing.T) {
 		t.Fatal("s1 devrait être live")
 	}
 	ls.Stop("s1")
+}
+
+func TestLiveSessions_IngestExpiryStopsSilentSession(t *testing.T) {
+	ls := newTestSessions(context.Background())
+	expired := make(chan string, 1)
+	ls.SetIngestDisconnectHandler(10*time.Millisecond, func(id string) error {
+		expired <- id
+		return nil
+	})
+	ls.Start("s1", "KEY1")
+	defer ls.StopAll()
+
+	select {
+	case id := <-expired:
+		if id != "s1" {
+			t.Fatalf("id expiré = %q, want s1", id)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("le direct sans ingest n'a pas expiré")
+	}
+}
+
+func TestLiveSessions_IngestReconnectResetsExpiry(t *testing.T) {
+	ls := sessionsWithFakeSeg(t)
+	expired := make(chan string, 1)
+	ls.SetIngestDisconnectHandler(40*time.Millisecond, func(id string) error {
+		expired <- id
+		return nil
+	})
+	ls.Start("s1", "KEY1")
+	defer ls.StopAll()
+
+	_, release, err := ls.AttachIngest("KEY1")
+	if err != nil {
+		t.Fatalf("attach ingest: %v", err)
+	}
+	select {
+	case <-expired:
+		t.Fatal("un ingest actif ne doit pas expirer")
+	case <-time.After(80 * time.Millisecond):
+	}
+
+	release()
+	select {
+	case id := <-expired:
+		if id != "s1" {
+			t.Fatalf("id expiré = %q, want s1", id)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("le délai n'a pas été réarmé après déconnexion")
+	}
+}
+
+func TestLiveSessions_StopCancelsIngestExpiry(t *testing.T) {
+	ls := newTestSessions(context.Background())
+	expired := make(chan string, 1)
+	ls.SetIngestDisconnectHandler(20*time.Millisecond, func(id string) error {
+		expired <- id
+		return nil
+	})
+	ls.Start("s1", "KEY1")
+	ls.Stop("s1")
+
+	select {
+	case <-expired:
+		t.Fatal("un flux arrêté explicitement ne doit pas expirer ensuite")
+	case <-time.After(60 * time.Millisecond):
+	}
+}
+
+func TestLiveSessions_IngestExpiryRetriesAfterHandlerFailure(t *testing.T) {
+	ls := newTestSessions(context.Background())
+	attempts := make(chan int, 2)
+	count := 0
+	ls.SetIngestDisconnectHandler(10*time.Millisecond, func(string) error {
+		count++
+		attempts <- count
+		if count == 1 {
+			return errors.New("database unavailable")
+		}
+		return nil
+	})
+	ls.Start("s1", "KEY1")
+	defer ls.StopAll()
+
+	for want := 1; want <= 2; want++ {
+		select {
+		case got := <-attempts:
+			if got != want {
+				t.Fatalf("tentative = %d, want %d", got, want)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("tentative %d non reçue", want)
+		}
+	}
 }
 
 func TestLiveSessions_SubscribeReceivesEnded(t *testing.T) {

--- a/backend/internal/streaming/session_test.go
+++ b/backend/internal/streaming/session_test.go
@@ -137,6 +137,67 @@ func TestLiveSessions_IngestExpiryRetriesAfterHandlerFailure(t *testing.T) {
 	}
 }
 
+// Le handler d'expiration termine la session hors du verrou de session. Un
+// diffuseur qui se reconnecte pendant cet intervalle doit être refusé : lui
+// rendre un ingest que Stop casserait aussitôt le laisserait pousser dans le
+// vide, sur un flux déjà passé à `ended`.
+func TestLiveSessions_AttachIngestRefusedWhileExpiryStops(t *testing.T) {
+	ls := sessionsWithFakeSeg(t)
+	running := make(chan struct{})
+	release := make(chan struct{})
+	ls.SetIngestDisconnectHandler(10*time.Millisecond, func(string) error {
+		close(running)
+		<-release
+		return nil
+	})
+	ls.Start("s1", "KEY1")
+	defer ls.StopAll()
+
+	select {
+	case <-running:
+	case <-time.After(time.Second):
+		t.Fatal("le bail n'a pas expiré")
+	}
+
+	_, _, err := ls.AttachIngest("KEY1")
+	close(release)
+	if !errors.Is(err, errNotLive) {
+		t.Fatalf("AttachIngest pendant l'arrêt = %v, want errNotLive", err)
+	}
+}
+
+// Miroir du test précédent : si l'arrêt échoue, la session reste live et le
+// diffuseur doit pouvoir se rattacher — le refus ne doit pas être définitif.
+func TestLiveSessions_AttachIngestAllowedAfterFailedExpiryStop(t *testing.T) {
+	ls := sessionsWithFakeSeg(t)
+	failed := make(chan struct{}, 2)
+	count := 0
+	ls.SetIngestDisconnectHandler(10*time.Millisecond, func(string) error {
+		count++
+		failed <- struct{}{}
+		return errors.New("database unavailable")
+	})
+	ls.Start("s1", "KEY1")
+	defer ls.StopAll()
+
+	select {
+	case <-failed:
+	case <-time.After(time.Second):
+		t.Fatal("le bail n'a pas expiré")
+	}
+
+	// Le réarmement suit immédiatement l'échec ; on laisse la goroutine du
+	// timer repasser par armIngestExpiry avant de tenter le rattachement.
+	var err error
+	for i := 0; i < 100; i++ {
+		if _, _, err = ls.AttachIngest("KEY1"); err == nil {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("AttachIngest après un arrêt en échec = %v, want nil", err)
+}
+
 func TestLiveSessions_SubscribeReceivesEnded(t *testing.T) {
 	ls := newTestSessions(context.Background())
 	ls.Start("s1", "")

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -65,6 +65,8 @@ services:
       # cette variable, le backend retombe sur http://localhost:8080 (config.go),
       # inutilisable en prod où l'API est exposée via Caddy sur le domaine public.
       STREAM_INGEST_BASE_URL: ${STREAM_INGEST_BASE_URL:-https://api.streampulse.win}
+      INGEST_RECONNECT_GRACE_SECONDS: ${INGEST_RECONNECT_GRACE_SECONDS:-45}
+      INGEST_STOP_TIMEOUT_SECONDS: ${INGEST_STOP_TIMEOUT_SECONDS:-10}
       # LOG_PRETTY volontairement absent : en conteneur la sortie doit rester
       # du JSON pour la collecte Loki (STR-163, ADR 018).
       LOG_LEVEL: ${LOG_LEVEL:-info}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,8 @@ services:
       APP_BASE_URL: ${APP_BASE_URL:-http://localhost:8080}
       CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
       STREAM_INGEST_BASE_URL: ${STREAM_INGEST_BASE_URL:-http://localhost:8080}
+      INGEST_RECONNECT_GRACE_SECONDS: ${INGEST_RECONNECT_GRACE_SECONDS:-45}
+      INGEST_STOP_TIMEOUT_SECONDS: ${INGEST_STOP_TIMEOUT_SECONDS:-10}
       # Comptage d'audience derrière un reverse proxy (STR-154, ADR 025).
       # false en local ; true uniquement quand Caddy est devant, sinon le
       # compteur d'auditeurs sature à 1.

--- a/docs/adr/024-tableau-de-bord-diffuseur-lancer-et-arreter-un-flux.md
+++ b/docs/adr/024-tableau-de-bord-diffuseur-lancer-et-arreter-un-flux.md
@@ -22,6 +22,11 @@ laissant l'encodeur du diffuseur pousser vers l'URL d'ingest ?
 
 ### 1. Plan de contrôle uniquement — la capture micro sort du périmètre
 
+> **Mise à jour 2026-08-04** — Cette limite est levée par
+> [l'ADR 027](027-capture-microphone-et-push-aac-mobile.md) : `record` 6.2.1
+> sait désormais streamer de l'AAC/ADTS sur Android et iOS. La décision
+> ci-dessous reste l'historique du périmètre de STR-153.
+
 Le tableau de bord crée, démarre et arrête les flux, et remet au diffuseur l'URL d'ingest à
 donner à son encodeur (ffmpeg, BUTT, Mixxx). Il ne capture pas le micro.
 

--- a/docs/adr/027-capture-microphone-et-push-aac-mobile.md
+++ b/docs/adr/027-capture-microphone-et-push-aac-mobile.md
@@ -1,0 +1,109 @@
+# ADR 027 — Capture microphone et push AAC depuis l'application mobile
+
+**Date** : 2026-08-04
+**Statut** : Accepté
+**Ticket** : [STR-156](https://linear.app/streampulse/issue/STR-156)
+
+---
+
+## Contexte
+
+Le tableau de bord livré par STR-153 pilote le cycle de vie d'un flux mais
+laisse un encodeur externe pousser l'audio vers `stream_source_url`. STR-156
+doit rendre la diffusion autonome depuis iOS et Android : permission micro,
+encodage compatible avec l'ingest et reprise après une coupure réseau.
+
+Le backend attend un flux **AAC avec en-têtes ADTS** et le transmet à ffmpeg
+avec `-c:a copy` ([ADR 015](015-moteur-hls-segmentation-ffmpeg.md)). Il ne faut
+donc ni lui envoyer du PCM, ni lui faire supporter le coût CPU d'un transcodage
+par diffuseur.
+
+L'analyse initiale de STR-153 reposait sur `record` v5, qui ne savait streamer
+que du PCM16. Depuis `record` 6.2.0, Android et iOS savent produire un stream
+AAC/ADTS ; la version 6.2.1 corrige en plus un crash possible du stream AAC sur
+Android. `record` 7 demande Flutter 3.44 / Dart 3.12, au-delà de la toolchain du
+projet (Flutter 3.41 / Dart 3.11).
+
+## Décision
+
+### 1. `record` 6.2.1, AAC-LC mono 44,1 kHz à 64 kbit/s
+
+L'application utilise `AudioRecorder.startStream` avec `AudioEncoder.aacLc`.
+La permission et `isEncoderSupported` sont vérifiés **avant** l'appel
+`PATCH /start` : un refus de permission ou un appareil incompatible ne doit
+jamais créer un direct silencieux.
+
+Si le serveur a accepté le démarrage mais que la capture échoue avant le
+premier push, le client appelle immédiatement `PATCH /stop` et rend l'erreur à
+l'écran.
+
+### 2. Corps HTTP brut chunked, malgré le mot « multipart » du ticket
+
+Le contrat réel de l'ingest est un corps brut `Content-Type: audio/aac`, pas un
+formulaire multipart. Un client Dio dédié envoie directement le
+`Stream<List<int>>` sans `Content-Length` : l'adaptateur IO utilise ainsi le
+transfert HTTP chunked, sans fichier temporaire ni accumulation en mémoire.
+
+Ce client n'hérite ni du timeout de réception des appels REST courts, ni de
+l'intercepteur JWT : la requête dure tout le direct et l'authentification est
+portée par la clé secrète dans l'URL.
+
+### 3. Reconnexion avec un nouvel encodeur et un backoff borné
+
+Une fin de requête ou une erreur réseau pendant que la diffusion est désirée
+déclenche une nouvelle tentative après 1, 2, 4, 8, 16 puis 30 secondes. Chaque
+tentative redémarre `record`, afin que le nouveau corps commence par des trames
+AAC/ADTS autonomes. L'interface affiche « Reconnexion audio… » pendant cette
+fenêtre et le bouton Arrêter reste disponible.
+
+### 4. Diffusion au premier plan uniquement
+
+`record` ne garantit pas à lui seul une capture continue en arrière-plan sur
+iOS et Android. Ajouter un service foreground Android et une stratégie iOS
+spécifique augmenterait fortement le périmètre et donnerait des comportements
+différents selon l'OS.
+
+La règle mobile est explicite : quand l'application reçoit
+`paused`, `hidden` ou `detached`, elle termine d'abord le flux côté serveur puis
+libère le micro. Ainsi, une suspension normale de l'OS ne laisse pas un statut
+`live` sans audio. `inactive` est ignoré, car cet état transitoire apparaît
+notamment pendant la boîte de permission micro.
+
+Le serveur couvre le cas où aucun callback ne peut partir : chaque session live
+porte un bail d'ingest configurable (`INGEST_RECONNECT_GRACE_SECONDS`, 45
+secondes par défaut), armé dès le démarrage puis réarmé à
+chaque déconnexion. La deadline réseau est elle aussi glissante : une socket
+half-open sans nouveaux octets finit par libérer le slot. Une reconnexion
+annule le timer ; sinon le backend passe le flux à `ended`, ferme ffmpeg et
+notifie les abonnés. Un échec persistant est borné par
+`INGEST_STOP_TIMEOUT_SECONDS` (10 secondes par défaut), puis le bail est réarmé
+pour réessayer. Le délai par défaut dépasse le plus grand backoff mobile (30
+secondes), ce qui laisse une tentative de reprise sans conserver indéfiniment
+un live silencieux.
+
+### 5. Pas de capture sur Flutter web
+
+L'adaptateur HTTP navigateur ne sait pas pousser ce corps streamé de la même
+manière. La vérification échoue avant le démarrage avec un message
+d'indisponibilité ; aucun live muet n'est créé.
+
+## Alternatives écartées
+
+- Enregistrer un fichier `.aac` et le lire pendant son écriture : dépendance au
+  flush de la plateforme, latence et reprise fragile.
+- Écrire un encodeur via platform channel : doublon désormais inutile avec
+  `record` 6.2.1.
+- Envoyer du PCM et transcoder côté backend : coût CPU permanent, et préempte
+  la décision de STR-224.
+- Maintenir le direct en arrière-plan dès ce lot : nécessite un service
+  foreground et une UX de notification, avec des contraintes iOS distinctes.
+
+## Conséquences
+
+- Le bouton « Démarrer » active désormais le micro du téléphone ; l'URL reste
+  affichée pour les encodeurs externes et le diagnostic.
+- Une coupure réseau ne termine pas immédiatement le direct : le client tente
+  de reprendre et expose son état dans la carte.
+- La mise en arrière-plan termine volontairement la diffusion.
+- Le protocole est verrouillé par un test HTTP réel : octets bruts, type
+  `audio/aac`, absence de `Content-Length`.

--- a/docs/adr/027-capture-microphone-et-push-aac-mobile.md
+++ b/docs/adr/027-capture-microphone-et-push-aac-mobile.md
@@ -48,13 +48,29 @@ Ce client n'hérite ni du timeout de réception des appels REST courts, ni de
 l'intercepteur JWT : la requête dure tout le direct et l'authentification est
 portée par la clé secrète dans l'URL.
 
-### 3. Reconnexion avec un nouvel encodeur et un backoff borné
+### 3. Reconnexion avec un nouvel encodeur, un backoff borné et un abandon borné
 
 Une fin de requête ou une erreur réseau pendant que la diffusion est désirée
 déclenche une nouvelle tentative après 1, 2, 4, 8, 16 puis 30 secondes. Chaque
 tentative redémarre `record`, afin que le nouveau corps commence par des trames
 AAC/ADTS autonomes. L'interface affiche « Reconnexion audio… » pendant cette
 fenêtre et le bouton Arrêter reste disponible.
+
+Toutes les pannes ne sont pas des coupures réseau : une permission révoquée en
+cours de direct, un micro capté par une autre application ou un encodeur en
+échec ne guériront pas d'eux-mêmes. Le nombre de tentatives **consécutives
+n'ayant transmis aucun octet** est donc borné (six, soit la rampe complète du
+backoff, ~31 s). Au-delà, le diffuseur audio passe à l'état terminal `failed` ;
+le contrôleur de session termine alors le direct côté serveur et l'écran
+l'annonce, plutôt que de laisser la carte figée sur « Reconnexion audio… »
+jusqu'à l'expiration du bail. Une tentative qui transmet de l'audio réarme à la
+fois ce compteur et la rampe de backoff : un direct de plusieurs heures ne doit
+pas céder à la énième micro-coupure.
+
+L'état `live` n'est émis qu'au **premier octet réellement poussé**, pas à
+l'ouverture du micro : le signaler plus tôt ferait clignoter la ligne micro
+entre « Microphone diffusé » et « Reconnexion audio… » à chaque cycle de backoff
+sur une connexion qui n'aboutit jamais.
 
 ### 4. Diffusion au premier plan uniquement
 
@@ -79,13 +95,27 @@ notifie les abonnés. Un échec persistant est borné par
 `INGEST_STOP_TIMEOUT_SECONDS` (10 secondes par défaut), puis le bail est réarmé
 pour réessayer. Le délai par défaut dépasse le plus grand backoff mobile (30
 secondes), ce qui laisse une tentative de reprise sans conserver indéfiniment
-un live silencieux.
+un live silencieux. Cet invariant est **validé au démarrage** : l'API refuse un
+`INGEST_RECONNECT_GRACE_SECONDS` inférieur ou égal à 30, qui couperait les
+directs pendant la fenêtre de reconnexion normale du téléphone.
+
+Pendant que le handler d'expiration termine la session (hors verrou), la
+session est marquée « en fermeture » : un diffuseur qui se reconnecterait dans
+cet intervalle est refusé, plutôt que d'obtenir un ingest aussitôt cassé par
+l'arrêt sur un flux déjà passé à `ended`.
 
 ### 5. Pas de capture sur Flutter web
 
 L'adaptateur HTTP navigateur ne sait pas pousser ce corps streamé de la même
 manière. La vérification échoue avant le démarrage avec un message
 d'indisponibilité ; aucun live muet n'est créé.
+
+L'indisponibilité est portée par le contrat (`BroadcastAudioPublisher
+.isSupported`) et non déduite de `kIsWeb` par l'écran : le tableau de bord
+**désactive** le bouton « Démarrer la diffusion » et indique que la diffusion
+se fait depuis l'application mobile, plutôt que de laisser l'utilisateur
+découvrir l'indisponibilité après un tap. L'URL d'ingest reste affichée : un
+encodeur externe, lui, fonctionne depuis n'importe quelle plateforme.
 
 ## Alternatives écartées
 
@@ -103,7 +133,9 @@ d'indisponibilité ; aucun live muet n'est créé.
 - Le bouton « Démarrer » active désormais le micro du téléphone ; l'URL reste
   affichée pour les encodeurs externes et le diagnostic.
 - Une coupure réseau ne termine pas immédiatement le direct : le client tente
-  de reprendre et expose son état dans la carte.
+  de reprendre et expose son état dans la carte. La reprise est bornée, et la
+  carte le dit — un direct peut donc s'arrêter sans action de l'utilisateur,
+  auquel cas un message l'explique.
 - La mise en arrière-plan termine volontairement la diffusion.
 - Le protocole est verrouillé par un test HTTP réel : octets bruts, type
   `audio/aac`, absence de `Content-Length`.

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -60,7 +60,7 @@ caractères → l'API refuse de démarrer.
 | `DB_USER` | Utilisateur PostgreSQL | — | **Oui** |
 | `DB_PASSWORD` | Mot de passe PostgreSQL | — | **Oui** |
 | `DB_NAME` | Nom de la base PostgreSQL | — | **Oui** |
-| `INGEST_RECONNECT_GRACE_SECONDS` | Délai sans audio avant l'arrêt automatique d'un live | `45` | Non |
+| `INGEST_RECONNECT_GRACE_SECONDS` | Délai sans audio avant l'arrêt automatique d'un live (doit dépasser 30 s, le backoff mobile max — refusé au démarrage sinon) | `45` | Non |
 | `INGEST_STOP_TIMEOUT_SECONDS` | Timeout d'une tentative d'arrêt automatique en base | `10` | Non |
 
 > **Note :** en compose, le service `api` reçoit `DB_HOST=postgres` (nom du service Docker),

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -60,6 +60,8 @@ caractères → l'API refuse de démarrer.
 | `DB_USER` | Utilisateur PostgreSQL | — | **Oui** |
 | `DB_PASSWORD` | Mot de passe PostgreSQL | — | **Oui** |
 | `DB_NAME` | Nom de la base PostgreSQL | — | **Oui** |
+| `INGEST_RECONNECT_GRACE_SECONDS` | Délai sans audio avant l'arrêt automatique d'un live | `45` | Non |
+| `INGEST_STOP_TIMEOUT_SECONDS` | Timeout d'une tentative d'arrêt automatique en base | `10` | Non |
 
 > **Note :** en compose, le service `api` reçoit `DB_HOST=postgres` (nom du service Docker),
 > tandis qu'en dev natif (hors compose) `DB_HOST=localhost`. Les deux cas sont couverts par

--- a/mobile/ios/Podfile.lock
+++ b/mobile/ios/Podfile.lock
@@ -10,6 +10,8 @@ PODS:
   - just_audio (0.0.1):
     - Flutter
     - FlutterMacOS
+  - record_ios (1.2.1):
+    - Flutter
   - sqflite_darwin (0.0.4):
     - Flutter
     - FlutterMacOS
@@ -20,6 +22,7 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - just_audio (from `.symlinks/plugins/just_audio/darwin`)
+  - record_ios (from `.symlinks/plugins/record_ios/ios`)
   - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
 
 EXTERNAL SOURCES:
@@ -33,6 +36,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_secure_storage/ios"
   just_audio:
     :path: ".symlinks/plugins/just_audio/darwin"
+  record_ios:
+    :path: ".symlinks/plugins/record_ios/ios"
   sqflite_darwin:
     :path: ".symlinks/plugins/sqflite_darwin/darwin"
 
@@ -42,6 +47,7 @@ SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
   just_audio: 4e391f57b79cad2b0674030a00453ca5ce817eed
+  record_ios: 980fd386a97a35987d0fce3dfda4b26a38c90f4c
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
 
 PODFILE CHECKSUM: 3c63482e143d1b91d2d2560aee9fb04ecc74ac7e

--- a/mobile/lib/core/utils/retry_backoff.dart
+++ b/mobile/lib/core/utils/retry_backoff.dart
@@ -1,0 +1,6 @@
+/// Backoff exponentiel 1, 2, 4… secondes, plafonné sans risque de débordement
+/// du décalage binaire lors d'une panne prolongée.
+Duration cappedExponentialBackoff(int attempt, {int maxSeconds = 30}) {
+  final seconds = attempt >= 5 ? maxSeconds : 1 << attempt;
+  return Duration(seconds: seconds > maxSeconds ? maxSeconds : seconds);
+}

--- a/mobile/lib/features/broadcast/data/services/audio_capture.dart
+++ b/mobile/lib/features/broadcast/data/services/audio_capture.dart
@@ -1,0 +1,10 @@
+import 'dart:typed_data';
+
+/// Source audio injectable, indépendante des canaux de plateforme de `record`.
+abstract interface class AudioCapture {
+  Future<bool> hasPermission();
+  Future<bool> supportsAacAdts();
+  Future<Stream<Uint8List>> start();
+  Future<void> stop();
+  Future<void> dispose();
+}

--- a/mobile/lib/features/broadcast/data/services/audio_ingest_client.dart
+++ b/mobile/lib/features/broadcast/data/services/audio_ingest_client.dart
@@ -1,0 +1,5 @@
+/// Une tentative HTTP. Sa durée est celle de la requête chunked entière.
+abstract interface class AudioIngestClient {
+  Future<void> push(Uri sourceUrl, Stream<List<int>> audio);
+  Future<void> cancel();
+}

--- a/mobile/lib/features/broadcast/data/services/dio_audio_ingest_client.dart
+++ b/mobile/lib/features/broadcast/data/services/dio_audio_ingest_client.dart
@@ -1,0 +1,49 @@
+import 'package:dio/dio.dart';
+
+import 'audio_ingest_client.dart';
+
+/// Client Dio sans timeout de réception ni intercepteur d'auth, dédié aux
+/// requêtes d'ingest longues. Un `Stream` sans `Content-Length` devient un
+/// transfert HTTP chunked sans accumulation en mémoire.
+class DioAudioIngestClient implements AudioIngestClient {
+  DioAudioIngestClient([Dio? dio])
+    : _dio =
+          dio ??
+          Dio(
+            BaseOptions(
+              connectTimeout: const Duration(seconds: 10),
+              receiveTimeout: null,
+              sendTimeout: null,
+            ),
+          );
+
+  final Dio _dio;
+  CancelToken? _cancelToken;
+
+  @override
+  Future<void> push(Uri sourceUrl, Stream<List<int>> audio) async {
+    final token = CancelToken();
+    _cancelToken = token;
+    try {
+      await _dio.postUri<void>(
+        sourceUrl,
+        data: audio,
+        cancelToken: token,
+        options: Options(
+          contentType: 'audio/aac',
+          responseType: ResponseType.plain,
+          validateStatus: (status) =>
+              status != null && status >= 200 && status < 300,
+        ),
+      );
+    } finally {
+      if (identical(_cancelToken, token)) _cancelToken = null;
+    }
+  }
+
+  @override
+  Future<void> cancel() async {
+    _cancelToken?.cancel('Diffusion audio arrêtée');
+    _cancelToken = null;
+  }
+}

--- a/mobile/lib/features/broadcast/data/services/microphone_audio_publisher.dart
+++ b/mobile/lib/features/broadcast/data/services/microphone_audio_publisher.dart
@@ -1,0 +1,158 @@
+import 'dart:async';
+
+import '../../../../core/utils/retry_backoff.dart';
+import '../../domain/services/broadcast_audio_publisher.dart';
+import 'audio_capture.dart';
+import 'audio_ingest_client.dart';
+import 'dio_audio_ingest_client.dart';
+import 'record_audio_capture.dart';
+
+/// Orchestre capture, push et reconnexion sans jamais mettre les octets audio
+/// en tampon. Une nouvelle tentative redémarre l'encodeur afin que le serveur
+/// reçoive un flux AAC/ADTS autonome après chaque coupure.
+class MicrophoneAudioPublisher implements BroadcastAudioPublisher {
+  MicrophoneAudioPublisher({
+    AudioCapture? capture,
+    AudioIngestClient? ingest,
+    Duration Function(int attempt)? backoff,
+  }) : _capture = capture ?? RecordAudioCapture(),
+       _ingest = ingest ?? DioAudioIngestClient(),
+       _backoff = backoff ?? cappedExponentialBackoff;
+
+  final AudioCapture _capture;
+  final AudioIngestClient _ingest;
+  final Duration Function(int attempt) _backoff;
+  final StreamController<BroadcastAudioState> _states =
+      StreamController<BroadcastAudioState>.broadcast();
+
+  BroadcastAudioState _state = BroadcastAudioState.idle;
+  bool _desired = false;
+  bool _disposed = false;
+  Future<void>? _runFuture;
+  Completer<void>? _retryGate;
+
+  @override
+  BroadcastAudioState get state => _state;
+
+  @override
+  Stream<BroadcastAudioState> get states => _states.stream;
+
+  @override
+  Future<void> prepare() async {
+    if (!await _capture.hasPermission()) {
+      throw const MicrophonePermissionException();
+    }
+    if (!await _capture.supportsAacAdts()) {
+      throw const AudioEncoderUnsupportedException();
+    }
+  }
+
+  @override
+  Future<void> start(Uri sourceUrl) async {
+    if (_disposed) throw StateError('Diffuseur audio déjà libéré');
+    if (_desired) return;
+    if (sourceUrl.scheme != 'http' && sourceUrl.scheme != 'https') {
+      throw ArgumentError.value(sourceUrl, 'sourceUrl', 'URL HTTP(S) attendue');
+    }
+
+    _desired = true;
+    final firstAttempt = Completer<void>();
+    _runFuture = _run(sourceUrl, firstAttempt);
+    await firstAttempt.future;
+  }
+
+  Future<void> _run(Uri sourceUrl, Completer<void> firstAttempt) async {
+    var attempt = 0;
+    Object? initialError;
+    StackTrace? initialStackTrace;
+    try {
+      while (_desired) {
+        _emit(
+          attempt == 0
+              ? BroadcastAudioState.connecting
+              : BroadcastAudioState.reconnecting,
+        );
+        try {
+          final audio = await _capture.start();
+          if (!_desired) break;
+
+          _emit(BroadcastAudioState.live);
+          if (!firstAttempt.isCompleted) firstAttempt.complete();
+          await _ingest.push(sourceUrl, audio);
+        } catch (error, stackTrace) {
+          // Une erreur avant même l'obtention du flux micro est un échec de
+          // démarrage. Une coupure après démarrage, elle, est transitoire et
+          // déclenche la reprise ci-dessous.
+          if (!firstAttempt.isCompleted) {
+            _desired = false;
+            initialError = error;
+            initialStackTrace = stackTrace;
+          }
+        } finally {
+          await _closeAttempt();
+        }
+
+        if (!_desired) break;
+        _emit(BroadcastAudioState.reconnecting);
+        await _waitForRetry(_backoff(attempt));
+        attempt++;
+      }
+    } finally {
+      _emit(BroadcastAudioState.idle);
+      if (initialError != null && !firstAttempt.isCompleted) {
+        firstAttempt.completeError(initialError, initialStackTrace!);
+      } else if (!firstAttempt.isCompleted) {
+        firstAttempt.completeError(StateError('Démarrage audio interrompu'));
+      }
+    }
+  }
+
+  Future<void> _closeAttempt() async {
+    try {
+      await _ingest.cancel();
+    } catch (_) {
+      // La requête est déjà cassée : son annulation ne doit pas tuer la boucle
+      // de reconnexion.
+    }
+    try {
+      await _capture.stop();
+    } catch (_) {
+      // Certaines plateformes signalent une erreur si l'enregistreur s'est
+      // déjà arrêté lors d'une interruption audio. La tentative suivante
+      // recrée malgré tout un stream propre.
+    }
+  }
+
+  Future<void> _waitForRetry(Duration duration) async {
+    final gate = Completer<void>();
+    _retryGate = gate;
+    await Future.any([Future<void>.delayed(duration), gate.future]);
+    if (identical(_retryGate, gate)) _retryGate = null;
+  }
+
+  @override
+  Future<void> stop() async {
+    _desired = false;
+    final gate = _retryGate;
+    if (gate != null && !gate.isCompleted) gate.complete();
+    await _closeAttempt();
+    await _runFuture;
+    _runFuture = null;
+    _emit(BroadcastAudioState.idle);
+  }
+
+  void _emit(BroadcastAudioState state) {
+    if (_state == state) return;
+    _state = state;
+    if (!_disposed) _states.add(state);
+  }
+
+  @override
+  Future<void> dispose() async {
+    if (_disposed) return;
+    await stop();
+    _disposed = true;
+    await _capture.dispose();
+    await _states.close();
+  }
+}

--- a/mobile/lib/features/broadcast/data/services/microphone_audio_publisher.dart
+++ b/mobile/lib/features/broadcast/data/services/microphone_audio_publisher.dart
@@ -15,13 +15,28 @@ class MicrophoneAudioPublisher implements BroadcastAudioPublisher {
     AudioCapture? capture,
     AudioIngestClient? ingest,
     Duration Function(int attempt)? backoff,
+    int maxSilentAttempts = _defaultMaxSilentAttempts,
   }) : _capture = capture ?? RecordAudioCapture(),
        _ingest = ingest ?? DioAudioIngestClient(),
-       _backoff = backoff ?? cappedExponentialBackoff;
+       _backoff = backoff ?? cappedExponentialBackoff,
+       _maxSilentAttempts = maxSilentAttempts;
+
+  /// Nombre de tentatives consécutives n'ayant transmis aucun octet avant
+  /// d'abandonner. Toutes les pannes ne sont pas des coupures réseau : une
+  /// permission révoquée en cours de direct, un micro capté par une autre
+  /// application ou un encodeur en échec ne guériront pas d'eux-mêmes, et une
+  /// reprise sans borne laisserait la carte figée sur « Reconnexion audio… ».
+  ///
+  /// Six tentatives couvrent la rampe complète du backoff
+  /// (1 + 2 + 4 + 8 + 16 = 31 s d'attente), soit plus que le plus long délai
+  /// utile côté client et moins que le bail d'ingest du serveur, qui prendrait
+  /// de toute façon le relais (`INGEST_RECONNECT_GRACE_SECONDS` > 30 s).
+  static const int _defaultMaxSilentAttempts = 6;
 
   final AudioCapture _capture;
   final AudioIngestClient _ingest;
   final Duration Function(int attempt) _backoff;
+  final int _maxSilentAttempts;
   final StreamController<BroadcastAudioState> _states =
       StreamController<BroadcastAudioState>.broadcast();
 
@@ -30,6 +45,9 @@ class MicrophoneAudioPublisher implements BroadcastAudioPublisher {
   bool _disposed = false;
   Future<void>? _runFuture;
   Completer<void>? _retryGate;
+
+  @override
+  bool get isSupported => true;
 
   @override
   BroadcastAudioState get state => _state;
@@ -52,7 +70,14 @@ class MicrophoneAudioPublisher implements BroadcastAudioPublisher {
     if (_disposed) throw StateError('Diffuseur audio déjà libéré');
     if (_desired) return;
     if (sourceUrl.scheme != 'http' && sourceUrl.scheme != 'https') {
-      throw ArgumentError.value(sourceUrl, 'sourceUrl', 'URL HTTP(S) attendue');
+      // Seul le schéma est rapporté : l'URL d'ingest porte le `stream_key` en
+      // clair, et le message d'une exception finit facilement dans un log ou
+      // un rapport de crash.
+      throw ArgumentError.value(
+        sourceUrl.scheme,
+        'sourceUrl.scheme',
+        'URL HTTP(S) attendue',
+      );
     }
 
     _desired = true;
@@ -62,23 +87,39 @@ class MicrophoneAudioPublisher implements BroadcastAudioPublisher {
   }
 
   Future<void> _run(Uri sourceUrl, Completer<void> firstAttempt) async {
-    var attempt = 0;
+    var started = false;
+    var silentAttempts = 0;
+    var gaveUp = false;
     Object? initialError;
     StackTrace? initialStackTrace;
     try {
       while (_desired) {
         _emit(
-          attempt == 0
-              ? BroadcastAudioState.connecting
-              : BroadcastAudioState.reconnecting,
+          started
+              ? BroadcastAudioState.reconnecting
+              : BroadcastAudioState.connecting,
         );
+        var pushedBytes = false;
         try {
           final audio = await _capture.start();
           if (!_desired) break;
 
-          _emit(BroadcastAudioState.live);
+          started = true;
           if (!firstAttempt.isCompleted) firstAttempt.complete();
-          await _ingest.push(sourceUrl, audio);
+          // `live` n'est émis qu'au premier octet réellement poussé : le
+          // signaler dès l'ouverture du micro ferait clignoter la carte entre
+          // « Microphone diffusé » et « Reconnexion audio… » à chaque cycle de
+          // backoff sur une connexion qui n'aboutit jamais.
+          await _ingest.push(
+            sourceUrl,
+            audio.map((chunk) {
+              if (!pushedBytes && chunk.isNotEmpty) {
+                pushedBytes = true;
+                _emit(BroadcastAudioState.live);
+              }
+              return chunk;
+            }),
+          );
         } catch (error, stackTrace) {
           // Une erreur avant même l'obtention du flux micro est un échec de
           // démarrage. Une coupure après démarrage, elle, est transitoire et
@@ -93,12 +134,24 @@ class MicrophoneAudioPublisher implements BroadcastAudioPublisher {
         }
 
         if (!_desired) break;
+        // Une tentative qui a transmis de l'audio prouve que la chaîne est
+        // saine : le compteur d'abandon ET la rampe de backoff repartent de
+        // zéro, sinon un direct de plusieurs heures finirait par attendre 30 s
+        // à la moindre micro-coupure.
+        if (pushedBytes) {
+          silentAttempts = 0;
+        } else if (++silentAttempts >= _maxSilentAttempts) {
+          gaveUp = true;
+          _desired = false;
+          break;
+        }
         _emit(BroadcastAudioState.reconnecting);
-        await _waitForRetry(_backoff(attempt));
-        attempt++;
+        await _waitForRetry(
+          _backoff(silentAttempts == 0 ? 0 : silentAttempts - 1),
+        );
       }
     } finally {
-      _emit(BroadcastAudioState.idle);
+      _emit(gaveUp ? BroadcastAudioState.failed : BroadcastAudioState.idle);
       if (initialError != null && !firstAttempt.isCompleted) {
         firstAttempt.completeError(initialError, initialStackTrace!);
       } else if (!firstAttempt.isCompleted) {

--- a/mobile/lib/features/broadcast/data/services/record_audio_capture.dart
+++ b/mobile/lib/features/broadcast/data/services/record_audio_capture.dart
@@ -1,0 +1,42 @@
+import 'dart:typed_data';
+
+import 'package:record/record.dart';
+
+import 'audio_capture.dart';
+
+/// Capture AAC/ADTS native avec la configuration voix de StreamPulse.
+class RecordAudioCapture implements AudioCapture {
+  RecordAudioCapture([AudioRecorder? recorder])
+    : _recorder = recorder ?? AudioRecorder();
+
+  final AudioRecorder _recorder;
+
+  @override
+  Future<bool> hasPermission() => _recorder.hasPermission();
+
+  @override
+  Future<bool> supportsAacAdts() =>
+      _recorder.isEncoderSupported(AudioEncoder.aacLc);
+
+  @override
+  Future<Stream<Uint8List>> start() => _recorder.startStream(
+    const RecordConfig(
+      encoder: AudioEncoder.aacLc,
+      bitRate: 64000,
+      sampleRate: 44100,
+      numChannels: 1,
+      autoGain: true,
+      echoCancel: true,
+      noiseSuppress: true,
+      audioInterruption: AudioInterruptionMode.pauseResume,
+    ),
+  );
+
+  @override
+  Future<void> stop() async {
+    await _recorder.stop();
+  }
+
+  @override
+  Future<void> dispose() => _recorder.dispose();
+}

--- a/mobile/lib/features/broadcast/domain/services/broadcast_audio_publisher.dart
+++ b/mobile/lib/features/broadcast/domain/services/broadcast_audio_publisher.dart
@@ -1,5 +1,10 @@
 /// Etat du chemin audio local, distinct du statut métier du flux côté API.
-enum BroadcastAudioState { idle, connecting, live, reconnecting }
+///
+/// [failed] est terminal et n'est émis *que* de la propre initiative du
+/// diffuseur audio, lorsqu'il renonce à se reconnecter. Un arrêt demandé passe
+/// toujours par [idle] : le contrôleur peut donc distinguer une panne d'un
+/// arrêt volontaire sans drapeau supplémentaire.
+enum BroadcastAudioState { idle, connecting, live, reconnecting, failed }
 
 /// Capture le microphone et pousse l'audio vers l'URL d'ingest d'un direct.
 ///
@@ -7,6 +12,11 @@ enum BroadcastAudioState { idle, connecting, live, reconnecting }
 /// la permission et vérifier l'encodeur *avant* de passer le flux à `live`,
 /// tout en n'ouvrant l'ingest qu'après la réponse de l'API.
 abstract interface class BroadcastAudioPublisher {
+  /// Faux quand la plateforme ne sait pas capturer et pousser l'audio. L'écran
+  /// s'en sert pour neutraliser le démarrage en amont, plutôt que de laisser
+  /// l'utilisateur découvrir l'indisponibilité après un tap.
+  bool get isSupported;
+
   BroadcastAudioState get state;
   Stream<BroadcastAudioState> get states;
 
@@ -35,6 +45,9 @@ class AudioEncoderUnsupportedException implements Exception {
 /// L'échec survient pendant [prepare], donc avant le passage serveur à `live`.
 class UnsupportedBroadcastAudioPublisher implements BroadcastAudioPublisher {
   const UnsupportedBroadcastAudioPublisher();
+
+  @override
+  bool get isSupported => false;
 
   @override
   BroadcastAudioState get state => BroadcastAudioState.idle;

--- a/mobile/lib/features/broadcast/domain/services/broadcast_audio_publisher.dart
+++ b/mobile/lib/features/broadcast/domain/services/broadcast_audio_publisher.dart
@@ -1,0 +1,60 @@
+/// Etat du chemin audio local, distinct du statut métier du flux côté API.
+enum BroadcastAudioState { idle, connecting, live, reconnecting }
+
+/// Capture le microphone et pousse l'audio vers l'URL d'ingest d'un direct.
+///
+/// Le découpage [prepare]/[start] est volontaire : le contrôleur peut demander
+/// la permission et vérifier l'encodeur *avant* de passer le flux à `live`,
+/// tout en n'ouvrant l'ingest qu'après la réponse de l'API.
+abstract interface class BroadcastAudioPublisher {
+  BroadcastAudioState get state;
+  Stream<BroadcastAudioState> get states;
+
+  /// Demande l'accès au micro et vérifie la disponibilité de l'AAC/ADTS.
+  Future<void> prepare();
+
+  /// Démarre la capture et rend la main lorsque le premier push est lancé.
+  /// Les coupures ultérieures sont reprises en interne avec backoff.
+  Future<void> start(Uri sourceUrl);
+
+  /// Interrompt le push et libère le microphone.
+  Future<void> stop();
+
+  Future<void> dispose();
+}
+
+class MicrophonePermissionException implements Exception {
+  const MicrophonePermissionException();
+}
+
+class AudioEncoderUnsupportedException implements Exception {
+  const AudioEncoderUnsupportedException();
+}
+
+/// Repli des plateformes où un corps HTTP streamé n'est pas disponible.
+/// L'échec survient pendant [prepare], donc avant le passage serveur à `live`.
+class UnsupportedBroadcastAudioPublisher implements BroadcastAudioPublisher {
+  const UnsupportedBroadcastAudioPublisher();
+
+  @override
+  BroadcastAudioState get state => BroadcastAudioState.idle;
+
+  @override
+  Stream<BroadcastAudioState> get states => const Stream.empty();
+
+  @override
+  Future<void> prepare() async {
+    throw const AudioEncoderUnsupportedException();
+  }
+
+  @override
+  Future<void> start(Uri sourceUrl) async {
+    throw const AudioEncoderUnsupportedException();
+  }
+
+  @override
+  Future<void> stop() async {}
+
+  @override
+  Future<void> dispose() async {}
+}

--- a/mobile/lib/features/broadcast/presentation/controllers/broadcast_session_controller.dart
+++ b/mobile/lib/features/broadcast/presentation/controllers/broadcast_session_controller.dart
@@ -11,19 +11,33 @@ import '../../domain/services/broadcast_audio_publisher.dart';
 /// Le dashboard conserve ainsi la présentation de la liste/SSE/statistiques,
 /// tandis que les invariants « jamais live sans tentative audio » restent ici.
 class BroadcastSessionController {
-  BroadcastSessionController(this._repository, this._audioPublisher);
+  BroadcastSessionController(this._repository, this._audioPublisher) {
+    _audioSubscription = _audioPublisher?.states.listen(_onAudioState);
+  }
 
   final BroadcastRepository _repository;
   final BroadcastAudioPublisher? _audioPublisher;
 
   String? _publishingStreamId;
   bool _backgroundStopRequested = false;
+  StreamSubscription<BroadcastAudioState>? _audioSubscription;
+  final StreamController<BroadcastAudioFailure> _audioFailures =
+      StreamController<BroadcastAudioFailure>.broadcast();
 
   BroadcastAudioState get audioState =>
       _audioPublisher?.state ?? BroadcastAudioState.idle;
   Stream<BroadcastAudioState> get audioStates =>
       _audioPublisher?.states ?? const Stream.empty();
   String? get publishingStreamId => _publishingStreamId;
+
+  /// Faux quand la plateforme ne sait pas diffuser : sans publisher injecté
+  /// (tests de présentation), rien ne l'interdit.
+  bool get audioSupported => _audioPublisher?.isSupported ?? true;
+
+  /// Emet la fin d'un direct que la capture locale a fait échouer. La
+  /// présentation s'en sert pour réaligner la liste et prévenir l'utilisateur ;
+  /// l'arrêt serveur, lui, est déjà tenté ici.
+  Stream<BroadcastAudioFailure> get audioFailures => _audioFailures.stream;
 
   bool isPublishing(String streamId) => _publishingStreamId == streamId;
 
@@ -102,6 +116,36 @@ class BroadcastSessionController {
     }
   }
 
+  /// Le diffuseur audio ne passe à `failed` que de sa propre initiative, après
+  /// avoir épuisé ses tentatives de reconnexion. Laisser le flux `live` sans
+  /// audio violerait l'invariant « jamais de live silencieux » (ADR 027) : on
+  /// termine donc le direct côté serveur, sans attendre l'expiration du bail.
+  void _onAudioState(BroadcastAudioState state) {
+    if (state != BroadcastAudioState.failed) return;
+    final id = _publishingStreamId;
+    if (id == null) return;
+    unawaited(_endAfterAudioFailure(id));
+  }
+
+  Future<void> _endAfterAudioFailure(String id) async {
+    BroadcastStream? ended;
+    try {
+      ended = await _repository.stopStream(id);
+    } catch (_) {
+      // Réseau toujours coupé — le cas le plus probable quand le micro
+      // renonce — ou direct déjà terminé par un administrateur : le bail
+      // d'ingest du serveur s'en chargera. La panne est signalée sans état
+      // serveur, à charge pour la présentation de resynchroniser.
+    } finally {
+      await _stopAudio(expectedId: id, ignoreErrors: true);
+      if (!_audioFailures.isClosed) {
+        _audioFailures.add(
+          BroadcastAudioFailure(streamId: id, serverState: ended),
+        );
+      }
+    }
+  }
+
   Future<void> _stopAudio({
     String? expectedId,
     bool ignoreErrors = false,
@@ -122,7 +166,24 @@ class BroadcastSessionController {
     }
   }
 
-  Future<void> dispose() => _audioPublisher?.dispose() ?? Future.value();
+  Future<void> dispose() async {
+    await _audioSubscription?.cancel();
+    _audioSubscription = null;
+    await _audioFailures.close();
+    await _audioPublisher?.dispose();
+  }
+}
+
+/// Fin de direct subie : la capture locale a renoncé après avoir épuisé ses
+/// reconnexions, et le direct a été terminé côté serveur dans la foulée.
+class BroadcastAudioFailure {
+  const BroadcastAudioFailure({required this.streamId, this.serverState});
+
+  final String streamId;
+
+  /// Flux tel que renvoyé par l'arrêt, ou null si cet arrêt a lui aussi échoué
+  /// — la liste affichée est alors périmée et doit être rechargée.
+  final BroadcastStream? serverState;
 }
 
 /// Transporte vers la présentation l'état serveur obtenu pendant le rollback,

--- a/mobile/lib/features/broadcast/presentation/controllers/broadcast_session_controller.dart
+++ b/mobile/lib/features/broadcast/presentation/controllers/broadcast_session_controller.dart
@@ -1,0 +1,142 @@
+import 'dart:async';
+
+import '../../../../core/errors/exceptions.dart';
+import '../../domain/entities/broadcast_stream.dart';
+import '../../domain/repositories/broadcast_repository.dart';
+import '../../domain/services/broadcast_audio_publisher.dart';
+
+/// Orchestre une session de diffusion locale : transition serveur, capture
+/// microphone, rollback et politique premier plan (ADR 027).
+///
+/// Le dashboard conserve ainsi la présentation de la liste/SSE/statistiques,
+/// tandis que les invariants « jamais live sans tentative audio » restent ici.
+class BroadcastSessionController {
+  BroadcastSessionController(this._repository, this._audioPublisher);
+
+  final BroadcastRepository _repository;
+  final BroadcastAudioPublisher? _audioPublisher;
+
+  String? _publishingStreamId;
+  bool _backgroundStopRequested = false;
+
+  BroadcastAudioState get audioState =>
+      _audioPublisher?.state ?? BroadcastAudioState.idle;
+  Stream<BroadcastAudioState> get audioStates =>
+      _audioPublisher?.states ?? const Stream.empty();
+  String? get publishingStreamId => _publishingStreamId;
+
+  bool isPublishing(String streamId) => _publishingStreamId == streamId;
+
+  Future<BroadcastStream> start(String id) async {
+    final publisher = _audioPublisher;
+    if (publisher != null) await publisher.prepare();
+    _throwIfBackgrounded();
+
+    final live = await _repository.startStream(id);
+    if (publisher == null) return live;
+
+    try {
+      _throwIfBackgrounded();
+      final rawUrl = live.streamSourceUrl;
+      if (rawUrl == null) {
+        throw const ServerException('URL d\'ingest absente');
+      }
+      _publishingStreamId = id;
+      await publisher.start(Uri.parse(rawUrl));
+      _throwIfBackgrounded();
+      return live;
+    } catch (error, stackTrace) {
+      await _stopAudio(expectedId: id, ignoreErrors: true);
+      try {
+        final rolledBack = await _repository.stopStream(id);
+        throw BroadcastSessionStartException(
+          cause: error,
+          stackTrace: stackTrace,
+          serverState: rolledBack,
+        );
+      } catch (rollbackError) {
+        if (rollbackError is BroadcastSessionStartException) rethrow;
+        throw BroadcastSessionStartException(
+          cause: error,
+          stackTrace: stackTrace,
+          serverState: live,
+          refreshRequired: true,
+        );
+      }
+    }
+  }
+
+  Future<BroadcastStream> stop(String id) async {
+    final ended = await _repository.stopStream(id);
+    if (_publishingStreamId == id) await _stopAudio(expectedId: id);
+    return ended;
+  }
+
+  Future<void> delete(String id) async {
+    await _repository.deleteStream(id);
+    if (_publishingStreamId == id) await _stopAudio(expectedId: id);
+  }
+
+  /// Termine le direct si possible puis libère toujours le microphone.
+  Future<BroadcastStream?> stopForBackground() async {
+    _backgroundStopRequested = true;
+    final id = _publishingStreamId;
+    if (id == null) return null;
+    try {
+      return await _repository.stopStream(id);
+    } finally {
+      if (_publishingStreamId == id) {
+        await _stopAudio(expectedId: id, ignoreErrors: true);
+      }
+    }
+  }
+
+  void setActive(bool active) {
+    if (active) _backgroundStopRequested = false;
+  }
+
+  /// Coupe une capture locale devenue orpheline après resynchronisation API.
+  Future<void> reconcile(BroadcastStream? live) async {
+    if (_publishingStreamId != null && live?.id != _publishingStreamId) {
+      await _stopAudio(ignoreErrors: true);
+    }
+  }
+
+  Future<void> _stopAudio({
+    String? expectedId,
+    bool ignoreErrors = false,
+  }) async {
+    if (expectedId != null && _publishingStreamId != expectedId) return;
+    if (_publishingStreamId == null) return;
+    _publishingStreamId = null;
+    try {
+      await _audioPublisher?.stop();
+    } catch (_) {
+      if (!ignoreErrors) rethrow;
+    }
+  }
+
+  void _throwIfBackgrounded() {
+    if (_backgroundStopRequested) {
+      throw StateError('Démarrage interrompu par la mise en arrière-plan');
+    }
+  }
+
+  Future<void> dispose() => _audioPublisher?.dispose() ?? Future.value();
+}
+
+/// Transporte vers la présentation l'état serveur obtenu pendant le rollback,
+/// sans lui faire réimplémenter l'orchestration de la session audio.
+class BroadcastSessionStartException implements Exception {
+  const BroadcastSessionStartException({
+    required this.cause,
+    required this.stackTrace,
+    required this.serverState,
+    this.refreshRequired = false,
+  });
+
+  final Object cause;
+  final StackTrace stackTrace;
+  final BroadcastStream serverState;
+  final bool refreshRequired;
+}

--- a/mobile/lib/features/broadcast/presentation/providers/broadcast_notifier.dart
+++ b/mobile/lib/features/broadcast/presentation/providers/broadcast_notifier.dart
@@ -48,6 +48,23 @@ class BroadcastNotifier extends ChangeNotifier {
     _audioSubscription = _sessionController.audioStates.listen(
       (_) => _safeNotify(),
     );
+    // Le contrôleur a déjà terminé le direct côté serveur : il reste à
+    // réaligner la liste, dont la tuile est encore affichée « en direct ».
+    // Une panne du micro va souvent de pair avec une panne réseau — on
+    // privilégie donc l'état rendu par l'arrêt, et on ne recharge que s'il
+    // manque.
+    _audioFailureSubscription = _sessionController.audioFailures.listen((
+      failure,
+    ) {
+      final ended = failure.serverState;
+      if (ended == null) {
+        unawaited(refresh());
+        return;
+      }
+      _replace(ended);
+      _safeNotify();
+      _syncSubscription();
+    });
   }
 
   final BroadcastRepository _repository;
@@ -84,6 +101,7 @@ class BroadcastNotifier extends ChangeNotifier {
 
   StreamSubscription<SseEvent>? _sseSubscription;
   StreamSubscription<BroadcastAudioState>? _audioSubscription;
+  StreamSubscription<BroadcastAudioFailure>? _audioFailureSubscription;
   Timer? _reconnectTimer;
   Timer? _pollTimer;
   Timer? _statsTimer;
@@ -116,8 +134,18 @@ class BroadcastNotifier extends ChangeNotifier {
 
   /// Etat du micro de cet appareil. Un flux peut être `live` sans être capturé
   /// localement s'il a été démarré depuis un autre téléphone ou un encodeur.
-  BroadcastAudioState get audioState =>
-      _sessionController.audioState;
+  BroadcastAudioState get audioState => _sessionController.audioState;
+
+  /// Faux sur une plateforme incapable de capturer et pousser l'audio (web) :
+  /// l'écran désactive alors le démarrage plutôt que de laisser l'utilisateur
+  /// découvrir l'indisponibilité après un tap.
+  bool get audioSupported => _sessionController.audioSupported;
+
+  /// Direct terminé parce que la capture locale a renoncé à se reconnecter.
+  /// L'écran s'y abonne pour le signaler ; la liste, elle, est réalignée ici
+  /// même.
+  Stream<BroadcastAudioFailure> get audioFailures =>
+      _sessionController.audioFailures;
 
   bool isPublishingAudio(String streamId) =>
       _sessionController.isPublishing(streamId);
@@ -484,6 +512,7 @@ class BroadcastNotifier extends ChangeNotifier {
     _cancelPolling();
     _statsTimer?.cancel();
     _audioSubscription?.cancel();
+    _audioFailureSubscription?.cancel();
     unawaited(_sessionController.dispose());
     super.dispose();
   }

--- a/mobile/lib/features/broadcast/presentation/providers/broadcast_notifier.dart
+++ b/mobile/lib/features/broadcast/presentation/providers/broadcast_notifier.dart
@@ -5,9 +5,12 @@ import 'package:flutter/foundation.dart';
 import '../../../../core/constants/api_constants.dart';
 import '../../../../core/errors/exceptions.dart';
 import '../../../../core/network/sse_client.dart';
+import '../../../../core/utils/retry_backoff.dart';
 import '../../domain/entities/broadcast_stats.dart';
 import '../../domain/entities/broadcast_stream.dart';
 import '../../domain/repositories/broadcast_repository.dart';
+import '../../domain/services/broadcast_audio_publisher.dart';
+import '../controllers/broadcast_session_controller.dart';
 
 /// Pilote `DashboardScreen` : flux du diffuseur connecté, création, démarrage
 /// et arrêt du direct (US-06-01, ADR 024).
@@ -27,15 +30,25 @@ import '../../domain/repositories/broadcast_repository.dart';
 /// relayées à l'écran, qui a un point d'appel unique où afficher un toast.
 class BroadcastNotifier extends ChangeNotifier {
   BroadcastNotifier(
-    this._repository, {
+    BroadcastRepository repository, {
     SseConnector? sse,
     Duration Function(int attempt)? backoff,
     Duration pollInterval = const Duration(seconds: 15),
     Duration statsInterval = const Duration(seconds: 5),
-  })  : _sse = sse,
-        _backoff = backoff ?? _defaultBackoff,
+    BroadcastAudioPublisher? audioPublisher,
+  })  : _repository = repository,
+        _sse = sse,
+        _backoff = backoff ?? cappedExponentialBackoff,
         _pollInterval = pollInterval,
-        _statsInterval = statsInterval;
+        _statsInterval = statsInterval,
+        _sessionController = BroadcastSessionController(
+          repository,
+          audioPublisher,
+        ) {
+    _audioSubscription = _sessionController.audioStates.listen(
+      (_) => _safeNotify(),
+    );
+  }
 
   final BroadcastRepository _repository;
 
@@ -50,6 +63,7 @@ class BroadcastNotifier extends ChangeNotifier {
   /// Cadence des statistiques d'audience. 5 s : c'est la fréquence de mise à
   /// jour demandée par l'AC de l'US-06-02.
   final Duration _statsInterval;
+  final BroadcastSessionController _sessionController;
 
   List<BroadcastStream> _streams = const [];
   bool _loading = false;
@@ -69,6 +83,7 @@ class BroadcastNotifier extends ChangeNotifier {
   bool _active = false;
 
   StreamSubscription<SseEvent>? _sseSubscription;
+  StreamSubscription<BroadcastAudioState>? _audioSubscription;
   Timer? _reconnectTimer;
   Timer? _pollTimer;
   Timer? _statsTimer;
@@ -98,6 +113,14 @@ class BroadcastNotifier extends ChangeNotifier {
   bool get isMutating => _mutatingId != null;
   String? get error => _error;
   bool get isNetworkError => _isNetworkError;
+
+  /// Etat du micro de cet appareil. Un flux peut être `live` sans être capturé
+  /// localement s'il a été démarré depuis un autre téléphone ou un encodeur.
+  BroadcastAudioState get audioState =>
+      _sessionController.audioState;
+
+  bool isPublishingAudio(String streamId) =>
+      _sessionController.isPublishing(streamId);
 
   /// Flux actuellement en direct, ou null. Le backend garantit qu'il y en a au
   /// plus un par diffuseur (migration `000016_streams_one_live`).
@@ -178,13 +201,63 @@ class BroadcastNotifier extends ChangeNotifier {
   ///
   /// Le 409 « you already have a live stream » reste possible sur une course
   /// entre deux appareils et remonte alors à l'appelant.
-  Future<bool> start(String id) => _mutate(id, _repository.startStream);
+  Future<bool> start(String id) async {
+    if (_mutatingId != null) return false;
+    _mutatingId = id;
+    _safeNotify();
+    try {
+      final updated = await _sessionController.start(id);
+      _replace(updated);
+      _clearError();
+      return true;
+    } on BroadcastSessionStartException catch (error) {
+      _replace(error.serverState);
+      if (error.refreshRequired) unawaited(refresh());
+      Error.throwWithStackTrace(error.cause, error.stackTrace);
+    } finally {
+      _mutatingId = null;
+      _safeNotify();
+      _syncSubscription();
+    }
+  }
 
   /// Arrête le direct. Même contrat de retour que [start]. Un 409 signifie que
   /// le flux n'était déjà plus en direct (arrêt par un administrateur, par
   /// exemple) : l'écran le traite en rechargeant plutôt qu'en affichant un
   /// échec sec.
-  Future<bool> stop(String id) => _mutate(id, _repository.stopStream);
+  Future<bool> stop(String id) async {
+    if (_mutatingId != null) return false;
+    _mutatingId = id;
+    _safeNotify();
+    try {
+      final updated = await _sessionController.stop(id);
+      _replace(updated);
+      _clearError();
+      return true;
+    } finally {
+      _mutatingId = null;
+      _safeNotify();
+      _syncSubscription();
+    }
+  }
+
+  /// Politique mobile choisie par l'ADR 027 : diffusion au premier plan
+  /// uniquement. On termine d'abord le live côté serveur, puis on libère le
+  /// micro quoi qu'il arrive lorsque l'OS suspend l'application.
+  Future<void> stopForBackground() async {
+    try {
+      final ended = await _sessionController.stopForBackground();
+      if (ended != null) _replace(ended);
+    } catch (_) {
+      // L'OS peut suspendre le réseau avant la fin du stop. Le micro est déjà
+      // libéré par le contrôleur et le bail backend terminera le live ; une
+      // resynchronisation est tentée si l'application reste assez longtemps.
+      unawaited(refresh());
+    } finally {
+      _safeNotify();
+      _syncSubscription();
+    }
+  }
 
   /// Archive le flux et le retire de la liste. Même contrat de retour que
   /// [start]. Sur un flux en direct, le backend termine la diffusion au
@@ -194,7 +267,7 @@ class BroadcastNotifier extends ChangeNotifier {
     _mutatingId = id;
     _safeNotify();
     try {
-      await _repository.deleteStream(id);
+      await _sessionController.delete(id);
       _streams = List.unmodifiable(
         _streams.where((stream) => stream.id != id).toList(),
       );
@@ -209,28 +282,11 @@ class BroadcastNotifier extends ChangeNotifier {
     }
   }
 
-  /// Retourne `false` en no-op quand une mutation est déjà en vol, `true` quand
-  /// l'appel a réellement eu lieu (les erreurs, elles, remontent en exception).
-  Future<bool> _mutate(
-    String id,
-    Future<BroadcastStream> Function(String id) action,
-  ) async {
-    if (_mutatingId != null) return false;
-    _mutatingId = id;
-    _safeNotify();
-    try {
-      final updated = await action(id);
-      _streams = _sorted([
-        for (final stream in _streams)
-          if (stream.id == updated.id) updated else stream,
-      ]);
-      _clearError();
-      return true;
-    } finally {
-      _mutatingId = null;
-      _safeNotify();
-      _syncSubscription();
-    }
+  void _replace(BroadcastStream updated) {
+    _streams = _sorted([
+      for (final stream in _streams)
+        if (stream.id == updated.id) updated else stream,
+    ]);
   }
 
   /// Signale que l'écran est visible ou non. Appelé au montage/démontage et
@@ -239,6 +295,7 @@ class BroadcastNotifier extends ChangeNotifier {
   void setActive(bool active) {
     if (_active == active) return;
     _active = active;
+    _sessionController.setActive(active);
     // `_syncSubscription` traite les deux sens : à faux, il coupe la
     // souscription SSE **et** le polling. Les séparer avait laissé le timer de
     // polling tourner en arrière-plan.
@@ -249,6 +306,7 @@ class BroadcastNotifier extends ChangeNotifier {
   /// sens que sur un flux en direct (l'endpoint SSE répond 409 sinon).
   void _syncSubscription() {
     final live = liveStream;
+    unawaited(_sessionController.reconcile(live));
     _syncStats(live);
     if (!_active || live == null) {
       _cancelSubscription();
@@ -294,8 +352,10 @@ class BroadcastNotifier extends ChangeNotifier {
     // Première mesure tout de suite : attendre 5 s laisserait la carte sans
     // chiffre juste après le démarrage, au moment où on la regarde le plus.
     unawaited(_fetchStats());
-    _statsTimer =
-        Timer.periodic(_statsInterval, (_) => unawaited(_fetchStats()));
+    _statsTimer = Timer.periodic(
+      _statsInterval,
+      (_) => unawaited(_fetchStats()),
+    );
   }
 
   /// Récupère l'audience. Un échec est ignoré volontairement : l'audience est
@@ -333,9 +393,7 @@ class BroadcastNotifier extends ChangeNotifier {
     final id = _sseStreamId;
     final sse = _sse;
     if (id == null || sse == null) return;
-    _sseSubscription = sse
-        .connect('${ApiConstants.streams}/$id/events')
-        .listen(
+    _sseSubscription = sse.connect('${ApiConstants.streams}/$id/events').listen(
           _onSseEvent,
           onError: (Object _) => _scheduleReconnect(),
           onDone: _scheduleReconnect,
@@ -419,20 +477,14 @@ class BroadcastNotifier extends ChangeNotifier {
     _isNetworkError = false;
   }
 
-  static Duration _defaultBackoff(int attempt) {
-    const maxSeconds = 30;
-    // 1, 2, 4, 8, 16 puis palier à 30 s. Le décalage est borné avant le shift
-    // pour ne pas déborder sur une coupure très longue.
-    final seconds = attempt >= 5 ? maxSeconds : 1 << attempt;
-    return Duration(seconds: seconds > maxSeconds ? maxSeconds : seconds);
-  }
-
   @override
   void dispose() {
     _disposed = true;
     _cancelSubscription();
     _cancelPolling();
     _statsTimer?.cancel();
+    _audioSubscription?.cancel();
+    unawaited(_sessionController.dispose());
     super.dispose();
   }
 }

--- a/mobile/lib/features/broadcast/presentation/screens/dashboard_screen.dart
+++ b/mobile/lib/features/broadcast/presentation/screens/dashboard_screen.dart
@@ -14,18 +14,17 @@ import '../../../auth/presentation/widgets/auth_toasts.dart';
 import '../../../profile/presentation/providers/profile_controller.dart';
 import '../../data/datasources/broadcast_remote_data_source.dart';
 import '../../data/repositories/broadcast_repository_impl.dart';
+import '../../data/services/microphone_audio_publisher.dart';
 import '../../domain/entities/broadcast_stats.dart';
 import '../../domain/entities/broadcast_stream.dart';
 import '../../domain/repositories/broadcast_repository.dart';
+import '../../domain/services/broadcast_audio_publisher.dart';
 import '../providers/broadcast_notifier.dart';
 import 'create_stream_sheet.dart';
 
-/// Tableau de bord du diffuseur (US-06-01, ADR 024) : créer un flux, lancer et
-/// arrêter le direct, récupérer l'URL d'ingest à donner à son encodeur.
-///
-/// La capture micro depuis le téléphone ne fait PAS partie de cette US : le
-/// diffuseur pousse son audio vers `stream_source_url` avec l'encodeur de son
-/// choix (ffmpeg, BUTT, Mixxx). Cf. STR-156 pour le push mobile.
+/// Tableau de bord du diffuseur (US-06-01, ADR 024 et ADR 027) : créer un flux,
+/// lancer/arrêter le direct et pousser le microphone du téléphone en AAC/ADTS.
+/// L'URL d'ingest reste disponible pour un encodeur externe.
 ///
 /// [repository] et [sse] sont injectables pour les tests ; en production ils
 /// sont construits depuis [DioClient] et [SecureStorage].
@@ -35,10 +34,16 @@ import 'create_stream_sheet.dart';
 /// hors de cet onglet, et le laisser local garantit que la souscription SSE
 /// meurt avec l'écran.
 class DashboardScreen extends StatelessWidget {
-  const DashboardScreen({super.key, this.repository, this.sse});
+  const DashboardScreen({
+    super.key,
+    this.repository,
+    this.sse,
+    this.audioPublisher,
+  });
 
   final BroadcastRepository? repository;
   final SseConnector? sse;
+  final BroadcastAudioPublisher? audioPublisher;
 
   @override
   Widget build(BuildContext context) {
@@ -53,6 +58,10 @@ class DashboardScreen extends StatelessWidget {
         // (`net::ERR_FAILED`) et la relancer n'y changerait rien. Le notifier
         // bascule alors sur un rafraîchissement périodique.
         sse: sse ?? (kIsWeb ? null : SseClient(ctx.read<SecureStorage>())),
+        audioPublisher: audioPublisher ??
+            (kIsWeb
+                ? const UnsupportedBroadcastAudioPublisher()
+                : MicrophoneAudioPublisher()),
       ),
       child: const _DashboardBody(),
     );
@@ -101,9 +110,13 @@ class _DashboardBodyState extends State<_DashboardBody>
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (!mounted) return;
-    context
-        .read<BroadcastNotifier>()
-        .setActive(state == AppLifecycleState.resumed);
+    final notifier = context.read<BroadcastNotifier>();
+    notifier.setActive(state == AppLifecycleState.resumed);
+    if (state == AppLifecycleState.paused ||
+        state == AppLifecycleState.hidden ||
+        state == AppLifecycleState.detached) {
+      unawaited(notifier.stopForBackground());
+    }
   }
 
   /// (Dés)active le battement de seconde selon la présence d'un direct.
@@ -166,7 +179,7 @@ class _DashboardBodyState extends State<_DashboardBody>
         context,
         notifier.hasLiveStream
             ? 'Un autre flux est déjà en direct'
-            : "Ce flux n'est plus démarrable",
+            : 'Ce flux n\'est plus démarrable',
       );
       // L'état local était périmé : on repart de la vérité serveur plutôt que
       // de laisser l'écran mentir.
@@ -177,6 +190,18 @@ class _DashboardBodyState extends State<_DashboardBody>
     } on ServerException catch (e) {
       if (!mounted) return;
       showAuthErrorToast(context, e.message);
+    } on MicrophonePermissionException {
+      if (!mounted) return;
+      showAuthErrorToast(
+        context,
+        'Autorisez le microphone pour démarrer le direct',
+      );
+    } on AudioEncoderUnsupportedException {
+      if (!mounted) return;
+      showAuthErrorToast(
+        context,
+        'La diffusion AAC n\'est pas disponible sur cet appareil',
+      );
     } catch (_) {
       if (!mounted) return;
       showAuthErrorToast(context, 'Échec du démarrage');
@@ -224,7 +249,7 @@ class _DashboardBodyState extends State<_DashboardBody>
       showAuthErrorToast(context, e.message);
     } catch (_) {
       if (!mounted) return;
-      showAuthErrorToast(context, "Échec de l'arrêt");
+      showAuthErrorToast(context, 'Échec de l\'arrêt');
     }
   }
 
@@ -342,8 +367,7 @@ class _DashboardBodyState extends State<_DashboardBody>
       return _MessageView(
         icon: Icons.mic_none_outlined,
         title: 'Diffusez vos propres flux',
-        message:
-            'Demandez le rôle diffuseur pour créer et lancer un direct.',
+        message: 'Demandez le rôle diffuseur pour créer et lancer un direct.',
         actionLabel: 'Devenir diffuseur',
         actionKey: const Key('dashboard_become_broadcaster_button'),
         onAction: () => context.push('/broadcaster-request'),
@@ -393,8 +417,7 @@ class _DashboardBodyState extends State<_DashboardBody>
           // Un seul direct par diffuseur : on désactive le démarrage des
           // autres flux plutôt que de laisser l'utilisateur découvrir la
           // règle par un 409.
-          blockedByOtherLive:
-              notifier.hasLiveStream && !stream.isLive,
+          blockedByOtherLive: notifier.hasLiveStream && !stream.isLive,
           mutating: notifier.mutatingId == stream.id,
           // Tant qu'une mutation quelconque est en vol, les autres tuiles sont
           // neutralisées : leur flux n'est pas encore à jour localement, un tap
@@ -403,6 +426,8 @@ class _DashboardBodyState extends State<_DashboardBody>
               notifier.isMutating && notifier.mutatingId != stream.id,
           // L'audience ne concerne que le direct en cours.
           stats: stream.isLive ? notifier.stats : null,
+          audioState: notifier.audioState,
+          publishingAudio: notifier.isPublishingAudio(stream.id),
           onStart: () => _onStart(stream),
           onStop: () => _onStop(stream),
           onDelete: () => _onDelete(stream),
@@ -419,6 +444,8 @@ class _StreamCard extends StatelessWidget {
     required this.mutating,
     required this.otherMutationInFlight,
     required this.stats,
+    required this.audioState,
+    required this.publishingAudio,
     required this.onStart,
     required this.onStop,
     required this.onDelete,
@@ -432,6 +459,8 @@ class _StreamCard extends StatelessWidget {
   /// Audience du direct, ou null si le flux n'est pas en direct ou si aucune
   /// mesure n'est encore arrivée.
   final BroadcastStats? stats;
+  final BroadcastAudioState audioState;
+  final bool publishingAudio;
   final VoidCallback onStart;
   final VoidCallback onStop;
   final VoidCallback onDelete;
@@ -456,9 +485,7 @@ class _StreamCard extends StatelessWidget {
           children: [
             Row(
               children: [
-                Expanded(
-                  child: Text(stream.title, style: text.titleMedium),
-                ),
+                Expanded(child: Text(stream.title, style: text.titleMedium)),
                 _StatusBadge(status: stream.status),
                 PopupMenuButton<String>(
                   key: Key('dashboard_stream_menu_${stream.id}'),
@@ -526,6 +553,12 @@ class _StreamCard extends StatelessWidget {
             // place et affiche « — » en attendant.
             if (stream.isLive) ...[
               const SizedBox(height: 12),
+              _MicrophoneStatusRow(
+                streamId: stream.id,
+                state: audioState,
+                publishing: publishingAudio,
+              ),
+              const SizedBox(height: 8),
               _AudienceRow(streamId: stream.id, stats: stats),
             ],
             // Rien à pousser sur un flux terminé : la clé y est inutilisable
@@ -545,9 +578,7 @@ class _StreamCard extends StatelessWidget {
             if (stream.isEnded)
               Text(
                 'Diffusion terminée. Créez un nouveau flux pour rediffuser.',
-                style: text.bodySmall?.copyWith(
-                  color: colors.onSurfaceVariant,
-                ),
+                style: text.bodySmall?.copyWith(color: colors.onSurfaceVariant),
               )
             else
               SizedBox(
@@ -565,8 +596,7 @@ class _StreamCard extends StatelessWidget {
                       )
                     : FilledButton.icon(
                         key: Key('dashboard_start_button_${stream.id}'),
-                        onPressed:
-                            _busy || blockedByOtherLive ? null : onStart,
+                        onPressed: _busy || blockedByOtherLive ? null : onStart,
                         icon: const Icon(Icons.play_circle_outline),
                         label: const Text('Démarrer la diffusion'),
                       ),
@@ -575,14 +605,69 @@ class _StreamCard extends StatelessWidget {
               const SizedBox(height: 6),
               Text(
                 'Un autre flux est en direct',
-                style: text.bodySmall?.copyWith(
-                  color: colors.onSurfaceVariant,
-                ),
+                style: text.bodySmall?.copyWith(color: colors.onSurfaceVariant),
               ),
             ],
           ],
         ),
       ),
+    );
+  }
+}
+
+class _MicrophoneStatusRow extends StatelessWidget {
+  const _MicrophoneStatusRow({
+    required this.streamId,
+    required this.state,
+    required this.publishing,
+  });
+
+  final String streamId;
+  final BroadcastAudioState state;
+  final bool publishing;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    final (IconData icon, String label, Color color) = !publishing
+        ? (
+            Icons.devices_outlined,
+            'Microphone de cet appareil inactif',
+            colors.onSurfaceVariant,
+          )
+        : switch (state) {
+            BroadcastAudioState.connecting => (
+                Icons.mic_none_outlined,
+                'Connexion du microphone…',
+                colors.primary,
+              ),
+            BroadcastAudioState.reconnecting => (
+                Icons.wifi_tethering_error_outlined,
+                'Reconnexion audio…',
+                colors.tertiary,
+              ),
+            BroadcastAudioState.live => (
+                Icons.mic_outlined,
+                'Microphone diffusé',
+                colors.primary,
+              ),
+            BroadcastAudioState.idle => (
+                Icons.mic_off_outlined,
+                'Microphone arrêté',
+                colors.error,
+              ),
+          };
+
+    return Row(
+      key: Key('dashboard_microphone_status_$streamId'),
+      children: [
+        Icon(icon, size: 18, color: color),
+        const SizedBox(width: 8),
+        Text(
+          label,
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(color: color),
+        ),
+      ],
     );
   }
 }
@@ -706,7 +791,7 @@ class _IngestUrlRowState extends State<_IngestUrlRow> {
     await Clipboard.setData(ClipboardData(text: widget.sourceUrl));
     if (!mounted) return;
     // Le toast ne réécrit surtout pas la valeur copiée.
-    showAuthSuccessToast(context, "URL d'ingest copiée");
+    showAuthSuccessToast(context, 'URL d\'ingest copiée');
   }
 
   @override
@@ -727,7 +812,7 @@ class _IngestUrlRowState extends State<_IngestUrlRow> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  "URL d'ingest",
+                  'URL d\'ingest',
                   style: text.labelSmall?.copyWith(
                     color: colors.onSurfaceVariant,
                   ),
@@ -752,7 +837,9 @@ class _IngestUrlRowState extends State<_IngestUrlRow> {
           IconButton(
             key: Key('dashboard_reveal_key_${widget.streamId}'),
             icon: Icon(
-              _revealed ? Icons.visibility_off_outlined : Icons.visibility_outlined,
+              _revealed
+                  ? Icons.visibility_off_outlined
+                  : Icons.visibility_outlined,
             ),
             tooltip: _revealed ? 'Masquer' : 'Révéler 15 s',
             onPressed: _toggleReveal,
@@ -760,7 +847,7 @@ class _IngestUrlRowState extends State<_IngestUrlRow> {
           IconButton(
             key: Key('dashboard_copy_key_${widget.streamId}'),
             icon: const Icon(Icons.copy_outlined),
-            tooltip: "Copier l'URL",
+            tooltip: 'Copier l\'URL',
             onPressed: _copy,
           ),
         ],

--- a/mobile/lib/features/broadcast/presentation/screens/dashboard_screen.dart
+++ b/mobile/lib/features/broadcast/presentation/screens/dashboard_screen.dart
@@ -19,6 +19,7 @@ import '../../domain/entities/broadcast_stats.dart';
 import '../../domain/entities/broadcast_stream.dart';
 import '../../domain/repositories/broadcast_repository.dart';
 import '../../domain/services/broadcast_audio_publisher.dart';
+import '../controllers/broadcast_session_controller.dart';
 import '../providers/broadcast_notifier.dart';
 import 'create_stream_sheet.dart';
 
@@ -81,6 +82,11 @@ class _DashboardBodyState extends State<_DashboardBody>
   /// flux est en direct : inutile de reconstruire l'écran chaque seconde sinon.
   Timer? _ticker;
 
+  /// Le direct peut s'arrêter sans action de l'utilisateur (micro définitivement
+  /// perdu) : sans ce toast, la tuile passerait de « en direct » à « terminé »
+  /// sans explication.
+  StreamSubscription<BroadcastAudioFailure>? _audioFailureSubscription;
+
   @override
   void initState() {
     super.initState();
@@ -93,6 +99,13 @@ class _DashboardBodyState extends State<_DashboardBody>
       }
       final notifier = context.read<BroadcastNotifier>();
       notifier.setActive(true);
+      _audioFailureSubscription = notifier.audioFailures.listen((_) {
+        if (!mounted) return;
+        showAuthErrorToast(
+          context,
+          'Diffusion arrêtée : le microphone n\'est plus disponible',
+        );
+      });
       notifier.load();
     });
   }
@@ -100,6 +113,7 @@ class _DashboardBodyState extends State<_DashboardBody>
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    unawaited(_audioFailureSubscription?.cancel());
     _ticker?.cancel();
     super.dispose();
   }
@@ -428,6 +442,9 @@ class _DashboardBodyState extends State<_DashboardBody>
           stats: stream.isLive ? notifier.stats : null,
           audioState: notifier.audioState,
           publishingAudio: notifier.isPublishingAudio(stream.id),
+          // Sur une plateforme sans capture (web), `prepare()` échouerait après
+          // coup : mieux vaut neutraliser le bouton et le dire.
+          audioSupported: notifier.audioSupported,
           onStart: () => _onStart(stream),
           onStop: () => _onStop(stream),
           onDelete: () => _onDelete(stream),
@@ -446,6 +463,7 @@ class _StreamCard extends StatelessWidget {
     required this.stats,
     required this.audioState,
     required this.publishingAudio,
+    required this.audioSupported,
     required this.onStart,
     required this.onStop,
     required this.onDelete,
@@ -461,6 +479,10 @@ class _StreamCard extends StatelessWidget {
   final BroadcastStats? stats;
   final BroadcastAudioState audioState;
   final bool publishingAudio;
+
+  /// Faux sur une plateforme incapable de capturer le micro : le démarrage est
+  /// neutralisé plutôt que rejeté après coup par un toast fugace.
+  final bool audioSupported;
   final VoidCallback onStart;
   final VoidCallback onStop;
   final VoidCallback onDelete;
@@ -596,12 +618,23 @@ class _StreamCard extends StatelessWidget {
                       )
                     : FilledButton.icon(
                         key: Key('dashboard_start_button_${stream.id}'),
-                        onPressed: _busy || blockedByOtherLive ? null : onStart,
+                        onPressed: _busy || blockedByOtherLive || !audioSupported
+                            ? null
+                            : onStart,
                         icon: const Icon(Icons.play_circle_outline),
                         label: const Text('Démarrer la diffusion'),
                       ),
               ),
-            if (blockedByOtherLive && stream.isIdle) ...[
+            if (!audioSupported && stream.isIdle) ...[
+              const SizedBox(height: 6),
+              Text(
+                key: Key('dashboard_audio_unsupported_${stream.id}'),
+                'Diffusion disponible depuis l\'application mobile. '
+                'L\'URL d\'ingest ci-dessus reste utilisable par un encodeur '
+                'externe.',
+                style: text.bodySmall?.copyWith(color: colors.onSurfaceVariant),
+              ),
+            ] else if (blockedByOtherLive && stream.isIdle) ...[
               const SizedBox(height: 6),
               Text(
                 'Un autre flux est en direct',
@@ -629,12 +662,14 @@ class _MicrophoneStatusRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).colorScheme;
+    final text = Theme.of(context).textTheme;
+    final (IconData, String, Color) inactive = (
+      Icons.devices_outlined,
+      'Microphone de cet appareil inactif',
+      colors.onSurfaceVariant,
+    );
     final (IconData icon, String label, Color color) = !publishing
-        ? (
-            Icons.devices_outlined,
-            'Microphone de cet appareil inactif',
-            colors.onSurfaceVariant,
-          )
+        ? inactive
         : switch (state) {
             BroadcastAudioState.connecting => (
                 Icons.mic_none_outlined,
@@ -651,22 +686,40 @@ class _MicrophoneStatusRow extends StatelessWidget {
                 'Microphone diffusé',
                 colors.primary,
               ),
-            BroadcastAudioState.idle => (
+            BroadcastAudioState.failed => (
                 Icons.mic_off_outlined,
-                'Microphone arrêté',
+                'Diffusion du micro interrompue',
                 colors.error,
               ),
+            // Fenêtre courte entre l'arrêt du micro et la remise à zéro de
+            // `publishing` par le contrôleur : la ligne inactive est plus juste
+            // qu'un état d'erreur, l'arrêt étant volontaire.
+            BroadcastAudioState.idle => inactive,
           };
 
-    return Row(
+    return Column(
       key: Key('dashboard_microphone_status_$streamId'),
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Icon(icon, size: 18, color: color),
-        const SizedBox(width: 8),
-        Text(
-          label,
-          style: Theme.of(context).textTheme.bodySmall?.copyWith(color: color),
+        Row(
+          children: [
+            Icon(icon, size: 18, color: color),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(label, style: text.bodySmall?.copyWith(color: color)),
+            ),
+          ],
         ),
+        // La reprise est bornée (cf. MicrophoneAudioPublisher) : le dire évite
+        // de laisser croire à une reconnexion indéfinie, et prépare
+        // l'utilisateur à l'arrêt automatique si le réseau ne revient pas.
+        if (publishing && state == BroadcastAudioState.reconnecting) ...[
+          const SizedBox(height: 4),
+          Text(
+            'Le direct s\'arrêtera si la reconnexion échoue.',
+            style: text.bodySmall?.copyWith(color: colors.onSurfaceVariant),
+          ),
+        ],
       ],
     );
   }

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -736,6 +736,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  record:
+    dependency: "direct main"
+    description:
+      name: record
+      sha256: "10911465138fafacef459a780564e883e01bd48eabf87ab20543684884492870"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.1"
+  record_android:
+    dependency: transitive
+    description:
+      name: record_android
+      sha256: eb1732e42d0d2a1895b8db86e4fc917287e6d8491b6ed59918aea8bed6c69de4
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.2"
+  record_ios:
+    dependency: transitive
+    description:
+      name: record_ios
+      sha256: c051fb48edd7a0e265daafb9108730dc827c27b551728a3fdfb3ef69efd89c73
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  record_linux:
+    dependency: transitive
+    description:
+      name: record_linux
+      sha256: "31181787bf7eccb0e298835836b69b3cd0a903863b75d70e937de3dec71cd8f3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
+  record_macos:
+    dependency: transitive
+    description:
+      name: record_macos
+      sha256: cfe1b61435e27db418bf513dc36820d10c9f7eb1843786c2c9a52e07e2f4f627
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.2"
+  record_platform_interface:
+    dependency: transitive
+    description:
+      name: record_platform_interface
+      sha256: "8e56cbe06c6984137fb86132ff03459f29938d927496d9b2d0962e2d6345d488"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.0"
   record_use:
     dependency: transitive
     description:
@@ -744,6 +792,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.0"
+  record_web:
+    dependency: transitive
+    description:
+      name: record_web
+      sha256: "7e9846981c1f2d111d86f0ae3309071f5bba8b624d1c977316706f08fc31d16d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
+  record_windows:
+    dependency: transitive
+    description:
+      name: record_windows
+      sha256: "223258060a1d25c62bae18282c16783f28581ec19401d17e56b5205b9f039d78"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.7"
   rxdart:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -23,6 +23,9 @@ dependencies:
   streampulse_api:
     path: packages/streampulse_api
 
+  # Capture microphone AAC/ADTS pour l'ingest du direct (STR-156)
+  record: ^6.2.1
+
   # Stockage sécurisé (tokens JWT)
   flutter_secure_storage: ^9.0.0
 

--- a/mobile/test/features/broadcast/data/microphone_audio_publisher_test.dart
+++ b/mobile/test/features/broadcast/data/microphone_audio_publisher_test.dart
@@ -1,0 +1,215 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:streampulse/features/broadcast/data/services/audio_capture.dart';
+import 'package:streampulse/features/broadcast/data/services/audio_ingest_client.dart';
+import 'package:streampulse/features/broadcast/data/services/dio_audio_ingest_client.dart';
+import 'package:streampulse/features/broadcast/data/services/microphone_audio_publisher.dart';
+import 'package:streampulse/features/broadcast/domain/services/broadcast_audio_publisher.dart';
+
+class _FakeCapture implements AudioCapture {
+  bool permission = true;
+  bool supported = true;
+  Object? startError;
+  int starts = 0;
+  int stops = 0;
+  bool disposed = false;
+  StreamController<Uint8List>? current;
+
+  @override
+  Future<bool> hasPermission() async => permission;
+
+  @override
+  Future<bool> supportsAacAdts() async => supported;
+
+  @override
+  Future<Stream<Uint8List>> start() async {
+    starts++;
+    if (startError != null) throw startError!;
+    current = StreamController<Uint8List>();
+    return current!.stream;
+  }
+
+  @override
+  Future<void> stop() async {
+    stops++;
+    final controller = current;
+    current = null;
+    if (controller != null && !controller.isClosed) await controller.close();
+  }
+
+  @override
+  Future<void> dispose() async {
+    disposed = true;
+  }
+}
+
+class _FakeIngest implements AudioIngestClient {
+  int pushes = 0;
+  int cancels = 0;
+  Uri? sourceUrl;
+  Completer<void>? current;
+  StreamSubscription<List<int>>? audioSubscription;
+
+  @override
+  Future<void> push(Uri sourceUrl, Stream<List<int>> audio) {
+    pushes++;
+    this.sourceUrl = sourceUrl;
+    audioSubscription = audio.listen((_) {});
+    current = Completer<void>();
+    return current!.future;
+  }
+
+  void fail() => current!.completeError(const SocketException('coupure'));
+
+  @override
+  Future<void> cancel() async {
+    cancels++;
+    await audioSubscription?.cancel();
+    audioSubscription = null;
+    final request = current;
+    current = null;
+    if (request != null && !request.isCompleted) request.complete();
+  }
+}
+
+Future<void> _pumpUntil(bool Function() condition) async {
+  for (var i = 0; i < 100 && !condition(); i++) {
+    await Future<void>.delayed(const Duration(milliseconds: 1));
+  }
+  expect(condition(), isTrue);
+}
+
+void main() {
+  group('MicrophoneAudioPublisher', () {
+    test('refuse de démarrer sans permission microphone', () async {
+      final capture = _FakeCapture()..permission = false;
+      final publisher = MicrophoneAudioPublisher(
+        capture: capture,
+        ingest: _FakeIngest(),
+      );
+
+      await expectLater(
+        publisher.prepare(),
+        throwsA(isA<MicrophonePermissionException>()),
+      );
+      expect(capture.starts, 0);
+
+      await publisher.dispose();
+    });
+
+    test('refuse un appareil qui ne sait pas streamer l\'AAC/ADTS', () async {
+      final capture = _FakeCapture()..supported = false;
+      final publisher = MicrophoneAudioPublisher(
+        capture: capture,
+        ingest: _FakeIngest(),
+      );
+
+      await expectLater(
+        publisher.prepare(),
+        throwsA(isA<AudioEncoderUnsupportedException>()),
+      );
+
+      await publisher.dispose();
+    });
+
+    test(
+      'pousse le micro et reprend sur une nouvelle requête après coupure',
+      () async {
+        final capture = _FakeCapture();
+        final ingest = _FakeIngest();
+        final publisher = MicrophoneAudioPublisher(
+          capture: capture,
+          ingest: ingest,
+          backoff: (_) => Duration.zero,
+        );
+        final states = <BroadcastAudioState>[];
+        final subscription = publisher.states.listen(states.add);
+        final endpoint = Uri.parse('https://api.test/ingest/secret');
+
+        await publisher.prepare();
+        await publisher.start(endpoint);
+        expect(ingest.pushes, 1);
+        expect(ingest.sourceUrl, endpoint);
+        expect(publisher.state, BroadcastAudioState.live);
+
+        ingest.fail();
+        await _pumpUntil(() => ingest.pushes == 2);
+
+        expect(capture.starts, 2);
+        expect(states, contains(BroadcastAudioState.reconnecting));
+        expect(publisher.state, BroadcastAudioState.live);
+
+        await publisher.stop();
+        expect(publisher.state, BroadcastAudioState.idle);
+        expect(capture.stops, greaterThanOrEqualTo(2));
+
+        await subscription.cancel();
+        await publisher.dispose();
+        expect(capture.disposed, isTrue);
+      },
+    );
+
+    test('relaie un échec de capture initial sans lancer de push', () async {
+      final capture = _FakeCapture()..startError = StateError('micro occupé');
+      final ingest = _FakeIngest();
+      final publisher = MicrophoneAudioPublisher(
+        capture: capture,
+        ingest: ingest,
+      );
+
+      await expectLater(
+        publisher.start(Uri.parse('https://api.test/ingest/secret')),
+        throwsStateError,
+      );
+      expect(ingest.pushes, 0);
+      expect(publisher.state, BroadcastAudioState.idle);
+
+      await publisher.dispose();
+    });
+  });
+
+  test(
+    'DioAudioIngestClient envoie le flux brut en HTTP chunked audio/aac',
+    () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final received =
+          Completer<({List<int> bytes, String? contentType, int length})>();
+      final serverFuture = server.first.then((request) async {
+        final bytes = await request.fold<List<int>>(<int>[], (all, chunk) {
+          all.addAll(chunk);
+          return all;
+        });
+        received.complete((
+          bytes: bytes,
+          contentType: request.headers.contentType?.mimeType,
+          length: request.contentLength,
+        ));
+        request.response.statusCode = HttpStatus.noContent;
+        await request.response.close();
+      });
+      final audio = StreamController<List<int>>();
+      final client = DioAudioIngestClient();
+      final push = client.push(
+        Uri.parse('http://127.0.0.1:${server.port}/ingest/secret'),
+        audio.stream,
+      );
+
+      audio.add([0xff, 0xf1, 0x50]);
+      audio.add([0x80, 0x00]);
+      await audio.close();
+      await push;
+
+      final request = await received.future;
+      expect(request.bytes, [0xff, 0xf1, 0x50, 0x80, 0x00]);
+      expect(request.contentType, 'audio/aac');
+      expect(request.length, -1); // absence de Content-Length => chunked
+
+      await serverFuture;
+      await server.close(force: true);
+    },
+  );
+}

--- a/mobile/test/features/broadcast/data/microphone_audio_publisher_test.dart
+++ b/mobile/test/features/broadcast/data/microphone_audio_publisher_test.dart
@@ -38,7 +38,12 @@ class _FakeCapture implements AudioCapture {
     stops++;
     final controller = current;
     current = null;
-    if (controller != null && !controller.isClosed) await controller.close();
+    // `close()` d'un StreamController jamais écouté ne complète pas : une
+    // tentative d'ingest qui échoue avant de s'abonner laisse précisément le
+    // flux micro sans écouteur. Le vrai `record` ne dépend pas de l'abonné.
+    if (controller != null && !controller.isClosed) {
+      unawaited(controller.close());
+    }
   }
 
   @override
@@ -54,10 +59,15 @@ class _FakeIngest implements AudioIngestClient {
   Completer<void>? current;
   StreamSubscription<List<int>>? audioSubscription;
 
+  /// Si non nul, chaque tentative échoue immédiatement, avant d'avoir consommé
+  /// le moindre octet — le cas d'une connexion qui n'aboutit jamais.
+  Object? pushError;
+
   @override
   Future<void> push(Uri sourceUrl, Stream<List<int>> audio) {
     pushes++;
     this.sourceUrl = sourceUrl;
+    if (pushError != null) return Future<void>.error(pushError!);
     audioSubscription = audio.listen((_) {});
     current = Completer<void>();
     return current!.future;
@@ -82,6 +92,10 @@ Future<void> _pumpUntil(bool Function() condition) async {
   }
   expect(condition(), isTrue);
 }
+
+/// Une trame ADTS minimale : n'importe quel octet suffit à prouver que le
+/// premier morceau d'audio a bien traversé le client d'ingest.
+final _frame = Uint8List.fromList([0xff, 0xf1, 0x50]);
 
 void main() {
   group('MicrophoneAudioPublisher', () {
@@ -134,14 +148,21 @@ void main() {
         await publisher.start(endpoint);
         expect(ingest.pushes, 1);
         expect(ingest.sourceUrl, endpoint);
-        expect(publisher.state, BroadcastAudioState.live);
+        // Requête ouverte mais aucun octet transmis : encore « connexion ».
+        expect(publisher.state, BroadcastAudioState.connecting);
+
+        capture.current!.add(_frame);
+        await _pumpUntil(() => publisher.state == BroadcastAudioState.live);
 
         ingest.fail();
         await _pumpUntil(() => ingest.pushes == 2);
 
         expect(capture.starts, 2);
         expect(states, contains(BroadcastAudioState.reconnecting));
-        expect(publisher.state, BroadcastAudioState.live);
+        expect(publisher.state, BroadcastAudioState.reconnecting);
+
+        capture.current!.add(_frame);
+        await _pumpUntil(() => publisher.state == BroadcastAudioState.live);
 
         await publisher.stop();
         expect(publisher.state, BroadcastAudioState.idle);
@@ -152,6 +173,63 @@ void main() {
         expect(capture.disposed, isTrue);
       },
     );
+
+    // Sans borne, une panne définitive (permission révoquée en cours de direct,
+    // micro capté par une autre application) serait rejouée indéfiniment et la
+    // carte resterait figée sur « Reconnexion audio… ».
+    test(
+      'abandonne après N tentatives sans le moindre octet transmis',
+      () async {
+        final capture = _FakeCapture();
+        final ingest = _FakeIngest()..pushError = const SocketException('refus');
+        final publisher = MicrophoneAudioPublisher(
+          capture: capture,
+          ingest: ingest,
+          backoff: (_) => Duration.zero,
+          maxSilentAttempts: 3,
+        );
+        final states = <BroadcastAudioState>[];
+        final subscription = publisher.states.listen(states.add);
+
+        await publisher.start(Uri.parse('https://api.test/ingest/secret'));
+        await _pumpUntil(() => publisher.state == BroadcastAudioState.failed);
+
+        expect(ingest.pushes, 3);
+        expect(states.last, BroadcastAudioState.failed);
+        expect(states, isNot(contains(BroadcastAudioState.live)));
+
+        await subscription.cancel();
+        await publisher.dispose();
+      },
+    );
+
+    // Le compteur d'abandon porte sur les tentatives *stériles* : une
+    // reconnexion qui refait passer de l'audio doit rendre son crédit complet
+    // au diffuseur, sinon un direct de plusieurs heures finirait par céder à la
+    // énième micro-coupure.
+    test('une tentative productive réarme le compteur d\'abandon', () async {
+      final capture = _FakeCapture();
+      final ingest = _FakeIngest();
+      final publisher = MicrophoneAudioPublisher(
+        capture: capture,
+        ingest: ingest,
+        backoff: (_) => Duration.zero,
+        maxSilentAttempts: 2,
+      );
+
+      await publisher.start(Uri.parse('https://api.test/ingest/secret'));
+      for (var round = 0; round < 4; round++) {
+        capture.current!.add(_frame);
+        await _pumpUntil(() => publisher.state == BroadcastAudioState.live);
+        ingest.fail();
+        await _pumpUntil(() => ingest.pushes == round + 2);
+      }
+
+      expect(publisher.state, isNot(BroadcastAudioState.failed));
+
+      await publisher.stop();
+      await publisher.dispose();
+    });
 
     test('relaie un échec de capture initial sans lancer de push', () async {
       final capture = _FakeCapture()..startError = StateError('micro occupé');

--- a/mobile/test/features/broadcast/presentation/broadcast_notifier_test.dart
+++ b/mobile/test/features/broadcast/presentation/broadcast_notifier_test.dart
@@ -197,7 +197,16 @@ class _FakeAudioPublisher implements BroadcastAudioPublisher {
   Uri? sourceUrl;
 
   @override
+  bool isSupported = true;
+
+  @override
   BroadcastAudioState state = BroadcastAudioState.idle;
+
+  /// Abandon du diffuseur audio après épuisement de ses reconnexions.
+  void giveUp() {
+    state = BroadcastAudioState.failed;
+    _states.add(state);
+  }
 
   @override
   Stream<BroadcastAudioState> get states => _states.stream;
@@ -228,6 +237,15 @@ class _FakeAudioPublisher implements BroadcastAudioPublisher {
   Future<void> dispose() async {
     await _states.close();
   }
+}
+
+/// Laisse tourner les callbacks asynchrones (arrêt serveur déclenché en
+/// `unawaited` derrière un flux d'états) jusqu'à ce que [condition] tienne.
+Future<void> _pumpUntil(bool Function() condition) async {
+  for (var i = 0; i < 100 && !condition(); i++) {
+    await Future<void>.delayed(const Duration(milliseconds: 1));
+  }
+  expect(condition(), isTrue);
 }
 
 void main() {
@@ -372,6 +390,29 @@ void main() {
         expect(repository.stoppedIds, ['a']);
         expect(notifier.streams.single.isEnded, isTrue);
         expect(notifier.isPublishingAudio('a'), isFalse);
+      },
+    );
+
+    // Une panne définitive du micro coupe le direct sans passer par `stop()` :
+    // la liste doit s'aligner sur l'état rendu par l'arrêt serveur, sans
+    // rechargement — c'est justement le moment où le réseau est le moins sûr.
+    test(
+      'un abandon du micro réaligne la liste sans recharger',
+      () async {
+        final repository = _FakeBroadcastRepository(streams: [_stream('a')]);
+        final audio = _FakeAudioPublisher();
+        final notifier = BroadcastNotifier(repository, audioPublisher: audio);
+        await notifier.load();
+        await notifier.start('a');
+        final listCallsBefore = repository.listCalls;
+
+        audio.giveUp();
+        await _pumpUntil(() => notifier.streams.single.isEnded);
+
+        expect(repository.stoppedIds, ['a']);
+        expect(notifier.hasLiveStream, isFalse);
+        expect(notifier.isPublishingAudio('a'), isFalse);
+        expect(repository.listCalls, listCallsBefore);
       },
     );
 

--- a/mobile/test/features/broadcast/presentation/broadcast_notifier_test.dart
+++ b/mobile/test/features/broadcast/presentation/broadcast_notifier_test.dart
@@ -7,6 +7,7 @@ import 'package:streampulse/core/network/sse_client.dart';
 import 'package:streampulse/features/broadcast/domain/entities/broadcast_stats.dart';
 import 'package:streampulse/features/broadcast/domain/entities/broadcast_stream.dart';
 import 'package:streampulse/features/broadcast/domain/repositories/broadcast_repository.dart';
+import 'package:streampulse/features/broadcast/domain/services/broadcast_audio_publisher.dart';
 import 'package:streampulse/features/broadcast/presentation/providers/broadcast_notifier.dart';
 
 BroadcastStream _stream(
@@ -15,21 +16,20 @@ BroadcastStream _stream(
   String? title,
   DateTime? startedAt,
   DateTime? createdAt,
-}) =>
-    BroadcastStream(
-      id: id,
-      title: title ?? 'Flux $id',
-      status: status,
-      isPublic: true,
-      createdAt: createdAt ?? DateTime.utc(2026, 1, 1),
-      startedAt: startedAt,
-      streamKey: 'key-$id',
-      streamSourceUrl: 'http://localhost:8080/api/streams/ingest/key-$id',
-    );
+}) => BroadcastStream(
+  id: id,
+  title: title ?? 'Flux $id',
+  status: status,
+  isPublic: true,
+  createdAt: createdAt ?? DateTime.utc(2026, 1, 1),
+  startedAt: startedAt,
+  streamKey: 'key-$id',
+  streamSourceUrl: 'http://localhost:8080/api/streams/ingest/key-$id',
+);
 
 class _FakeBroadcastRepository implements BroadcastRepository {
   _FakeBroadcastRepository({List<BroadcastStream>? streams})
-      : streams = streams ?? [_stream('a')];
+    : streams = streams ?? [_stream('a')];
 
   List<BroadcastStream> streams;
 
@@ -92,11 +92,7 @@ class _FakeBroadcastRepository implements BroadcastRepository {
   Future<BroadcastStats> streamStats(String id) async {
     statsCalls++;
     if (statsError != null) throw statsError!;
-    return BroadcastStats(
-      streamId: id,
-      listeners: listeners,
-      peak: listeners,
-    );
+    return BroadcastStats(streamId: id, listeners: listeners, peak: listeners);
   }
 
   final List<String> deletedIds = [];
@@ -124,8 +120,7 @@ class _DeferredRepository implements BroadcastRepository {
     required bool isPublic,
     String? description,
     String? category,
-  }) =>
-      throw UnimplementedError();
+  }) => throw UnimplementedError();
 
   @override
   Future<BroadcastStream> startStream(String id) => throw UnimplementedError();
@@ -161,8 +156,7 @@ class _DeferredMutationRepository implements BroadcastRepository {
     required bool isPublic,
     String? description,
     String? category,
-  }) =>
-      throw UnimplementedError();
+  }) => throw UnimplementedError();
 
   @override
   Future<BroadcastStream> stopStream(String id) => throw UnimplementedError();
@@ -192,28 +186,75 @@ class _FakeSseConnector implements SseConnector {
   }
 }
 
+class _FakeAudioPublisher implements BroadcastAudioPublisher {
+  final StreamController<BroadcastAudioState> _states =
+      StreamController<BroadcastAudioState>.broadcast();
+  Object? prepareError;
+  Object? startError;
+  int prepares = 0;
+  int starts = 0;
+  int stops = 0;
+  Uri? sourceUrl;
+
+  @override
+  BroadcastAudioState state = BroadcastAudioState.idle;
+
+  @override
+  Stream<BroadcastAudioState> get states => _states.stream;
+
+  @override
+  Future<void> prepare() async {
+    prepares++;
+    if (prepareError != null) throw prepareError!;
+  }
+
+  @override
+  Future<void> start(Uri sourceUrl) async {
+    starts++;
+    this.sourceUrl = sourceUrl;
+    if (startError != null) throw startError!;
+    state = BroadcastAudioState.live;
+    _states.add(state);
+  }
+
+  @override
+  Future<void> stop() async {
+    stops++;
+    state = BroadcastAudioState.idle;
+    _states.add(state);
+  }
+
+  @override
+  Future<void> dispose() async {
+    await _states.close();
+  }
+}
+
 void main() {
   group('BroadcastNotifier — chargement', () {
-    test('trie le direct en tête, puis les flux prêts, puis les terminés',
-        () async {
-      final repository = _FakeBroadcastRepository(
-        streams: [
-          _stream('ended', status: 'ended'),
-          _stream('idle'),
-          _stream('live', status: 'live'),
-        ],
-      );
-      final notifier = BroadcastNotifier(repository);
+    test(
+      'trie le direct en tête, puis les flux prêts, puis les terminés',
+      () async {
+        final repository = _FakeBroadcastRepository(
+          streams: [
+            _stream('ended', status: 'ended'),
+            _stream('idle'),
+            _stream('live', status: 'live'),
+          ],
+        );
+        final notifier = BroadcastNotifier(repository);
 
-      await notifier.load();
+        await notifier.load();
 
-      expect(
-        notifier.streams.map((s) => s.id).toList(),
-        ['live', 'idle', 'ended'],
-      );
-      expect(notifier.liveStream?.id, 'live');
-      expect(notifier.hasLiveStream, isTrue);
-    });
+        expect(notifier.streams.map((s) => s.id).toList(), [
+          'live',
+          'idle',
+          'ended',
+        ]);
+        expect(notifier.liveStream?.id, 'live');
+        expect(notifier.hasLiveStream, isTrue);
+      },
+    );
 
     test('expose un message dédié sur erreur réseau', () async {
       final repository = _FakeBroadcastRepository()
@@ -227,20 +268,21 @@ void main() {
       expect(notifier.loading, isFalse);
     });
 
-    test('erreur non réseau : message générique, isNetworkError faux',
-        () async {
-      final repository = _FakeBroadcastRepository()
-        ..listError = const ServerException();
-      final notifier = BroadcastNotifier(repository);
-
-      await notifier.load();
-
-      expect(notifier.error, 'Impossible de charger vos flux');
-      expect(notifier.isNetworkError, isFalse);
-    });
-
     test(
-        'deux chargements concurrents : seul le plus récent écrit l\'état, '
+      'erreur non réseau : message générique, isNetworkError faux',
+      () async {
+        final repository = _FakeBroadcastRepository()
+          ..listError = const ServerException();
+        final notifier = BroadcastNotifier(repository);
+
+        await notifier.load();
+
+        expect(notifier.error, 'Impossible de charger vos flux');
+        expect(notifier.isNetworkError, isFalse);
+      },
+    );
+
+    test('deux chargements concurrents : seul le plus récent écrit l\'état, '
         'sans spinner figé', () async {
       final repository = _DeferredRepository();
       final notifier = BroadcastNotifier(repository);
@@ -285,6 +327,54 @@ void main() {
       expect(notifier.mutatingId, isNull);
     });
 
+    test('start prépare le micro puis pousse vers stream_source_url', () async {
+      final repository = _FakeBroadcastRepository(streams: [_stream('a')]);
+      final audio = _FakeAudioPublisher();
+      final notifier = BroadcastNotifier(repository, audioPublisher: audio);
+      await notifier.load();
+
+      await notifier.start('a');
+
+      expect(audio.prepares, 1);
+      expect(audio.starts, 1);
+      expect(audio.sourceUrl, Uri.parse(_stream('a').streamSourceUrl!));
+      expect(notifier.audioState, BroadcastAudioState.live);
+      expect(notifier.isPublishingAudio('a'), isTrue);
+    });
+
+    test('un refus micro ne passe jamais le flux serveur à live', () async {
+      final repository = _FakeBroadcastRepository(streams: [_stream('a')]);
+      final audio = _FakeAudioPublisher()
+        ..prepareError = const MicrophonePermissionException();
+      final notifier = BroadcastNotifier(repository, audioPublisher: audio);
+      await notifier.load();
+
+      await expectLater(
+        notifier.start('a'),
+        throwsA(isA<MicrophonePermissionException>()),
+      );
+
+      expect(repository.startedIds, isEmpty);
+      expect(notifier.streams.single.isIdle, isTrue);
+    });
+
+    test(
+      'un échec de capture après start annule immédiatement le live',
+      () async {
+        final repository = _FakeBroadcastRepository(streams: [_stream('a')]);
+        final audio = _FakeAudioPublisher()..startError = StateError('occupé');
+        final notifier = BroadcastNotifier(repository, audioPublisher: audio);
+        await notifier.load();
+
+        await expectLater(notifier.start('a'), throwsStateError);
+
+        expect(repository.startedIds, ['a']);
+        expect(repository.stoppedIds, ['a']);
+        expect(notifier.streams.single.isEnded, isTrue);
+        expect(notifier.isPublishingAudio('a'), isFalse);
+      },
+    );
+
     test('stop remplace le flux par sa version terminée', () async {
       final repository = _FakeBroadcastRepository(
         streams: [_stream('a', status: 'live')],
@@ -298,6 +388,37 @@ void main() {
       expect(notifier.streams.single.isEnded, isTrue);
       expect(notifier.hasLiveStream, isFalse);
     });
+
+    test('stop termine le serveur avant de libérer le micro local', () async {
+      final repository = _FakeBroadcastRepository(streams: [_stream('a')]);
+      final audio = _FakeAudioPublisher();
+      final notifier = BroadcastNotifier(repository, audioPublisher: audio);
+      await notifier.load();
+      await notifier.start('a');
+
+      await notifier.stop('a');
+
+      expect(repository.stoppedIds, ['a']);
+      expect(audio.stops, 1);
+      expect(notifier.audioState, BroadcastAudioState.idle);
+    });
+
+    test(
+      'le passage en arrière-plan termine le live et coupe l\'audio',
+      () async {
+        final repository = _FakeBroadcastRepository(streams: [_stream('a')]);
+        final audio = _FakeAudioPublisher();
+        final notifier = BroadcastNotifier(repository, audioPublisher: audio);
+        await notifier.load();
+        await notifier.start('a');
+
+        await notifier.stopForBackground();
+
+        expect(repository.stoppedIds, ['a']);
+        expect(audio.stops, 1);
+        expect(notifier.hasLiveStream, isFalse);
+      },
+    );
 
     test('les erreurs de mutation remontent à l\'appelant', () async {
       final repository = _FakeBroadcastRepository(streams: [_stream('a')])
@@ -418,28 +539,30 @@ void main() {
       notifier.dispose();
     });
 
-    test('l\'arrêt du direct coupe les mesures et efface l\'audience',
-        () async {
-      final repository = _FakeBroadcastRepository(
-        streams: [_stream('a', status: 'live')],
-      );
-      final notifier = BroadcastNotifier(
-        repository,
-        statsInterval: const Duration(milliseconds: 20),
-      );
-      notifier.setActive(true);
-      await notifier.load();
-      await Future<void>.delayed(Duration.zero);
-      expect(notifier.stats, isNotNull);
+    test(
+      'l\'arrêt du direct coupe les mesures et efface l\'audience',
+      () async {
+        final repository = _FakeBroadcastRepository(
+          streams: [_stream('a', status: 'live')],
+        );
+        final notifier = BroadcastNotifier(
+          repository,
+          statsInterval: const Duration(milliseconds: 20),
+        );
+        notifier.setActive(true);
+        await notifier.load();
+        await Future<void>.delayed(Duration.zero);
+        expect(notifier.stats, isNotNull);
 
-      await notifier.stop('a');
-      final callsAfterStop = repository.statsCalls;
-      await Future<void>.delayed(const Duration(milliseconds: 60));
+        await notifier.stop('a');
+        final callsAfterStop = repository.statsCalls;
+        await Future<void>.delayed(const Duration(milliseconds: 60));
 
-      expect(notifier.stats, isNull);
-      expect(repository.statsCalls, callsAfterStop);
-      notifier.dispose();
-    });
+        expect(notifier.stats, isNull);
+        expect(repository.statsCalls, callsAfterStop);
+        notifier.dispose();
+      },
+    );
 
     test('les mesures s\'arrêtent en arrière-plan', () async {
       final repository = _FakeBroadcastRepository(
@@ -478,7 +601,11 @@ void main() {
       notifier.addListener(() => notifications++);
       await Future<void>.delayed(const Duration(milliseconds: 80));
 
-      expect(repository.statsCalls, greaterThan(1), reason: 'les mesures tournent');
+      expect(
+        repository.statsCalls,
+        greaterThan(1),
+        reason: 'les mesures tournent',
+      );
       expect(notifications, 0, reason: 'valeurs inchangées : aucun rebuild');
       notifier.dispose();
     });
@@ -521,7 +648,11 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 40));
 
       expect(notifier.stats, isNull);
-      expect(notifier.error, isNull, reason: 'pas d\'erreur remontée à l\'écran');
+      expect(
+        notifier.error,
+        isNull,
+        reason: 'pas d\'erreur remontée à l\'écran',
+      );
       expect(notifier.streams, hasLength(1));
       notifier.dispose();
     });
@@ -564,25 +695,26 @@ void main() {
   });
 
   group('BroadcastNotifier — souscription SSE', () {
-    test('ne se branche que sur un flux en direct, et sur le bon chemin',
-        () async {
-      final sse = _FakeSseConnector();
-      final repository = _FakeBroadcastRepository(streams: [_stream('a')]);
-      final notifier = BroadcastNotifier(repository, sse: sse);
-      notifier.setActive(true);
+    test(
+      'ne se branche que sur un flux en direct, et sur le bon chemin',
+      () async {
+        final sse = _FakeSseConnector();
+        final repository = _FakeBroadcastRepository(streams: [_stream('a')]);
+        final notifier = BroadcastNotifier(repository, sse: sse);
+        notifier.setActive(true);
 
-      await notifier.load();
-      expect(sse.connectCount, 0, reason: 'aucun flux en direct');
+        await notifier.load();
+        expect(sse.connectCount, 0, reason: 'aucun flux en direct');
 
-      repository.streams = [_stream('a', status: 'live')];
-      await notifier.load();
+        repository.streams = [_stream('a', status: 'live')];
+        await notifier.load();
 
-      expect(sse.connectCount, 1);
-      expect(sse.paths.single, '/api/streams/a/events');
-    });
+        expect(sse.connectCount, 1);
+        expect(sse.paths.single, '/api/streams/a/events');
+      },
+    );
 
-    test('l\'évènement ended coupe la souscription et resynchronise',
-        () async {
+    test('l\'évènement ended coupe la souscription et resynchronise', () async {
       final sse = _FakeSseConnector();
       final repository = _FakeBroadcastRepository(
         streams: [_stream('a', status: 'live')],
@@ -600,55 +732,64 @@ void main() {
       expect(notifier.hasLiveStream, isFalse);
     });
 
-    test('une coupure déclenche une reconnexion suivie d\'une resynchronisation',
-        () async {
-      final sse = _FakeSseConnector();
-      final repository = _FakeBroadcastRepository(
-        streams: [_stream('a', status: 'live')],
-      );
-      final notifier = BroadcastNotifier(
-        repository,
-        sse: sse,
-        // Backoff neutralisé : le test vérifie la mécanique, pas les délais.
-        backoff: (_) => Duration.zero,
-      );
-      notifier.setActive(true);
-      await notifier.load();
-      final callsBefore = repository.listCalls;
+    test(
+      'une coupure déclenche une reconnexion suivie d\'une resynchronisation',
+      () async {
+        final sse = _FakeSseConnector();
+        final repository = _FakeBroadcastRepository(
+          streams: [_stream('a', status: 'live')],
+        );
+        final notifier = BroadcastNotifier(
+          repository,
+          sse: sse,
+          // Backoff neutralisé : le test vérifie la mécanique, pas les délais.
+          backoff: (_) => Duration.zero,
+        );
+        notifier.setActive(true);
+        await notifier.load();
+        final callsBefore = repository.listCalls;
 
-      // Le serveur ferme la connexion sans avoir envoyé `ended`.
-      await sse.current.close();
-      await Future<void>.delayed(const Duration(milliseconds: 10));
+        // Le serveur ferme la connexion sans avoir envoyé `ended`.
+        await sse.current.close();
+        await Future<void>.delayed(const Duration(milliseconds: 10));
 
-      expect(sse.connectCount, 2, reason: 'reconnexion attendue');
-      expect(
-        repository.listCalls,
-        greaterThan(callsBefore),
-        reason: 'le SSE ne rejoue pas les évènements manqués : il faut '
-            'resynchroniser après chaque reconnexion',
-      );
-    });
+        expect(sse.connectCount, 2, reason: 'reconnexion attendue');
+        expect(
+          repository.listCalls,
+          greaterThan(callsBefore),
+          reason:
+              'le SSE ne rejoue pas les évènements manqués : il faut '
+              'resynchroniser après chaque reconnexion',
+        );
+      },
+    );
 
-    test('setActive(false) coupe la souscription et empêche la reconnexion',
-        () async {
-      final sse = _FakeSseConnector();
-      final repository = _FakeBroadcastRepository(
-        streams: [_stream('a', status: 'live')],
-      );
-      final notifier = BroadcastNotifier(
-        repository,
-        sse: sse,
-        backoff: (_) => Duration.zero,
-      );
-      notifier.setActive(true);
-      await notifier.load();
-      expect(sse.connectCount, 1);
+    test(
+      'setActive(false) coupe la souscription et empêche la reconnexion',
+      () async {
+        final sse = _FakeSseConnector();
+        final repository = _FakeBroadcastRepository(
+          streams: [_stream('a', status: 'live')],
+        );
+        final notifier = BroadcastNotifier(
+          repository,
+          sse: sse,
+          backoff: (_) => Duration.zero,
+        );
+        notifier.setActive(true);
+        await notifier.load();
+        expect(sse.connectCount, 1);
 
-      notifier.setActive(false);
-      await Future<void>.delayed(const Duration(milliseconds: 10));
+        notifier.setActive(false);
+        await Future<void>.delayed(const Duration(milliseconds: 10));
 
-      expect(sse.connectCount, 1, reason: 'aucune reconnexion en arrière-plan');
-    });
+        expect(
+          sse.connectCount,
+          1,
+          reason: 'aucune reconnexion en arrière-plan',
+        );
+      },
+    );
 
     test('sans connecteur SSE, le notifier reste fonctionnel', () async {
       final repository = _FakeBroadcastRepository(
@@ -664,63 +805,68 @@ void main() {
     });
   });
 
-  group('BroadcastNotifier — repli par polling (plateformes sans streaming)', () {
-    test('un direct sans connecteur SSE déclenche un rafraîchissement périodique',
+  group(
+    'BroadcastNotifier — repli par polling (plateformes sans streaming)',
+    () {
+      test(
+        'un direct sans connecteur SSE déclenche un rafraîchissement périodique',
         () async {
-      // Cas de Flutter web : l'adaptateur navigateur de Dio ne sait pas
-      // streamer, on ne branche donc aucun SSE et on interroge l'API.
-      final repository = _FakeBroadcastRepository(
-        streams: [_stream('a', status: 'live')],
+          // Cas de Flutter web : l'adaptateur navigateur de Dio ne sait pas
+          // streamer, on ne branche donc aucun SSE et on interroge l'API.
+          final repository = _FakeBroadcastRepository(
+            streams: [_stream('a', status: 'live')],
+          );
+          final notifier = BroadcastNotifier(
+            repository,
+            pollInterval: const Duration(milliseconds: 20),
+          );
+          notifier.setActive(true);
+          await notifier.load();
+          final callsAfterLoad = repository.listCalls;
+
+          await Future<void>.delayed(const Duration(milliseconds: 80));
+
+          expect(repository.listCalls, greaterThan(callsAfterLoad));
+          notifier.dispose();
+        },
       );
-      final notifier = BroadcastNotifier(
-        repository,
-        pollInterval: const Duration(milliseconds: 20),
-      );
-      notifier.setActive(true);
-      await notifier.load();
-      final callsAfterLoad = repository.listCalls;
 
-      await Future<void>.delayed(const Duration(milliseconds: 80));
+      test('aucun polling tant qu\'aucun flux n\'est en direct', () async {
+        final repository = _FakeBroadcastRepository(streams: [_stream('a')]);
+        final notifier = BroadcastNotifier(
+          repository,
+          pollInterval: const Duration(milliseconds: 20),
+        );
+        notifier.setActive(true);
+        await notifier.load();
+        final callsAfterLoad = repository.listCalls;
 
-      expect(repository.listCalls, greaterThan(callsAfterLoad));
-      notifier.dispose();
-    });
+        await Future<void>.delayed(const Duration(milliseconds: 80));
 
-    test('aucun polling tant qu\'aucun flux n\'est en direct', () async {
-      final repository = _FakeBroadcastRepository(streams: [_stream('a')]);
-      final notifier = BroadcastNotifier(
-        repository,
-        pollInterval: const Duration(milliseconds: 20),
-      );
-      notifier.setActive(true);
-      await notifier.load();
-      final callsAfterLoad = repository.listCalls;
+        expect(repository.listCalls, callsAfterLoad);
+        notifier.dispose();
+      });
 
-      await Future<void>.delayed(const Duration(milliseconds: 80));
+      test('le polling s\'arrête en arrière-plan', () async {
+        final repository = _FakeBroadcastRepository(
+          streams: [_stream('a', status: 'live')],
+        );
+        final notifier = BroadcastNotifier(
+          repository,
+          pollInterval: const Duration(milliseconds: 20),
+        );
+        notifier.setActive(true);
+        await notifier.load();
 
-      expect(repository.listCalls, callsAfterLoad);
-      notifier.dispose();
-    });
+        notifier.setActive(false);
+        final callsAfterPause = repository.listCalls;
+        await Future<void>.delayed(const Duration(milliseconds: 80));
 
-    test('le polling s\'arrête en arrière-plan', () async {
-      final repository = _FakeBroadcastRepository(
-        streams: [_stream('a', status: 'live')],
-      );
-      final notifier = BroadcastNotifier(
-        repository,
-        pollInterval: const Duration(milliseconds: 20),
-      );
-      notifier.setActive(true);
-      await notifier.load();
-
-      notifier.setActive(false);
-      final callsAfterPause = repository.listCalls;
-      await Future<void>.delayed(const Duration(milliseconds: 80));
-
-      expect(repository.listCalls, callsAfterPause);
-      notifier.dispose();
-    });
-  });
+        expect(repository.listCalls, callsAfterPause);
+        notifier.dispose();
+      });
+    },
+  );
 
   group('BroadcastStream', () {
     test('liveDurationAt ne vaut que pour un flux en direct', () {

--- a/mobile/test/features/broadcast/presentation/broadcast_session_controller_test.dart
+++ b/mobile/test/features/broadcast/presentation/broadcast_session_controller_test.dart
@@ -1,0 +1,289 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:streampulse/core/errors/exceptions.dart';
+import 'package:streampulse/features/broadcast/domain/entities/broadcast_stats.dart';
+import 'package:streampulse/features/broadcast/domain/entities/broadcast_stream.dart';
+import 'package:streampulse/features/broadcast/domain/repositories/broadcast_repository.dart';
+import 'package:streampulse/features/broadcast/domain/services/broadcast_audio_publisher.dart';
+import 'package:streampulse/features/broadcast/presentation/controllers/broadcast_session_controller.dart';
+
+BroadcastStream _stream(String id, {String status = 'idle'}) => BroadcastStream(
+  id: id,
+  title: 'Flux $id',
+  status: status,
+  isPublic: true,
+  createdAt: DateTime.utc(2026, 1, 1),
+  streamKey: 'key-$id',
+  streamSourceUrl: 'http://localhost:8080/api/streams/ingest/key-$id',
+);
+
+class _FakeRepository implements BroadcastRepository {
+  Object? startError;
+  Object? stopError;
+  BroadcastStream? sourceUrlOverride;
+
+  final List<String> startedIds = [];
+  final List<String> stoppedIds = [];
+
+  @override
+  Future<BroadcastStream> startStream(String id) async {
+    startedIds.add(id);
+    if (startError != null) throw startError!;
+    return sourceUrlOverride ?? _stream(id, status: 'live');
+  }
+
+  @override
+  Future<BroadcastStream> stopStream(String id) async {
+    stoppedIds.add(id);
+    if (stopError != null) throw stopError!;
+    return _stream(id, status: 'ended');
+  }
+
+  @override
+  Future<List<BroadcastStream>> listMyStreams() async => const [];
+
+  @override
+  Future<BroadcastStream> createStream({
+    required String title,
+    required bool isPublic,
+    String? description,
+    String? category,
+  }) async => _stream('new');
+
+  @override
+  Future<void> deleteStream(String id) async {}
+
+  @override
+  Future<BroadcastStats> streamStats(String id) async =>
+      BroadcastStats(streamId: id, listeners: 0, peak: 0);
+}
+
+class _FakePublisher implements BroadcastAudioPublisher {
+  final StreamController<BroadcastAudioState> _states =
+      StreamController<BroadcastAudioState>.broadcast();
+
+  Object? startError;
+  int stops = 0;
+
+  @override
+  bool isSupported = true;
+
+  @override
+  BroadcastAudioState state = BroadcastAudioState.idle;
+
+  @override
+  Stream<BroadcastAudioState> get states => _states.stream;
+
+  @override
+  Future<void> prepare() async {}
+
+  @override
+  Future<void> start(Uri sourceUrl) async {
+    if (startError != null) throw startError!;
+    _emit(BroadcastAudioState.live);
+  }
+
+  @override
+  Future<void> stop() async {
+    stops++;
+    _emit(BroadcastAudioState.idle);
+  }
+
+  /// Simule l'abandon du diffuseur audio après épuisement de ses tentatives.
+  void giveUp() => _emit(BroadcastAudioState.failed);
+
+  void _emit(BroadcastAudioState next) {
+    state = next;
+    _states.add(next);
+  }
+
+  @override
+  Future<void> dispose() async {
+    if (!_states.isClosed) await _states.close();
+  }
+}
+
+/// Laisse tourner les callbacks asynchrones (abonnement au flux d'états,
+/// arrêt serveur déclenché en `unawaited`) jusqu'à ce que [condition] tienne.
+Future<void> _pumpUntil(bool Function() condition) async {
+  for (var i = 0; i < 100 && !condition(); i++) {
+    await Future<void>.delayed(const Duration(milliseconds: 1));
+  }
+  expect(condition(), isTrue);
+}
+
+void main() {
+  group('BroadcastSessionController — démarrage', () {
+    test('un échec de capture annule le direct côté serveur', () async {
+      final repository = _FakeRepository();
+      final publisher = _FakePublisher()
+        ..startError = const MicrophonePermissionException();
+      final controller = BroadcastSessionController(repository, publisher);
+
+      await expectLater(
+        controller.start('a'),
+        throwsA(
+          isA<BroadcastSessionStartException>()
+              .having((e) => e.cause, 'cause', isA<MicrophonePermissionException>())
+              .having((e) => e.refreshRequired, 'refreshRequired', isFalse)
+              .having((e) => e.serverState.status, 'serverState.status', 'ended'),
+        ),
+      );
+      expect(repository.startedIds, ['a']);
+      expect(repository.stoppedIds, ['a']);
+      expect(controller.publishingStreamId, isNull);
+
+      await controller.dispose();
+    });
+
+    // Double échec réseau : le rollback lui-même ne passe pas. L'état serveur
+    // rendu à l'écran est alors périmé (le flux est peut-être resté `live`),
+    // d'où `refreshRequired` — la présentation doit resynchroniser.
+    test(
+      'un rollback en échec exige une resynchronisation et rend l\'état d\'origine',
+      () async {
+        final repository = _FakeRepository()
+          ..stopError = const NetworkException();
+        final publisher = _FakePublisher()
+          ..startError = const ServerException('ingest injoignable');
+        final controller = BroadcastSessionController(repository, publisher);
+
+        await expectLater(
+          controller.start('a'),
+          throwsA(
+            isA<BroadcastSessionStartException>()
+                .having((e) => e.cause, 'cause', isA<ServerException>())
+                .having((e) => e.refreshRequired, 'refreshRequired', isTrue)
+                // L'état rendu est celui du `start`, seul connu : le rollback
+                // n'a rien renvoyé.
+                .having((e) => e.serverState.status, 'serverState.status', 'live'),
+          ),
+        );
+        expect(repository.stoppedIds, ['a']);
+        expect(controller.publishingStreamId, isNull);
+
+        await controller.dispose();
+      },
+    );
+
+    test('une URL d\'ingest absente empêche la diffusion', () async {
+      final repository = _FakeRepository()
+        ..sourceUrlOverride = BroadcastStream(
+          id: 'a',
+          title: 'Flux a',
+          status: 'live',
+          isPublic: true,
+          createdAt: DateTime.utc(2026, 1, 1),
+        );
+      final controller = BroadcastSessionController(
+        repository,
+        _FakePublisher(),
+      );
+
+      await expectLater(
+        controller.start('a'),
+        throwsA(
+          isA<BroadcastSessionStartException>().having(
+            (e) => e.cause,
+            'cause',
+            isA<ServerException>(),
+          ),
+        ),
+      );
+      expect(repository.stoppedIds, ['a']);
+
+      await controller.dispose();
+    });
+  });
+
+  group('BroadcastSessionController — panne du micro', () {
+    test(
+      'un abandon du diffuseur audio termine le direct et est signalé',
+      () async {
+        final repository = _FakeRepository();
+        final publisher = _FakePublisher();
+        final controller = BroadcastSessionController(repository, publisher);
+        final failures = <BroadcastAudioFailure>[];
+        final subscription = controller.audioFailures.listen(failures.add);
+
+        await controller.start('a');
+        expect(controller.isPublishing('a'), isTrue);
+
+        publisher.giveUp();
+        await _pumpUntil(() => failures.isNotEmpty);
+
+        expect(repository.stoppedIds, ['a']);
+        expect(failures.single.streamId, 'a');
+        // L'état terminé est transporté avec la panne : la présentation n'a
+        // pas à refaire un aller-retour réseau pour réaligner sa liste.
+        expect(failures.single.serverState?.status, 'ended');
+        expect(controller.publishingStreamId, isNull);
+        // Le micro est relâché même si le serveur a répondu : la session locale
+        // ne doit pas survivre au direct.
+        expect(publisher.stops, 1);
+
+        await subscription.cancel();
+        await controller.dispose();
+      },
+    );
+
+    // Le réseau est souvent coupé au moment même où le micro renonce : l'échec
+    // du stop ne doit ni remonter, ni empêcher la notification.
+    test('un arrêt serveur en échec ne masque pas la panne', () async {
+      final repository = _FakeRepository()..stopError = const NetworkException();
+      final publisher = _FakePublisher();
+      final controller = BroadcastSessionController(repository, publisher);
+      final failures = <BroadcastAudioFailure>[];
+      final subscription = controller.audioFailures.listen(failures.add);
+
+      await controller.start('a');
+      publisher.giveUp();
+      await _pumpUntil(() => failures.isNotEmpty);
+
+      expect(failures.single.streamId, 'a');
+      // Arrêt serveur impossible : sans état à jour, la présentation devra
+      // recharger la liste elle-même.
+      expect(failures.single.serverState, isNull);
+      expect(controller.publishingStreamId, isNull);
+
+      await subscription.cancel();
+      await controller.dispose();
+    });
+
+    test('un arrêt volontaire n\'est pas traité comme une panne', () async {
+      final repository = _FakeRepository();
+      final publisher = _FakePublisher();
+      final controller = BroadcastSessionController(repository, publisher);
+      final failures = <BroadcastAudioFailure>[];
+      final subscription = controller.audioFailures.listen(failures.add);
+
+      await controller.start('a');
+      await controller.stop('a');
+      await _pumpUntil(() => controller.publishingStreamId == null);
+      // Laisse le temps à un éventuel faux positif d'arriver.
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(failures, isEmpty);
+      expect(repository.stoppedIds, ['a']); // le stop demandé, pas un second
+
+      await subscription.cancel();
+      await controller.dispose();
+    });
+  });
+
+  test('audioSupported reflète la capacité de la plateforme', () async {
+    final unsupported = BroadcastSessionController(
+      _FakeRepository(),
+      _FakePublisher()..isSupported = false,
+    );
+    expect(unsupported.audioSupported, isFalse);
+    await unsupported.dispose();
+
+    // Sans publisher (tests de présentation) rien n'interdit le démarrage.
+    final headless = BroadcastSessionController(_FakeRepository(), null);
+    expect(headless.audioSupported, isTrue);
+    await headless.dispose();
+  });
+}

--- a/mobile/test/features/broadcast/presentation/screens/dashboard_screen_test.dart
+++ b/mobile/test/features/broadcast/presentation/screens/dashboard_screen_test.dart
@@ -139,8 +139,13 @@ class _InertSseConnector implements SseConnector {
 }
 
 class _FakeAudioPublisher implements BroadcastAudioPublisher {
+  _FakeAudioPublisher({this.isSupported = true});
+
   final StreamController<BroadcastAudioState> _states =
       StreamController<BroadcastAudioState>.broadcast();
+
+  @override
+  final bool isSupported;
 
   @override
   BroadcastAudioState state = BroadcastAudioState.idle;
@@ -153,19 +158,27 @@ class _FakeAudioPublisher implements BroadcastAudioPublisher {
 
   @override
   Future<void> start(Uri sourceUrl) async {
-    state = BroadcastAudioState.live;
-    _states.add(state);
+    _emit(BroadcastAudioState.live);
   }
 
   @override
   Future<void> stop() async {
-    state = BroadcastAudioState.idle;
-    _states.add(state);
+    _emit(BroadcastAudioState.idle);
+  }
+
+  /// Reconnexion en cours, puis abandon : les deux états que le diffuseur
+  /// audio émet sans que l'utilisateur n'ait rien demandé.
+  void reconnect() => _emit(BroadcastAudioState.reconnecting);
+  void giveUp() => _emit(BroadcastAudioState.failed);
+
+  void _emit(BroadcastAudioState next) {
+    state = next;
+    _states.add(next);
   }
 
   @override
   Future<void> dispose() async {
-    await _states.close();
+    if (!_states.isClosed) await _states.close();
   }
 }
 
@@ -738,5 +751,84 @@ void main() {
         await tester.pump(const Duration(milliseconds: 700));
       },
     );
+
+    testWidgets('annonce que la reprise est bornée pendant une reconnexion', (
+      tester,
+    ) async {
+      final repository = _FakeBroadcastRepository(streams: [_stream('a')]);
+      final audio = _FakeAudioPublisher();
+      await tester.pumpWidget(_harness(repository, audioPublisher: audio));
+      await _settle(tester);
+      await tester.tap(find.byKey(const Key('dashboard_start_button_a')));
+      await _settle(tester);
+
+      audio.reconnect();
+      await _settle(tester);
+
+      expect(find.text('Reconnexion audio…'), findsOneWidget);
+      expect(
+        find.text('Le direct s\'arrêtera si la reconnexion échoue.'),
+        findsOneWidget,
+      );
+
+      toastification.dismissAll(delayForAnimation: false);
+      await tester.pump(const Duration(milliseconds: 700));
+    });
+
+    // La panne définitive du micro arrête le direct sans action de
+    // l'utilisateur : la carte doit le dire, sinon le flux passerait de « en
+    // direct » à « terminé » sans explication.
+    testWidgets('un abandon du micro termine le direct et le signale', (
+      tester,
+    ) async {
+      final repository = _FakeBroadcastRepository(streams: [_stream('a')]);
+      final audio = _FakeAudioPublisher();
+      await tester.pumpWidget(_harness(repository, audioPublisher: audio));
+      await _settle(tester);
+      await tester.tap(find.byKey(const Key('dashboard_start_button_a')));
+      await _settle(tester);
+      expect(find.text('EN DIRECT'), findsOneWidget);
+
+      audio.giveUp();
+      await _settle(tester);
+      // Laisse l'animation d'entrée du toast se jouer : `pump()` sans durée
+      // ne fait pas avancer l'overlay de toastification.
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(repository.stoppedIds, ['a']);
+      expect(find.text('TERMINÉ'), findsOneWidget);
+      expect(
+        find.text('Diffusion arrêtée : le microphone n\'est plus disponible'),
+        findsOneWidget,
+      );
+
+      toastification.dismissAll(delayForAnimation: false);
+      await tester.pump(const Duration(milliseconds: 700));
+    });
+
+    // Sur le web, `prepare()` échouerait après coup : un bouton pleinement
+    // actif qui ne fait qu'afficher un toast fugace est une fausse promesse.
+    testWidgets('neutralise le démarrage sur une plateforme sans capture', (
+      tester,
+    ) async {
+      final repository = _FakeBroadcastRepository(streams: [_stream('a')]);
+      await tester.pumpWidget(
+        _harness(
+          repository,
+          audioPublisher: _FakeAudioPublisher(isSupported: false),
+        ),
+      );
+      await _settle(tester);
+
+      final button = tester.widget<FilledButton>(
+        find.byKey(const Key('dashboard_start_button_a')),
+      );
+      expect(button.onPressed, isNull);
+      expect(
+        find.byKey(const Key('dashboard_audio_unsupported_a')),
+        findsOneWidget,
+      );
+      expect(find.text('EN DIRECT'), findsNothing);
+    });
   });
 }

--- a/mobile/test/features/broadcast/presentation/screens/dashboard_screen_test.dart
+++ b/mobile/test/features/broadcast/presentation/screens/dashboard_screen_test.dart
@@ -10,6 +10,7 @@ import 'package:streampulse/core/network/sse_client.dart';
 import 'package:streampulse/features/broadcast/domain/entities/broadcast_stats.dart';
 import 'package:streampulse/features/broadcast/domain/entities/broadcast_stream.dart';
 import 'package:streampulse/features/broadcast/domain/repositories/broadcast_repository.dart';
+import 'package:streampulse/features/broadcast/domain/services/broadcast_audio_publisher.dart';
 import 'package:streampulse/features/broadcast/presentation/screens/dashboard_screen.dart';
 import 'package:streampulse/features/profile/domain/entities/user_profile.dart';
 import 'package:streampulse/features/profile/domain/repositories/profile_repository.dart';
@@ -22,22 +23,21 @@ BroadcastStream _stream(
   DateTime? startedAt,
   String? sourceUrl,
   DateTime? createdAt,
-}) =>
-    BroadcastStream(
-      id: id,
-      title: title ?? 'Flux $id',
-      status: status,
-      isPublic: true,
-      createdAt: createdAt ?? DateTime.utc(2026, 1, 1),
-      startedAt: startedAt,
-      streamKey: 'cle-secrete-$id',
-      streamSourceUrl:
-          sourceUrl ?? 'http://localhost:8080/api/streams/ingest/cle-secrete-$id',
-    );
+}) => BroadcastStream(
+  id: id,
+  title: title ?? 'Flux $id',
+  status: status,
+  isPublic: true,
+  createdAt: createdAt ?? DateTime.utc(2026, 1, 1),
+  startedAt: startedAt,
+  streamKey: 'cle-secrete-$id',
+  streamSourceUrl:
+      sourceUrl ?? 'http://localhost:8080/api/streams/ingest/cle-secrete-$id',
+);
 
 class _FakeBroadcastRepository implements BroadcastRepository {
   _FakeBroadcastRepository({List<BroadcastStream>? streams, this.startError})
-      : streams = streams ?? const [];
+    : streams = streams ?? const [];
 
   List<BroadcastStream> streams;
 
@@ -57,14 +57,13 @@ class _FakeBroadcastRepository implements BroadcastRepository {
     required bool isPublic,
     String? description,
     String? category,
-  }) async =>
-      BroadcastStream(
-        id: 'new',
-        title: title,
-        status: 'idle',
-        isPublic: isPublic,
-        createdAt: DateTime.utc(2026, 6, 1),
-      );
+  }) async => BroadcastStream(
+    id: 'new',
+    title: title,
+    status: 'idle',
+    isPublic: isPublic,
+    createdAt: DateTime.utc(2026, 6, 1),
+  );
 
   @override
   Future<BroadcastStream> startStream(String id) async {
@@ -73,8 +72,10 @@ class _FakeBroadcastRepository implements BroadcastRepository {
   }
 
   @override
-  Future<BroadcastStream> stopStream(String id) async =>
-      _stream(id, status: 'ended');
+  Future<BroadcastStream> stopStream(String id) async {
+    stoppedIds.add(id);
+    return _stream(id, status: 'ended');
+  }
 
   @override
   Future<void> deleteStream(String id) async {
@@ -82,13 +83,11 @@ class _FakeBroadcastRepository implements BroadcastRepository {
   }
 
   @override
-  Future<BroadcastStats> streamStats(String id) async => BroadcastStats(
-        streamId: id,
-        listeners: listeners,
-        peak: peak,
-      );
+  Future<BroadcastStats> streamStats(String id) async =>
+      BroadcastStats(streamId: id, listeners: listeners, peak: peak);
 
   final List<String> deletedIds = [];
+  final List<String> stoppedIds = [];
   int listeners = 4;
   int peak = 9;
 }
@@ -100,7 +99,8 @@ class _DeferredStatsRepository extends _FakeBroadcastRepository {
   _DeferredStatsRepository({super.streams});
 
   @override
-  Future<BroadcastStats> streamStats(String id) => Completer<BroadcastStats>().future;
+  Future<BroadcastStats> streamStats(String id) =>
+      Completer<BroadcastStats>().future;
 }
 
 class _FakeProfileRepository implements ProfileRepository {
@@ -138,10 +138,42 @@ class _InertSseConnector implements SseConnector {
   Stream<SseEvent> connect(String path) => const Stream.empty();
 }
 
+class _FakeAudioPublisher implements BroadcastAudioPublisher {
+  final StreamController<BroadcastAudioState> _states =
+      StreamController<BroadcastAudioState>.broadcast();
+
+  @override
+  BroadcastAudioState state = BroadcastAudioState.idle;
+
+  @override
+  Stream<BroadcastAudioState> get states => _states.stream;
+
+  @override
+  Future<void> prepare() async {}
+
+  @override
+  Future<void> start(Uri sourceUrl) async {
+    state = BroadcastAudioState.live;
+    _states.add(state);
+  }
+
+  @override
+  Future<void> stop() async {
+    state = BroadcastAudioState.idle;
+    _states.add(state);
+  }
+
+  @override
+  Future<void> dispose() async {
+    await _states.close();
+  }
+}
+
 Widget _harness(
   BroadcastRepository repository, {
   String role = 'broadcaster',
   bool profileFails = false,
+  BroadcastAudioPublisher? audioPublisher,
 }) {
   return ToastificationWrapper(
     child: MultiProvider(
@@ -156,6 +188,7 @@ Widget _harness(
         home: DashboardScreen(
           repository: repository,
           sse: _InertSseConnector(),
+          audioPublisher: audioPublisher ?? _FakeAudioPublisher(),
         ),
       ),
     ),
@@ -173,9 +206,12 @@ Future<void> _settle(WidgetTester tester) async {
 
 void main() {
   group('DashboardScreen — accès', () {
-    testWidgets('un non-diffuseur est orienté vers la demande de rôle',
-        (tester) async {
-      await tester.pumpWidget(_harness(_FakeBroadcastRepository(), role: 'user'));
+    testWidgets('un non-diffuseur est orienté vers la demande de rôle', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _harness(_FakeBroadcastRepository(), role: 'user'),
+      );
       await _settle(tester);
 
       expect(find.text('Diffusez vos propres flux'), findsOneWidget);
@@ -187,8 +223,9 @@ void main() {
       expect(find.byKey(const Key('dashboard_create_button')), findsNothing);
     });
 
-    testWidgets('un visiteur non connecté est invité à se connecter',
-        (tester) async {
+    testWidgets('un visiteur non connecté est invité à se connecter', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         _harness(_FakeBroadcastRepository(), profileFails: true),
       );
@@ -198,8 +235,9 @@ void main() {
       expect(find.byKey(const Key('dashboard_login_button')), findsOneWidget);
     });
 
-    testWidgets('un diffuseur sans flux est invité à en créer un',
-        (tester) async {
+    testWidgets('un diffuseur sans flux est invité à en créer un', (
+      tester,
+    ) async {
       await tester.pumpWidget(_harness(_FakeBroadcastRepository()));
       await _settle(tester);
 
@@ -215,8 +253,12 @@ void main() {
     testWidgets('affiche le statut de chaque flux', (tester) async {
       final repository = _FakeBroadcastRepository(
         streams: [
-          _stream('a', title: 'Talk du soir', status: 'live',
-              startedAt: DateTime.now().subtract(const Duration(minutes: 2))),
+          _stream(
+            'a',
+            title: 'Talk du soir',
+            status: 'live',
+            startedAt: DateTime.now().subtract(const Duration(minutes: 2)),
+          ),
           _stream('b', title: 'Session jazz'),
           _stream('c', title: 'Archive', status: 'ended'),
         ],
@@ -239,12 +281,16 @@ void main() {
       expect(find.text('TERMINÉ'), findsOneWidget);
     });
 
-    testWidgets('le direct affiche un chronomètre, pas les autres flux',
-        (tester) async {
+    testWidgets('le direct affiche un chronomètre, pas les autres flux', (
+      tester,
+    ) async {
       final repository = _FakeBroadcastRepository(
         streams: [
-          _stream('a', status: 'live',
-              startedAt: DateTime.now().subtract(const Duration(minutes: 2))),
+          _stream(
+            'a',
+            status: 'live',
+            startedAt: DateTime.now().subtract(const Duration(minutes: 2)),
+          ),
           _stream('b'),
         ],
       );
@@ -256,44 +302,51 @@ void main() {
     });
 
     testWidgets(
-        'un seul live : le démarrage des autres flux est désactivé et expliqué',
-        (tester) async {
-      final repository = _FakeBroadcastRepository(
-        streams: [
-          _stream('a', status: 'live', startedAt: DateTime.now()),
-          _stream('b'),
-        ],
-      );
-      await tester.pumpWidget(_harness(repository));
-      await _settle(tester);
+      'un seul live : le démarrage des autres flux est désactivé et expliqué',
+      (tester) async {
+        final repository = _FakeBroadcastRepository(
+          streams: [
+            _stream('a', status: 'live', startedAt: DateTime.now()),
+            _stream('b'),
+          ],
+        );
+        await tester.pumpWidget(_harness(repository));
+        await _settle(tester);
 
-      final startB = tester.widget<FilledButton>(
-        find.byKey(const Key('dashboard_start_button_b')),
-      );
-      expect(startB.onPressed, isNull);
-      expect(find.text('Un autre flux est en direct'), findsOneWidget);
-      // Le flux en direct garde son bouton d'arrêt actif.
-      final stopA = tester.widget<FilledButton>(
-        find.byKey(const Key('dashboard_stop_button_a')),
-      );
-      expect(stopA.onPressed, isNotNull);
-    });
+        final startB = tester.widget<FilledButton>(
+          find.byKey(const Key('dashboard_start_button_b')),
+        );
+        expect(startB.onPressed, isNull);
+        expect(find.text('Un autre flux est en direct'), findsOneWidget);
+        // Le flux en direct garde son bouton d'arrêt actif.
+        final stopA = tester.widget<FilledButton>(
+          find.byKey(const Key('dashboard_stop_button_a')),
+        );
+        expect(stopA.onPressed, isNotNull);
+      },
+    );
   });
 
   group('DashboardScreen — audience (STR-154)', () {
-    testWidgets('le direct affiche les auditeurs estimés et le pic',
-        (tester) async {
-      final repository = _FakeBroadcastRepository(
-        streams: [_stream('a', status: 'live', startedAt: DateTime.now())],
-      )
-        ..listeners = 4
-        ..peak = 9;
+    testWidgets('le direct affiche les auditeurs estimés et le pic', (
+      tester,
+    ) async {
+      final repository =
+          _FakeBroadcastRepository(
+              streams: [
+                _stream('a', status: 'live', startedAt: DateTime.now()),
+              ],
+            )
+            ..listeners = 4
+            ..peak = 9;
       await tester.pumpWidget(_harness(repository));
       await _settle(tester);
 
       expect(find.byKey(const Key('dashboard_listeners_a')), findsOneWidget);
       expect(
-        tester.widget<Text>(find.byKey(const Key('dashboard_listeners_a'))).data,
+        tester
+            .widget<Text>(find.byKey(const Key('dashboard_listeners_a')))
+            .data,
         '4',
       );
       expect(
@@ -315,8 +368,9 @@ void main() {
       expect(find.text('auditeur estimé'), findsOneWidget);
     });
 
-    testWidgets('la ligne est présente dès le direct, avant toute mesure',
-        (tester) async {
+    testWidgets('la ligne est présente dès le direct, avant toute mesure', (
+      tester,
+    ) async {
       // Sans ça, la ligne « apparaît » au premier relevé et pousse le contenu
       // vers le bas ; et elle disparaît au passage en arrière-plan, quand
       // `_cancelStats()` remet l'audience à null.
@@ -328,7 +382,9 @@ void main() {
 
       expect(find.byKey(const Key('dashboard_listeners_a')), findsOneWidget);
       expect(
-        tester.widget<Text>(find.byKey(const Key('dashboard_listeners_a'))).data,
+        tester
+            .widget<Text>(find.byKey(const Key('dashboard_listeners_a')))
+            .data,
         '—',
       );
       expect(
@@ -350,8 +406,9 @@ void main() {
       );
     });
 
-    testWidgets('une info-bulle explique que le chiffre est une estimation',
-        (tester) async {
+    testWidgets('une info-bulle explique que le chiffre est une estimation', (
+      tester,
+    ) async {
       final repository = _FakeBroadcastRepository(
         streams: [_stream('a', status: 'live', startedAt: DateTime.now())],
       );
@@ -371,22 +428,28 @@ void main() {
       expect(tooltip.message, contains('même connexion comptent pour un'));
     });
 
-    testWidgets('aucune audience affichée sur un flux qui n\'est pas en direct',
-        (tester) async {
-      final repository = _FakeBroadcastRepository(
-        streams: [_stream('a'), _stream('b', status: 'ended')],
-      );
-      await tester.pumpWidget(_harness(repository));
-      await _settle(tester);
+    testWidgets(
+      'aucune audience affichée sur un flux qui n\'est pas en direct',
+      (tester) async {
+        final repository = _FakeBroadcastRepository(
+          streams: [
+            _stream('a'),
+            _stream('b', status: 'ended'),
+          ],
+        );
+        await tester.pumpWidget(_harness(repository));
+        await _settle(tester);
 
-      expect(find.byKey(const Key('dashboard_listeners_a')), findsNothing);
-      expect(find.byKey(const Key('dashboard_listeners_b')), findsNothing);
-    });
+        expect(find.byKey(const Key('dashboard_listeners_a')), findsNothing);
+        expect(find.byKey(const Key('dashboard_listeners_b')), findsNothing);
+      },
+    );
   });
 
   group('DashboardScreen — flux terminé', () {
-    testWidgets('aucun bouton de démarrage, le backend le refuserait',
-        (tester) async {
+    testWidgets('aucun bouton de démarrage, le backend le refuserait', (
+      tester,
+    ) async {
       // `start` n'accepte que idle -> live : proposer le bouton sur un flux
       // terminé ne peut produire qu'un 409.
       final repository = _FakeBroadcastRepository(
@@ -406,46 +469,48 @@ void main() {
       expect(find.text('Un autre flux est en direct'), findsNothing);
     });
 
-    testWidgets(
-      'un 409 sans autre direct est expliqué par la bonne raison',
-      (tester) async {
-        final repository = _FakeBroadcastRepository(
-          streams: [_stream('a')],
-          startError: const ConflictException('stream is not idle'),
-        );
-        await tester.pumpWidget(_harness(repository));
-        await _settle(tester);
+    testWidgets('un 409 sans autre direct est expliqué par la bonne raison', (
+      tester,
+    ) async {
+      final repository = _FakeBroadcastRepository(
+        streams: [_stream('a')],
+        startError: const ConflictException('stream is not idle'),
+      );
+      await tester.pumpWidget(_harness(repository));
+      await _settle(tester);
 
-        await tester.tap(find.byKey(const Key('dashboard_start_button_a')));
-        await _settle(tester);
-        // Le toast vit dans un overlay animé : laisser l'animation d'entrée
-        // se dérouler avant d'assert.
-        await tester.pump(const Duration(milliseconds: 600));
+      await tester.tap(find.byKey(const Key('dashboard_start_button_a')));
+      await _settle(tester);
+      // Le toast vit dans un overlay animé : laisser l'animation d'entrée
+      // se dérouler avant d'assert.
+      await tester.pump(const Duration(milliseconds: 600));
 
-        expect(find.text("Ce flux n'est plus démarrable"), findsOneWidget);
-        expect(find.text('Un autre flux est déjà en direct'), findsNothing);
+      expect(find.text("Ce flux n'est plus démarrable"), findsOneWidget);
+      expect(find.text('Un autre flux est déjà en direct'), findsNothing);
 
-        toastification.dismissAll(delayForAnimation: false);
-        await tester.pump(const Duration(milliseconds: 700));
-      },
-    );
+      toastification.dismissAll(delayForAnimation: false);
+      await tester.pump(const Duration(milliseconds: 700));
+    });
   });
 
   group('DashboardScreen — retours de revue', () {
-    testWidgets('les badges PRÊT et TERMINÉ ne partagent pas leur couleur',
-        (tester) async {
+    testWidgets('les badges PRÊT et TERMINÉ ne partagent pas leur couleur', (
+      tester,
+    ) async {
       final repository = _FakeBroadcastRepository(
-        streams: [_stream('a'), _stream('b', status: 'ended')],
+        streams: [
+          _stream('a'),
+          _stream('b', status: 'ended'),
+        ],
       );
       await tester.pumpWidget(_harness(repository));
       await _settle(tester);
 
       Color badgeColor(String label) {
         final container = tester.widget<Container>(
-          find.ancestor(
-            of: find.text(label),
-            matching: find.byType(Container),
-          ).first,
+          find
+              .ancestor(of: find.text(label), matching: find.byType(Container))
+              .first,
         );
         return (container.decoration! as BoxDecoration).color!;
       }
@@ -459,7 +524,10 @@ void main() {
 
     testWidgets('aucune URL d\'ingest sur un flux terminé', (tester) async {
       final repository = _FakeBroadcastRepository(
-        streams: [_stream('a', status: 'ended'), _stream('b')],
+        streams: [
+          _stream('a', status: 'ended'),
+          _stream('b'),
+        ],
       );
       await tester.pumpWidget(_harness(repository));
       await _settle(tester);
@@ -470,10 +538,14 @@ void main() {
       expect(find.byKey(const Key('dashboard_ingest_url_b')), findsOneWidget);
     });
 
-    testWidgets('supprimer un flux le retire après confirmation',
-        (tester) async {
+    testWidgets('supprimer un flux le retire après confirmation', (
+      tester,
+    ) async {
       final repository = _FakeBroadcastRepository(
-        streams: [_stream('a', title: 'À jeter'), _stream('b')],
+        streams: [
+          _stream('a', title: 'À jeter'),
+          _stream('b'),
+        ],
       );
       await tester.pumpWidget(_harness(repository));
       await _settle(tester);
@@ -484,7 +556,9 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Supprimer « À jeter » ?'), findsOneWidget);
-      await tester.tap(find.byKey(const Key('dashboard_confirm_delete_button')));
+      await tester.tap(
+        find.byKey(const Key('dashboard_confirm_delete_button')),
+      );
       await _settle(tester);
 
       expect(repository.deletedIds, ['a']);
@@ -495,12 +569,17 @@ void main() {
       await tester.pump(const Duration(milliseconds: 700));
     });
 
-    testWidgets('supprimer un direct annonce l\'arrêt de la diffusion',
-        (tester) async {
+    testWidgets('supprimer un direct annonce l\'arrêt de la diffusion', (
+      tester,
+    ) async {
       final repository = _FakeBroadcastRepository(
         streams: [
-          _stream('a', title: 'En cours', status: 'live',
-              startedAt: DateTime.now()),
+          _stream(
+            'a',
+            title: 'En cours',
+            status: 'live',
+            startedAt: DateTime.now(),
+          ),
         ],
       );
       await tester.pumpWidget(_harness(repository));
@@ -549,8 +628,9 @@ void main() {
       await tester.tap(find.byKey(const Key('dashboard_reveal_key_a')));
       await tester.pump();
 
-      final revealed =
-          tester.widget<Text>(find.byKey(const Key('dashboard_ingest_url_a')));
+      final revealed = tester.widget<Text>(
+        find.byKey(const Key('dashboard_ingest_url_a')),
+      );
       expect(revealed.data!, contains('cle-secrete-a'));
       // Tronquer l'URL révélée rendrait le bouton « révéler » inutile : on ne
       // pourrait pas lire la clé qu'on vient de demander à voir.
@@ -586,28 +666,74 @@ void main() {
   });
 
   group('DashboardScreen — latence de démarrage (STR-159)', () {
+    testWidgets('le passage EN DIRECT est rendu depuis la réponse de start, '
+        'sans rechargement bloquant', (tester) async {
+      final repository = _FakeBroadcastRepository(streams: [_stream('a')]);
+      await tester.pumpWidget(_harness(repository));
+      await _settle(tester);
+      final listCallsAfterLoad = repository.listCalls;
+
+      await tester.tap(find.byKey(const Key('dashboard_start_button_a')));
+      await _settle(tester);
+
+      expect(find.text('EN DIRECT'), findsOneWidget);
+      expect(
+        repository.listCalls,
+        listCallsAfterLoad,
+        reason:
+            'le rendu du direct ne doit pas attendre un refetch de la '
+            'liste : la réponse de start suffit',
+      );
+
+      // Le toast de succès arme un minuteur d'auto-fermeture : le purger
+      // avant la fin du test (même pattern que `AdminStreamsScreen`).
+      toastification.dismissAll(delayForAnimation: false);
+      await tester.pump(const Duration(milliseconds: 700));
+    });
+  });
+
+  group('DashboardScreen — microphone (STR-156)', () {
+    testWidgets('affiche que le microphone de cet appareil est diffusé', (
+      tester,
+    ) async {
+      final repository = _FakeBroadcastRepository(streams: [_stream('a')]);
+      final audio = _FakeAudioPublisher();
+      await tester.pumpWidget(_harness(repository, audioPublisher: audio));
+      await _settle(tester);
+
+      await tester.tap(find.byKey(const Key('dashboard_start_button_a')));
+      await _settle(tester);
+
+      expect(find.text('Microphone diffusé'), findsOneWidget);
+      expect(
+        find.byKey(const Key('dashboard_microphone_status_a')),
+        findsOneWidget,
+      );
+
+      toastification.dismissAll(delayForAnimation: false);
+      await tester.pump(const Duration(milliseconds: 700));
+    });
+
     testWidgets(
-      'le passage EN DIRECT est rendu depuis la réponse de start, '
-      'sans rechargement bloquant',
+      'le passage en arrière-plan arrête le live et libère le micro',
       (tester) async {
         final repository = _FakeBroadcastRepository(streams: [_stream('a')]);
-        await tester.pumpWidget(_harness(repository));
+        final audio = _FakeAudioPublisher();
+        await tester.pumpWidget(_harness(repository, audioPublisher: audio));
         await _settle(tester);
-        final listCallsAfterLoad = repository.listCalls;
-
         await tester.tap(find.byKey(const Key('dashboard_start_button_a')));
         await _settle(tester);
 
-        expect(find.text('EN DIRECT'), findsOneWidget);
-        expect(
-          repository.listCalls,
-          listCallsAfterLoad,
-          reason: 'le rendu du direct ne doit pas attendre un refetch de la '
-              'liste : la réponse de start suffit',
-        );
+        tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+        await _settle(tester);
 
-        // Le toast de succès arme un minuteur d'auto-fermeture : le purger
-        // avant la fin du test (même pattern que `AdminStreamsScreen`).
+        expect(repository.stoppedIds, ['a']);
+        expect(audio.state, BroadcastAudioState.idle);
+        expect(find.text('TERMINÉ'), findsOneWidget);
+
+        tester.binding.handleAppLifecycleStateChanged(
+          AppLifecycleState.resumed,
+        );
         toastification.dismissAll(delayForAnimation: false);
         await tester.pump(const Duration(milliseconds: 700));
       },


### PR DESCRIPTION
## Contexte

Implémente STR-156 : capture du microphone mobile en AAC/ADTS et envoi continu vers stream_source_url.

Refs: STR-156

## Changements

- capture AAC/ADTS avec record 6.2.1 et permission microphone iOS/Android
- push HTTP brut chunked audio/aac avec Dio, reprise réseau exponentielle et état visible dans le dashboard
- orchestration start/rollback/stop isolée dans un contrôleur de session ; arrêt volontaire au passage en arrière-plan
- bail d’ingest backend configurable avec deadline glissante et retry d’arrêt afin de ne pas conserver un live silencieux
- ADR 027 et couverture unitaire/widget/intégration HTTP

## Comment tester

1. cd mobile && flutter analyze && flutter test
2. cd mobile && flutter build apk --debug
3. cd mobile && flutter build ios --simulator
4. cd backend && go test ./...
5. cd backend && go test -race ./internal/streaming

## Checklist

- [x] Les commits suivent Conventional Commits
- [x] Le titre de la PR suit Conventional Commits
- [x] La branche est à jour avec develop
- [x] Les tests passent localement
- [x] Aucun secret / .env committé
- [x] La doc est mise à jour si nécessaire

## QA appareil

Les builds Android et iOS simulateur passent. La QA microphone réelle reste à exécuter sur un téléphone : aucun appareil physique n’était détecté par Flutter au moment de cette validation.