### PR TITLE
feat(api): rotation de la clé de diffusion (STR-228)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,6 +239,7 @@ Domaine `internal/streaming/` (handler/service/repository). Détails dans [ADR 0
 | GET | `/api/users/me/favorites` | `Handler.ListFavorites` | Oui (JWT) — liste « mes favoris » (tous statuts, visibles, non archivés), sans secret (US-04-05) |
 | GET | `/api/users/me/streams` | `Handler.ListMine` | Oui (JWT) — tableau de bord diffuseur : **mes** flux (tous statuts, non archivés), **avec** `stream_key`/`stream_source_url` (le filtre porte sur le porteur du JWT) ; `[]` si aucun flux, jamais 403 (STR-153, ADR 024) |
 | GET | `/api/streams/{id}/stats` | `Handler.Stats` | Oui (JWT) — audience du flux : auditeurs **estimés**, pic, durée. Propriétaire uniquement → 404 sinon ; flux non live → 200 avec compteurs à zéro (STR-154, ADR 025) |
+| POST | `/api/streams/{id}/key/rotate` | `Handler.RotateKey` | Oui — rôle `broadcaster`, owner ; remet une `stream_key` neuve et invalide l'ancienne, 409 si le flux est **live** (l'index `byKey` de `LiveSessions` pointerait sur l'ancienne clé). Chemin en `key/rotate` et **non** `rotate-key` : ce dernier entre en conflit ServeMux avec `ingest/{stream_key}` (STR-228, ADR 028) |
 | POST | `/api/streams/ingest/{stream_key}` | `Handler.Ingest` | **Non (JWT)** — auth par `stream_key` dans le path ; push audio AAC segmenté en HLS (STR-70/71) |
 | GET | `/api/streams/{id}/playlist.m3u8` | `Handler.Playlist` | **Public** (`OptionalAuth`) — flux publics servis à un anonyme, privé → 404 ; owner authentifié voit ses flux privés — manifeste HLS, 409 si pas live/pas prêt (STR-108) ; 503 si capacité atteinte (`HLS_MAX_CONCURRENT`, STR-88) |
 | GET | `/api/streams/{id}/segments/{segment}` | `Handler.Segment` | **Public** (`OptionalAuth`) — idem playlist — segment `.ts` (nom validé anti-traversal) (STR-108) ; 503 si capacité atteinte (`HLS_MAX_CONCURRENT`, STR-88) |
@@ -560,7 +561,7 @@ xcrun simctl openurl booted \
 | `docs/adr/012-openapi-source-de-verite.md` | Décision : OpenAPI source de vérité du contrat HTTP + client Dart/Dio généré |
 
 **Règle :** toute nouvelle décision d'architecture significative → nouvel ADR dans `docs/adr/`
-avec le numéro suivant (prochain : `027-...`). Référencer le ticket Linear correspondant.
+avec le numéro suivant (prochain : `029-...`). Référencer le ticket Linear correspondant.
 
 ## Principes SOLID
 

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -41,6 +41,11 @@ var _ admin.LiveStopper = (*streaming.Service)(nil)
 // consomme pour interrompre un flux lors d'une action de modération (STR-192).
 var _ admin.StreamModerator = (*streaming.Service)(nil)
 
+// var _ vérifie à la compilation que le repository admin, seul à savoir écrire
+// dans audit_logs, satisfait streaming.AuditRecorder — l'interface étroite que
+// le domaine streaming consomme pour journaliser une rotation de clé (STR-228).
+var _ streaming.AuditRecorder = (admin.Repository)(nil)
+
 func main() {
 	if err := run(); err != nil {
 		// Avant config.Load le logger applicatif n'existe pas encore : le
@@ -163,6 +168,12 @@ func run() error {
 	adminSvc := admin.NewService(adminRepo, streamingSvc, streamingSvc)
 	adminHandler := admin.NewHandler(adminSvc)
 
+	// `audit_logs` appartient au domaine admin ; le streaming n'en connaît que
+	// l'interface étroite AuditRecorder, satisfaite ici par le repository admin
+	// (STR-228). Injecté après coup plutôt qu'au constructeur : adminRepo dépend
+	// lui-même de streamingSvc via NewService juste au-dessus.
+	streamingSvc.SetAuditRecorder(adminRepo)
+
 	// 5. Démarrer le serveur HTTP
 	mux := http.NewServeMux()
 
@@ -228,6 +239,18 @@ func run() error {
 		auth.RequireRole("broadcaster", http.HandlerFunc(streamingHandler.Start))))
 	mux.Handle("PATCH /api/streams/{id}/stop", auth.RequireAuth(cfg.JWTSecret,
 		auth.RequireRole("broadcaster", http.HandlerFunc(streamingHandler.Stop))))
+	// Rotation du secret d'ingest (STR-228), propriétaire diffuseur uniquement.
+	//
+	// Le chemin porte un segment de plus que `{id}/rotate-key` proposé au
+	// ticket, pour la raison qui a imposé PUT aux favoris plus bas :
+	// POST /api/streams/{id}/rotate-key et POST /api/streams/ingest/{stream_key}
+	// ont quatre segments chacun et /api/streams/ingest/rotate-key matcherait les
+	// deux — le ServeMux refuse alors d'enregistrer les patterns. Départager par
+	// la longueur du chemin plutôt que par la méthode garde POST, qui est le bon
+	// verbe ici (chaque appel frappe une clé neuve, rien d'idempotent), et ne se
+	// recasse pas si un jour une autre méthode est montée sur `ingest/`.
+	mux.Handle("POST /api/streams/{id}/key/rotate", auth.RequireAuth(cfg.JWTSecret,
+		auth.RequireRole("broadcaster", http.HandlerFunc(streamingHandler.RotateKey))))
 	// Favoris (US-04-05) : ajout/retrait d'un flux et liste « mes favoris ».
 	// Action de niveau utilisateur : RequireAuth seul (pas de rôle diffuseur).
 	// Ajout en PUT (idempotent) et non POST : un POST /api/streams/{id}/favorite

--- a/backend/internal/admin/service.go
+++ b/backend/internal/admin/service.go
@@ -5,9 +5,10 @@ package admin
 
 import (
 	"context"
-	"log"
 	"strings"
 	"time"
+
+	"github.com/rs/zerolog"
 
 	"github.com/LignacAntony/streampulse/internal/shared/apperror"
 )
@@ -128,7 +129,13 @@ func (s *Service) StopStream(ctx context.Context, streamID, actorID string) erro
 		return err
 	}
 	if err := s.repo.InsertAuditLog(ctx, actorID, "stream.stopped", "stream", streamID); err != nil {
-		log.Printf("admin: audit stream.stopped %s par %s non journalisé: %v", streamID, actorID, err)
+		// Champs structurés plutôt qu'une phrase interpolée : c'est ce qui rend
+		// la trace requêtable dans Loki (ADR 018), et `zerolog.Ctx` la corrèle
+		// au request_id posé par le middleware d'accès.
+		zerolog.Ctx(ctx).Error().Err(err).
+			Str("stream_id", streamID).
+			Str("actor_id", actorID).
+			Msg("admin: interruption de flux non journalisée")
 	}
 	return nil
 }

--- a/backend/internal/openapi/openapi.yaml
+++ b/backend/internal/openapi/openapi.yaml
@@ -871,6 +871,64 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "500":
           $ref: "#/components/responses/InternalError"
+  /api/streams/{id}/key/rotate:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Streaming
+      operationId: rotateStreamKey
+      summary: Issue a new ingest key, invalidating the previous one (broadcaster owner only).
+      description: >-
+        Recovery path for a leaked stream_key (STR-228). The key authenticates
+        ingest on its own, so anyone holding it can broadcast in the owner's
+        place; before this endpoint the only remedy was deleting the stream and
+        losing its id, favourites and history.
+
+
+        The response carries the new secrets, which exist nowhere else. The
+        broadcaster's encoder must be reconfigured with the new URL.
+
+
+        Rejected with 409 while the stream is live: the in-memory session is
+        indexed by the key, so rotating mid-broadcast would cut the running
+        ingest and leave the index on the old key. Logged to the audit trail on
+        a best-effort basis, without ever recording the key itself.
+
+
+        The path is `/{id}/key/rotate` and not `/{id}/rotate-key` because the
+        latter structurally conflicts with `/api/streams/ingest/{stream_key}`
+        in Go's ServeMux — `/api/streams/ingest/rotate-key` would match both.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: >-
+            A new key was issued. stream_key and stream_source_url carry the new
+            secret; the previous one is no longer accepted for ingest.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StreamResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: The stream is live — stop it before rotating its key.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
   /api/streams/{id}/events:
     parameters:
       - name: id

--- a/backend/internal/streaming/db/streams.sql.go
+++ b/backend/internal/streaming/db/streams.sql.go
@@ -300,6 +300,64 @@ func (q *Queries) ListStreamsByOwner(ctx context.Context, userID pgtype.UUID) ([
 	return items, nil
 }
 
+const rotateStreamKey = `-- name: RotateStreamKey :one
+UPDATE streams
+SET stream_key = $1, updated_at = NOW()
+WHERE id = $2::uuid AND user_id = $3::uuid
+  AND status <> 'live' AND archived_at IS NULL
+RETURNING id::text AS id, user_id::text AS user_id, title, description, category,
+          status, is_public, stream_key, started_at, ended_at, created_at, updated_at
+`
+
+type RotateStreamKeyParams struct {
+	StreamKey string
+	ID        pgtype.UUID
+	UserID    pgtype.UUID
+}
+
+type RotateStreamKeyRow struct {
+	ID          string
+	UserID      string
+	Title       string
+	Description pgtype.Text
+	Category    pgtype.Text
+	Status      string
+	IsPublic    bool
+	StreamKey   string
+	StartedAt   *time.Time
+	EndedAt     *time.Time
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+// Remplace le secret d'ingest d'un flux (propriétaire, non archivé), invalidant
+// l'ancien du même coup : la colonne est unique, il n'y a qu'une clé valide par
+// flux à tout instant.
+//
+// Le statut 'live' est exclu ici, en SQL, et pas seulement gardé dans le
+// service : LiveSessions indexe la session par la clé au démarrage du direct.
+// Une rotation pendant la diffusion désynchroniserait cet index — l'ancienne
+// clé continuerait de router l'ingest, la nouvelle renverrait 404.
+func (q *Queries) RotateStreamKey(ctx context.Context, arg RotateStreamKeyParams) (RotateStreamKeyRow, error) {
+	row := q.db.QueryRow(ctx, rotateStreamKey, arg.StreamKey, arg.ID, arg.UserID)
+	var i RotateStreamKeyRow
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.Title,
+		&i.Description,
+		&i.Category,
+		&i.Status,
+		&i.IsPublic,
+		&i.StreamKey,
+		&i.StartedAt,
+		&i.EndedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const startStream = `-- name: StartStream :one
 UPDATE streams AS s
 SET status = 'live', started_at = NOW(), updated_at = NOW()

--- a/backend/internal/streaming/handler.go
+++ b/backend/internal/streaming/handler.go
@@ -59,6 +59,7 @@ type StreamService interface {
 	RemoveFavorite(ctx context.Context, streamID, requesterID string) error
 	ListFavorites(ctx context.Context, requesterID string) ([]Stream, error)
 	ListMyStreams(ctx context.Context, requesterID string) ([]Stream, error)
+	RotateStreamKey(ctx context.Context, id, requesterID string) (Stream, error)
 }
 
 // StreamSessions expose au handler les opérations sur les sessions live :
@@ -444,6 +445,31 @@ func (h *Handler) Stop(w http.ResponseWriter, r *http.Request) {
 
 	if err := httpjson.Write(w, http.StatusOK, h.toResponse(stream, true)); err != nil {
 		zerolog.Ctx(r.Context()).Error().Err(err).Msg("streaming: encode stop")
+	}
+}
+
+// RotateKey gère POST /api/streams/{id}/key/rotate : remet une clé d'ingest
+// neuve au propriétaire et invalide l'ancienne (STR-228). 404 si le flux est
+// absent ou appartient à un tiers ; 409 s'il est en direct.
+//
+// La réponse porte les secrets (`stream_key`, `stream_source_url`) comme
+// start/stop : la nouvelle clé n'existe nulle part ailleurs, ne pas la rendre
+// obligerait le client à un GET de plus juste après l'avoir demandée.
+func (h *Handler) RotateKey(w http.ResponseWriter, r *http.Request) {
+	requesterID, ok := auth.UserIDFromContext(r.Context())
+	if !ok {
+		httpjson.WriteError(w, r, apperror.Unauthorized("unauthenticated"))
+		return
+	}
+
+	stream, err := h.svc.RotateStreamKey(r.Context(), r.PathValue("id"), requesterID)
+	if err != nil {
+		httpjson.WriteError(w, r, err)
+		return
+	}
+
+	if err := httpjson.Write(w, http.StatusOK, h.toResponse(stream, true)); err != nil {
+		zerolog.Ctx(r.Context()).Error().Err(err).Msg("streaming: encode rotate key")
 	}
 }
 

--- a/backend/internal/streaming/handler_test.go
+++ b/backend/internal/streaming/handler_test.go
@@ -54,6 +54,9 @@ type stubService struct {
 	listFavErr   error
 	listMineRet  []Stream
 	listMineErr  error
+
+	rotateRet Stream
+	rotateErr error
 }
 
 func (s *stubService) CreateStream(_ context.Context, in CreateStreamInput) (Stream, error) {
@@ -97,6 +100,12 @@ func (s *stubService) StopStream(_ context.Context, id, requesterID string) (Str
 	s.gotID = id
 	s.gotRequester = requesterID
 	return s.stopRet, s.stopErr
+}
+
+func (s *stubService) RotateStreamKey(_ context.Context, id, requesterID string) (Stream, error) {
+	s.gotID = id
+	s.gotRequester = requesterID
+	return s.rotateRet, s.rotateErr
 }
 
 func (s *stubService) AddFavorite(_ context.Context, streamID, requesterID string) error {
@@ -519,6 +528,65 @@ func TestHandler_Stop_Conflict(t *testing.T) {
 
 	if rec.Code != http.StatusConflict {
 		t.Fatalf("want 409, got %d: %s", rec.Code, rec.Body)
+	}
+}
+
+// La nouvelle clé n'existe nulle part ailleurs : la réponse doit la porter,
+// ainsi que l'URL d'ingest reconstruite, sinon le diffuseur devrait faire un GET
+// de plus juste après l'avoir demandée.
+func TestHandler_RotateKey_OK(t *testing.T) {
+	stub := &stubService{rotateRet: Stream{ID: "s1", UserID: testUserID, Status: StatusIdle, StreamKey: "NOUVELLE"}}
+	h := NewHandler(stub, testIngestURL, NewLiveSessions(context.Background()))
+
+	rec := doID(t, http.MethodPost, "s1", "", http.HandlerFunc(h.RotateKey), true)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body)
+	}
+	if !strings.Contains(rec.Body.String(), `"stream_key":"NOUVELLE"`) {
+		t.Errorf("la nouvelle clé doit être rendue: %s", rec.Body)
+	}
+	if !strings.Contains(rec.Body.String(), testIngestURL+"/api/streams/ingest/NOUVELLE") {
+		t.Errorf("l'URL d'ingest doit refléter la nouvelle clé: %s", rec.Body)
+	}
+	if stub.gotRequester != testUserID {
+		t.Errorf("requester = %q, want %q", stub.gotRequester, testUserID)
+	}
+}
+
+func TestHandler_RotateKey_Live_Conflict(t *testing.T) {
+	stub := &stubService{rotateErr: apperror.Conflict("stream is live")}
+	h := NewHandler(stub, testIngestURL, NewLiveSessions(context.Background()))
+
+	rec := doID(t, http.MethodPost, "s1", "", http.HandlerFunc(h.RotateKey), true)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("want 409, got %d: %s", rec.Code, rec.Body)
+	}
+}
+
+func TestHandler_RotateKey_NotFound(t *testing.T) {
+	stub := &stubService{rotateErr: apperror.NotFound("stream not found")}
+	h := NewHandler(stub, testIngestURL, NewLiveSessions(context.Background()))
+
+	rec := doID(t, http.MethodPost, "s1", "", http.HandlerFunc(h.RotateKey), true)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d: %s", rec.Code, rec.Body)
+	}
+}
+
+func TestHandler_RotateKey_RequiresToken(t *testing.T) {
+	stub := &stubService{}
+	h := NewHandler(stub, testIngestURL, NewLiveSessions(context.Background()))
+
+	rec := doID(t, http.MethodPost, "s1", "", http.HandlerFunc(h.RotateKey), false)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d: %s", rec.Code, rec.Body)
+	}
+	if stub.gotID != "" {
+		t.Error("le service ne doit pas être appelé sans identité")
 	}
 }
 

--- a/backend/internal/streaming/queries/streams.sql
+++ b/backend/internal/streaming/queries/streams.sql
@@ -84,6 +84,22 @@ WHERE id = sqlc.arg(id)::uuid AND user_id = sqlc.arg(user_id)::uuid
 RETURNING id::text AS id, user_id::text AS user_id, title, description, category,
           status, is_public, stream_key, started_at, ended_at, created_at, updated_at;
 
+-- name: RotateStreamKey :one
+-- Remplace le secret d'ingest d'un flux (propriétaire, non archivé), invalidant
+-- l'ancien du même coup : la colonne est unique, il n'y a qu'une clé valide par
+-- flux à tout instant.
+--
+-- Le statut 'live' est exclu ici, en SQL, et pas seulement gardé dans le
+-- service : LiveSessions indexe la session par la clé au démarrage du direct.
+-- Une rotation pendant la diffusion désynchroniserait cet index — l'ancienne
+-- clé continuerait de router l'ingest, la nouvelle renverrait 404.
+UPDATE streams
+SET stream_key = sqlc.arg(stream_key), updated_at = NOW()
+WHERE id = sqlc.arg(id)::uuid AND user_id = sqlc.arg(user_id)::uuid
+  AND status <> 'live' AND archived_at IS NULL
+RETURNING id::text AS id, user_id::text AS user_id, title, description, category,
+          status, is_public, stream_key, started_at, ended_at, created_at, updated_at;
+
 -- name: EndOrphanLiveStreams :execrows
 -- Réconciliation au démarrage : les sessions LiveSessions sont en mémoire et
 -- reparties vides après un redémarrage ; on termine les flux restés 'live' en

--- a/backend/internal/streaming/repository.go
+++ b/backend/internal/streaming/repository.go
@@ -181,6 +181,32 @@ func (r *pgRepository) StopStream(ctx context.Context, id, userID string) (Strea
 		row.Status, row.IsPublic, row.StreamKey, row.StartedAt, row.EndedAt, row.CreatedAt, row.UpdatedAt), nil
 }
 
+// RotateStreamKey remplace le secret d'ingest par newKey. errNoRowAffected si le
+// flux est absent/archivé/pas au demandeur, ou s'il est en direct (cf. la query).
+//
+// Une collision sur uq_streams_stream_key n'est pas traitée à part, comme dans
+// Create : deux clés de 32 octets tirées d'un CSPRNG ne se rencontrent pas, et
+// si cela arrivait ce serait un incident interne, pas une erreur utilisateur.
+func (r *pgRepository) RotateStreamKey(ctx context.Context, id, userID, newKey string) (Stream, error) {
+	uid, ok := parseUUID(id)
+	if !ok {
+		return Stream{}, errNoRowAffected
+	}
+	row, err := r.q.RotateStreamKey(ctx, streamingdb.RotateStreamKeyParams{
+		StreamKey: newKey,
+		ID:        uid,
+		UserID:    uuidParam(userID),
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Stream{}, errNoRowAffected
+		}
+		return Stream{}, fmt.Errorf("repo: rotate stream key: %w", err)
+	}
+	return fullStream(row.ID, row.UserID, row.Title, row.Description, row.Category,
+		row.Status, row.IsPublic, row.StreamKey, row.StartedAt, row.EndedAt, row.CreatedAt, row.UpdatedAt), nil
+}
+
 // EndOrphanLiveStreams termine les flux restés 'live' en base sans session active
 // (réconciliation au démarrage après un redémarrage du process).
 func (r *pgRepository) EndOrphanLiveStreams(ctx context.Context) (int64, error) {

--- a/backend/internal/streaming/service.go
+++ b/backend/internal/streaming/service.go
@@ -7,6 +7,8 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/rs/zerolog"
+
 	"github.com/LignacAntony/streampulse/internal/shared/apperror"
 )
 
@@ -173,7 +175,20 @@ type Repository interface {
 	ListByOwner(ctx context.Context, userID string) ([]Stream, error)
 	StopLiveStreamsByUser(ctx context.Context, userID string) ([]string, error)
 	ForceStopLiveStream(ctx context.Context, id string) (string, error)
+	RotateStreamKey(ctx context.Context, id, userID, newKey string) (Stream, error)
 }
+
+// AuditRecorder journalise une action sensible dans le journal d'audit.
+// Interface étroite (ISP) : le domaine streaming ne connaît ni la table ni le
+// package qui sait y écrire — main.go lui injecte l'implémentation du domaine
+// admin, seul propriétaire d'audit_logs. Jamais nil : noopAudit par défaut.
+type AuditRecorder interface {
+	InsertAuditLog(ctx context.Context, actorID, action, targetType, targetID string) error
+}
+
+type noopAudit struct{}
+
+func (noopAudit) InsertAuditLog(context.Context, string, string, string, string) error { return nil }
 
 // KeyGenerator génère le secret de stream source (implémenté par keyGenerator).
 type KeyGenerator interface {
@@ -193,10 +208,22 @@ type Service struct {
 	repo     Repository
 	keys     KeyGenerator
 	sessions Sessions
+	audit    AuditRecorder // jamais nil : noopAudit par défaut
 }
 
 func NewService(repo Repository, keys KeyGenerator, sessions Sessions) *Service {
-	return &Service{repo: repo, keys: keys, sessions: sessions}
+	return &Service{repo: repo, keys: keys, sessions: sessions, audit: noopAudit{}}
+}
+
+// SetAuditRecorder injecte le journal d'audit (STR-228). Setter plutôt que
+// paramètre de constructeur, comme SetMetrics côté sessions : le domaine
+// fonctionne sans, et l'implémentation vit dans un autre domaine construit plus
+// tard dans main.go. Appelé une fois au démarrage, avant les requêtes HTTP.
+func (s *Service) SetAuditRecorder(rec AuditRecorder) {
+	if rec == nil {
+		rec = noopAudit{}
+	}
+	s.audit = rec
 }
 
 // CreateStream valide l'entrée, génère le stream_key et persiste le flux avec
@@ -335,6 +362,37 @@ func (s *Service) StopStream(ctx context.Context, id, requesterID string) (Strea
 		return Stream{}, err
 	}
 	s.sessions.Stop(stream.ID)
+	return stream, nil
+}
+
+// RotateStreamKey remplace le secret d'ingest d'un flux (propriétaire
+// uniquement) et invalide l'ancien. 404 si absent/pas propriétaire ; 409 si le
+// flux est en direct — une rotation couperait l'ingest en cours et laisserait
+// l'index de session sur l'ancienne clé (cf. la query).
+//
+// L'audit est best-effort, comme côté admin : la rotation est irréversible une
+// fois faite, échouer la requête sur un journal indisponible ne rendrait pas
+// l'ancienne clé et laisserait l'appelant croire que rien n'a bougé.
+func (s *Service) RotateStreamKey(ctx context.Context, id, requesterID string) (Stream, error) {
+	key, err := s.keys.NewStreamKey()
+	if err != nil {
+		return Stream{}, apperror.Internal("generate stream key", err)
+	}
+
+	stream, err := s.repo.RotateStreamKey(ctx, id, requesterID, key)
+	if err != nil {
+		if errors.Is(err, errNoRowAffected) {
+			return Stream{}, s.classifyTransitionFailure(ctx, id, requesterID, "stream is live")
+		}
+		return Stream{}, err
+	}
+
+	// Ni la clé ni l'URL d'ingest ne doivent atteindre le journal : seul l'id
+	// public du flux est tracé (cf. httpjson.LoggablePath, ADR 018).
+	if err := s.audit.InsertAuditLog(ctx, requesterID, "stream.key_rotated", "stream", stream.ID); err != nil {
+		zerolog.Ctx(ctx).Error().Err(err).Str("stream_id", stream.ID).
+			Msg("streaming: rotation de clé non journalisée")
+	}
 	return stream, nil
 }
 

--- a/backend/internal/streaming/service_test.go
+++ b/backend/internal/streaming/service_test.go
@@ -174,6 +174,12 @@ type fakeRepo struct {
 	gotForceStopID string
 	forceStopRet   string
 	forceStopErr   error
+
+	gotRotateID     string
+	gotRotateUserID string
+	gotRotateKey    string
+	rotateRet       Stream
+	rotateErr       error
 }
 
 func (f *fakeRepo) Create(_ context.Context, p CreateParams) (Stream, error) {
@@ -252,6 +258,13 @@ func (f *fakeRepo) StopLiveStreamsByUser(_ context.Context, userID string) ([]st
 func (f *fakeRepo) ForceStopLiveStream(_ context.Context, id string) (string, error) {
 	f.gotForceStopID = id
 	return f.forceStopRet, f.forceStopErr
+}
+
+func (f *fakeRepo) RotateStreamKey(_ context.Context, id, userID, newKey string) (Stream, error) {
+	f.gotRotateID = id
+	f.gotRotateUserID = userID
+	f.gotRotateKey = newKey
+	return f.rotateRet, f.rotateErr
 }
 
 type fakeKeys struct {
@@ -572,6 +585,125 @@ func TestService_StartStream_AlreadyLive_UniqueViolation(t *testing.T) {
 	}
 	if len(sessions.started) != 0 {
 		t.Error("aucune session ne doit démarrer sur échec")
+	}
+}
+
+// fakeAudit enregistre les appels au journal, et peut les faire échouer pour
+// vérifier que la rotation reste acquise malgré un audit indisponible.
+type fakeAudit struct {
+	calls [][5]string
+	err   error
+}
+
+func (f *fakeAudit) InsertAuditLog(_ context.Context, actorID, action, targetType, targetID string) error {
+	f.calls = append(f.calls, [5]string{actorID, action, targetType, targetID, ""})
+	return f.err
+}
+
+func TestService_RotateStreamKey_Success(t *testing.T) {
+	repo := &fakeRepo{rotateRet: Stream{ID: "s1", UserID: "u1", StreamKey: "nouvelle-cle"}}
+	audit := &fakeAudit{}
+	svc := NewService(repo, fakeKeys{key: "nouvelle-cle"}, &fakeSessions{})
+	svc.SetAuditRecorder(audit)
+
+	stream, err := svc.RotateStreamKey(context.Background(), "s1", "u1")
+	if err != nil {
+		t.Fatalf("erreur inattendue: %v", err)
+	}
+	if stream.StreamKey != "nouvelle-cle" {
+		t.Errorf("StreamKey = %q, want nouvelle-cle", stream.StreamKey)
+	}
+	if repo.gotRotateKey != "nouvelle-cle" || repo.gotRotateID != "s1" || repo.gotRotateUserID != "u1" {
+		t.Errorf("repo appelé avec (%q, %q, %q)", repo.gotRotateID, repo.gotRotateUserID, repo.gotRotateKey)
+	}
+	if len(audit.calls) != 1 {
+		t.Fatalf("appels d'audit = %d, want 1", len(audit.calls))
+	}
+	// L'acteur est le propriétaire, la cible l'id public — jamais la clé.
+	if got := audit.calls[0]; got[0] != "u1" || got[1] != "stream.key_rotated" ||
+		got[2] != "stream" || got[3] != "s1" {
+		t.Errorf("entrée d'audit = %v", got)
+	}
+}
+
+// Une rotation est irréversible : l'ancienne clé n'existe plus. Échouer la
+// requête parce que le journal est indisponible laisserait l'appelant croire
+// que rien n'a bougé, alors que son encodeur est déjà cassé.
+func TestService_RotateStreamKey_AuditFailureDoesNotFailRotation(t *testing.T) {
+	repo := &fakeRepo{rotateRet: Stream{ID: "s1", StreamKey: "nouvelle-cle"}}
+	audit := &fakeAudit{err: errors.New("audit_logs indisponible")}
+	svc := NewService(repo, fakeKeys{key: "nouvelle-cle"}, &fakeSessions{})
+	svc.SetAuditRecorder(audit)
+
+	stream, err := svc.RotateStreamKey(context.Background(), "s1", "u1")
+	if err != nil {
+		t.Fatalf("un audit en échec ne doit pas faire échouer la rotation: %v", err)
+	}
+	if stream.StreamKey != "nouvelle-cle" {
+		t.Errorf("StreamKey = %q, want nouvelle-cle", stream.StreamKey)
+	}
+}
+
+// Sans SetAuditRecorder (tests, binaire minimal), le service doit fonctionner :
+// noopAudit garantit qu'aucun nil ne circule.
+func TestService_RotateStreamKey_WithoutAuditRecorder(t *testing.T) {
+	repo := &fakeRepo{rotateRet: Stream{ID: "s1", StreamKey: "k"}}
+	svc := NewService(repo, fakeKeys{key: "k"}, &fakeSessions{})
+
+	if _, err := svc.RotateStreamKey(context.Background(), "s1", "u1"); err != nil {
+		t.Fatalf("erreur inattendue: %v", err)
+	}
+	svc.SetAuditRecorder(nil) // ne doit pas réintroduire un nil
+	if _, err := svc.RotateStreamKey(context.Background(), "s1", "u1"); err != nil {
+		t.Fatalf("erreur inattendue après SetAuditRecorder(nil): %v", err)
+	}
+}
+
+func TestService_RotateStreamKey_Live_Conflict(t *testing.T) {
+	// La query exclut 'live' : 0 ligne, propriétaire confirmé -> 409.
+	repo := &fakeRepo{rotateErr: errNoRowAffected, getRet: Stream{UserID: "u1", Status: StatusLive}}
+	audit := &fakeAudit{}
+	svc := NewService(repo, fakeKeys{key: "k"}, &fakeSessions{})
+	svc.SetAuditRecorder(audit)
+
+	_, err := svc.RotateStreamKey(context.Background(), "s1", "u1")
+	if !apperror.IsCode(err, apperror.CodeConflict) {
+		t.Fatalf("code = %v, want conflict (flux en direct)", err)
+	}
+	if len(audit.calls) != 0 {
+		t.Error("aucune entrée d'audit ne doit être écrite si rien n'a tourné")
+	}
+}
+
+func TestService_RotateStreamKey_NotOwner_NotFound(t *testing.T) {
+	// 0 ligne, et le flux appartient à un tiers : 404 plutôt que 409, pour ne pas
+	// divulguer l'existence du flux (même règle que Get).
+	repo := &fakeRepo{rotateErr: errNoRowAffected, getRet: Stream{UserID: "autre", Status: StatusIdle}}
+	svc := NewService(repo, fakeKeys{key: "k"}, &fakeSessions{})
+
+	_, err := svc.RotateStreamKey(context.Background(), "s1", "u1")
+	if !apperror.IsCode(err, apperror.CodeNotFound) {
+		t.Fatalf("code = %v, want not found", err)
+	}
+}
+
+// La clé est tirée avant l'UPDATE : un générateur en panne doit s'arrêter là,
+// sans écrire en base ni journaliser quoi que ce soit.
+func TestService_RotateStreamKey_KeyGeneratorFailure(t *testing.T) {
+	repo := &fakeRepo{}
+	audit := &fakeAudit{}
+	svc := NewService(repo, fakeKeys{err: errors.New("entropie indisponible")}, &fakeSessions{})
+	svc.SetAuditRecorder(audit)
+
+	_, err := svc.RotateStreamKey(context.Background(), "s1", "u1")
+	if !apperror.IsCode(err, apperror.CodeInternal) {
+		t.Fatalf("code = %v, want internal", err)
+	}
+	if repo.gotRotateID != "" {
+		t.Error("la base ne doit pas être touchée si la clé n'a pas pu être générée")
+	}
+	if len(audit.calls) != 0 {
+		t.Error("aucune entrée d'audit sans rotation")
 	}
 }
 

--- a/docs/adr/024-tableau-de-bord-diffuseur-lancer-et-arreter-un-flux.md
+++ b/docs/adr/024-tableau-de-bord-diffuseur-lancer-et-arreter-un-flux.md
@@ -95,16 +95,18 @@ plutôt qu'un échec sec.
 
 ### 6. La clé de diffusion n'est jamais rendue par défaut
 
-`stream_key` est un secret de type bearer : qui la détient diffuse à la place du propriétaire, et
-**aucun endpoint de rotation n'existe** — en cas de fuite, le seul recours est de supprimer le
-flux et d'en recréer un. L'URL d'ingest s'affiche donc masquée (points + 4 derniers caractères),
-la révélation se referme seule au bout de 15 s, et le bouton de copie place l'URL entière dans le
-presse-papier sans jamais l'afficher ni l'écho dans le toast.
+`stream_key` est un secret de type bearer : qui la détient diffuse à la place du propriétaire.
+L'URL d'ingest s'affiche donc masquée (points + 4 derniers caractères), la révélation se referme
+seule au bout de 15 s, et le bouton de copie place l'URL entière dans le presse-papier sans jamais
+l'afficher ni l'écho dans le toast.
 
 Limite assumée : sur Android le presse-papier est lisible par d'autres applications, et
 `Clipboard.setData` de Flutter n'expose pas le drapeau « contenu sensible » d'Android 13+.
 
-Un ticket dédié doit couvrir la rotation de `stream_key`.
+**Mise à jour (STR-228, [ADR 028](028-rotation-de-la-cle-de-diffusion.md))** : la clé se régénère
+désormais depuis le tableau de bord (`POST /api/streams/{id}/key/rotate`). En cas de fuite, le
+recours n'est plus de supprimer le flux et d'en recréer un — ce qui lui faisait perdre son
+identifiant, ses favoris et son historique.
 
 ### 7. Onglet visible pour tous, état vide orienté
 

--- a/docs/adr/028-rotation-de-la-cle-de-diffusion.md
+++ b/docs/adr/028-rotation-de-la-cle-de-diffusion.md
@@ -1,0 +1,103 @@
+# ADR 028 — Rotation de la clé de diffusion
+
+**Date** : 2026-08-05
+**Statut** : Accepté
+**Ticket** : [STR-228](https://linear.app/streampulse/issue/STR-228)
+
+---
+
+## Contexte
+
+`stream_key` authentifie l'ingest à elle seule : `POST /api/streams/ingest/{stream_key}` ne
+demande aucun JWT (cf. [ADR 015](015-moteur-hls-segmentation-ffmpeg.md)). Quiconque la détient
+diffuse à la place du propriétaire.
+
+Elle était générée une fois à la création du flux et ne pouvait plus changer. En cas de fuite —
+capture d'écran, presse-papier Android lisible par d'autres applications, partage d'écran pendant
+une démo — le seul recours était de supprimer le flux et d'en recréer un, ce qui lui faisait
+perdre son identifiant, ses favoris et son historique. La limite était documentée dans
+l'[ADR 024](024-tableau-de-bord-diffuseur-lancer-et-arreter-un-flux.md) § 6.
+
+## Décision
+
+### 1. `POST /api/streams/{id}/key/rotate`, et non `/{id}/rotate-key`
+
+Le chemin porte un segment de plus que le nom qui vient naturellement, pour une raison
+structurelle : `POST /api/streams/{id}/rotate-key` et `POST /api/streams/ingest/{stream_key}`
+comptent quatre segments chacun, et `/api/streams/ingest/rotate-key` matche les deux sans qu'aucun
+ne soit plus spécifique. Le `ServeMux` de Go refuse alors d'enregistrer les patterns — le serveur
+panique au démarrage.
+
+C'est le même écueil qui avait imposé `PUT` aux favoris (ADR 013). Départager par la longueur du
+chemin plutôt que par la méthode HTTP présente deux avantages : `POST` reste le verbe correct
+(chaque appel frappe une clé neuve, rien d'idempotent), et le contournement ne se recasse pas si
+une autre méthode est un jour montée sur `ingest/`.
+
+### 2. Refus pendant le direct, garanti en SQL
+
+Une rotation est rejetée en 409 si le flux est en direct. Ce n'est pas qu'une commodité : au
+démarrage d'un direct, `LiveSessions` indexe la session par la clé (`byKey`). Changer la clé en
+base sans toucher au registre laisserait l'ancienne router l'ingest et la nouvelle renvoyer 404.
+
+La garde vit dans la clause `WHERE` de la requête (`status <> 'live'`) et pas seulement dans le
+service : c'est la base qui arbitre, y compris face à un `start` concurrent. Zéro ligne affectée
+est ensuite traduit en 404 ou 409 par `classifyTransitionFailure`, comme les autres transitions —
+un flux appartenant à un tiers renvoie 404 pour ne pas divulguer son existence.
+
+### 3. La réponse porte la nouvelle clé
+
+Le corps est un `StreamResponse` complet avec `stream_key` et `stream_source_url`, comme
+`start`/`stop`. La clé neuve n'existe nulle part ailleurs : ne pas la rendre obligerait le client
+à enchaîner un `GET` juste après l'avoir demandée.
+
+### 4. L'audit traverse une interface, pas un import entre domaines
+
+`audit_logs` appartient au domaine `admin`, seul à posséder les requêtes sqlc de la table. Le
+domaine `streaming` déclare une interface étroite `AuditRecorder` (principe I) et `main.go` — le
+seul point de composition du projet — lui injecte le repository admin. Aucun SQL dupliqué, aucun
+import croisé entre domaines, et le code admin déjà livré n'est pas touché.
+
+L'écriture est **best-effort**, comme côté modération : une rotation est irréversible une fois
+faite, l'ancienne clé n'existe plus. Échouer la requête parce que le journal est indisponible ne
+la rendrait pas et laisserait l'appelant croire que rien n'a bougé, alors que son encodeur est
+déjà cassé. L'échec part dans les logs (`zerolog`), la requête réussit.
+
+Seul l'identifiant public du flux est journalisé — jamais la clé ni l'URL d'ingest (même règle que
+`httpjson.LoggablePath`, [ADR 018](018-supervision-admin-des-flux-et-journal-daudit.md)).
+
+### 5. Côté mobile : entrée de menu, confirmation, et une règle visible avant le tap
+
+L'action vit dans le menu contextuel de la tuile, à côté de « Supprimer ». La confirmation dit
+l'essentiel : l'ancienne clé cesse immédiatement de fonctionner, et un encodeur externe déjà
+configuré doit recevoir la nouvelle URL avant le prochain direct.
+
+L'entrée est **visible mais inerte** sur un flux en direct, avec la raison en clair
+(« arrêtez la diffusion ») : la règle se découvre dans le menu plutôt que par un 409 après coup —
+même parti pris que le bouton « Démarrer » neutralisé quand un autre flux est déjà live. Elle
+disparaît en revanche sur un flux terminé, dont la clé n'est de toute façon plus utilisable et
+dont l'URL d'ingest n'est même pas affichée.
+
+`rotateKey` ne déclenche pas de resynchronisation SSE ni de relevé d'audience, contrairement aux
+autres mutations : la rotation ne change pas le statut du flux, seule la tuile est réécrite.
+
+## Alternatives écartées
+
+- **Renommer la route en `PUT /{id}/rotate-key`** pour esquiver le conflit par la méthode, comme
+  les favoris : `PUT` annonce une idempotence que l'endpoint n'a pas, et le conflit reviendrait à
+  la première méthode ajoutée sur `ingest/`.
+- **Autoriser la rotation en direct** en réindexant `LiveSessions` à la volée : il faudrait
+  basculer l'index sous verrou pendant qu'un push est attaché, et l'ingest en cours casserait
+  quand même — le diffuseur devrait relancer son encodeur, donc arrêter son direct.
+- **Extraire un package `internal/audit` partagé** : plus propre à terme, mais touche du code
+  admin déjà livré et testé pour un besoin que l'interface étroite couvre déjà.
+- **Retenter la génération sur collision** de `uq_streams_stream_key` : deux clés de 32 octets
+  tirées d'un CSPRNG ne se rencontrent pas, et `CreateStream` ne traite pas ce cas non plus.
+
+## Conséquences
+
+- Une clé fuitée se remplace sans perdre le flux, ses favoris ni son historique.
+- Le diffuseur doit reconfigurer son encodeur externe après chaque rotation — d'où l'avertissement
+  explicite dans la confirmation.
+- Une rotation impose d'arrêter le direct en cours ; c'est le prix du refus documenté en § 2.
+- `audit_logs` n'enregistre plus seulement des actions d'administration : `stream.key_rotated`
+  porte comme acteur le propriétaire du flux.

--- a/mobile/lib/features/broadcast/data/datasources/broadcast_remote_data_source.dart
+++ b/mobile/lib/features/broadcast/data/datasources/broadcast_remote_data_source.dart
@@ -69,6 +69,18 @@ class BroadcastRemoteDataSource {
     }
   }
 
+  /// `POST /api/streams/{id}/key/rotate` — la réponse porte la clé neuve, qui
+  /// n'existe nulle part ailleurs. Le 409 (« flux en direct ») remonte tel quel,
+  /// même raison que `startStream`.
+  Future<StreamResponse> rotateStreamKey(String id) async {
+    try {
+      final response = await _api.rotateStreamKey(id: id);
+      return response.data ?? (throw const ServerException(_emptyBody));
+    } on DioException catch (e) {
+      throw mapDioException(e);
+    }
+  }
+
   /// `DELETE /api/streams/{id}` — 204 sans corps.
   Future<void> deleteStream(String id) async {
     try {

--- a/mobile/lib/features/broadcast/data/repositories/broadcast_repository_impl.dart
+++ b/mobile/lib/features/broadcast/data/repositories/broadcast_repository_impl.dart
@@ -47,6 +47,12 @@ class BroadcastRepositoryImpl implements BroadcastRepository {
   }
 
   @override
+  Future<BroadcastStream> rotateStreamKey(String id) async {
+    final dto = await _remote.rotateStreamKey(id);
+    return dto.toBroadcastEntity();
+  }
+
+  @override
   Future<void> deleteStream(String id) => _remote.deleteStream(id);
 
   @override

--- a/mobile/lib/features/broadcast/domain/repositories/broadcast_repository.dart
+++ b/mobile/lib/features/broadcast/domain/repositories/broadcast_repository.dart
@@ -31,6 +31,11 @@ abstract class BroadcastRepository {
   /// n'était pas en direct (arrêt concurrent par un admin, par exemple).
   Future<BroadcastStream> stopStream(String id);
 
+  /// Remet une clé d'ingest neuve et invalide l'ancienne (US-06-04). Lève une
+  /// `ConflictException` si le flux est en direct : la rotation couperait
+  /// l'ingest en cours. Le flux renvoyé porte la nouvelle `streamSourceUrl`.
+  Future<BroadcastStream> rotateStreamKey(String id);
+
   /// Archive le flux (suppression douce côté serveur : `archived_at`). Un flux
   /// en direct est terminé au passage par le backend — l'écran doit donc
   /// prévenir l'utilisateur avant d'appeler ceci sur un direct.

--- a/mobile/lib/features/broadcast/presentation/providers/broadcast_notifier.dart
+++ b/mobile/lib/features/broadcast/presentation/providers/broadcast_notifier.dart
@@ -287,6 +287,27 @@ class BroadcastNotifier extends ChangeNotifier {
     }
   }
 
+  /// Remet une clé d'ingest neuve et invalide l'ancienne (US-06-04). Même
+  /// contrat de retour que [start].
+  ///
+  /// Pas de `_syncSubscription()` ici, contrairement aux autres mutations : la
+  /// rotation ne change pas le statut du flux, donc ni le direct suivi en SSE
+  /// ni la remontée d'audience ne bougent. Seule la tuile est réécrite.
+  Future<bool> rotateKey(String id) async {
+    if (_mutatingId != null) return false;
+    _mutatingId = id;
+    _safeNotify();
+    try {
+      final updated = await _repository.rotateStreamKey(id);
+      _replace(updated);
+      _clearError();
+      return true;
+    } finally {
+      _mutatingId = null;
+      _safeNotify();
+    }
+  }
+
   /// Archive le flux et le retire de la liste. Même contrat de retour que
   /// [start]. Sur un flux en direct, le backend termine la diffusion au
   /// passage — l'écran doit l'avoir annoncé avant d'appeler ceci.

--- a/mobile/lib/features/broadcast/presentation/screens/dashboard_screen.dart
+++ b/mobile/lib/features/broadcast/presentation/screens/dashboard_screen.dart
@@ -267,6 +267,62 @@ class _DashboardBodyState extends State<_DashboardBody>
     }
   }
 
+  /// Régénère la clé d'ingest (US-06-04). L'ancienne cesse d'être acceptée
+  /// immédiatement : la confirmation le dit, et rappelle que tout encodeur
+  /// externe déjà configuré devra recevoir la nouvelle URL — sans quoi le
+  /// diffuseur découvrirait la coupure à son prochain direct.
+  Future<void> _onRotateKey(BroadcastStream stream) async {
+    final notifier = context.read<BroadcastNotifier>();
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Régénérer la clé de diffusion ?'),
+        content: const Text(
+          'L\'ancienne clé cessera immédiatement de fonctionner. Si vous '
+          'diffusez depuis un encodeur externe (OBS, ffmpeg, Mixxx), '
+          'reconfigurez-le avec la nouvelle URL avant votre prochain direct.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('Annuler'),
+          ),
+          FilledButton(
+            key: const Key('dashboard_confirm_rotate_key_button'),
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('Régénérer'),
+          ),
+        ],
+      ),
+    );
+    if (!mounted || confirmed != true) return;
+
+    try {
+      final rotated = await notifier.rotateKey(stream.id);
+      if (!mounted) return;
+      if (rotated) showAuthSuccessToast(context, 'Nouvelle clé générée');
+    } on ConflictException {
+      // Le flux est passé en direct entre l'ouverture du menu et la
+      // confirmation : recharger réaligne l'écran sur la vérité serveur.
+      if (!mounted) return;
+      showAuthErrorToast(
+        context,
+        'Arrêtez la diffusion avant de régénérer la clé',
+      );
+      await notifier.refresh();
+    } on NetworkException {
+      if (!mounted) return;
+      showAuthErrorToast(context, 'Pas de connexion réseau');
+    } on ServerException catch (e) {
+      if (!mounted) return;
+      showAuthErrorToast(context, e.message);
+    } catch (_) {
+      if (!mounted) return;
+      showAuthErrorToast(context, 'Échec de la régénération de la clé');
+    }
+  }
+
   /// Supprime un flux. Le backend fait une suppression douce (`archived_at`) et
   /// **termine la diffusion au passage** si le flux est en direct : la
   /// confirmation le dit explicitement plutôt que de laisser l'utilisateur
@@ -447,6 +503,7 @@ class _DashboardBodyState extends State<_DashboardBody>
           audioSupported: notifier.audioSupported,
           onStart: () => _onStart(stream),
           onStop: () => _onStop(stream),
+          onRotateKey: () => _onRotateKey(stream),
           onDelete: () => _onDelete(stream),
         );
       },
@@ -466,6 +523,7 @@ class _StreamCard extends StatelessWidget {
     required this.audioSupported,
     required this.onStart,
     required this.onStop,
+    required this.onRotateKey,
     required this.onDelete,
   });
 
@@ -485,6 +543,7 @@ class _StreamCard extends StatelessWidget {
   final bool audioSupported;
   final VoidCallback onStart;
   final VoidCallback onStop;
+  final VoidCallback onRotateKey;
   final VoidCallback onDelete;
 
   /// Vrai dès qu'une mutation touche cette carte ou une autre : dans les deux
@@ -514,9 +573,36 @@ class _StreamCard extends StatelessWidget {
                   enabled: !_busy,
                   tooltip: 'Actions',
                   onSelected: (value) {
+                    if (value == 'rotate-key') onRotateKey();
                     if (value == 'delete') onDelete();
                   },
                   itemBuilder: (context) => [
+                    // Rien à régénérer sur un flux terminé : sa clé n'est plus
+                    // utilisable (le backend n'autorise que idle -> live), et
+                    // l'URL d'ingest n'est même pas affichée. Sur un direct
+                    // l'entrée reste visible mais inerte : la règle se découvre
+                    // dans le menu plutôt que par un 409.
+                    if (!stream.isEnded)
+                      PopupMenuItem(
+                        key: Key('dashboard_rotate_key_item_${stream.id}'),
+                        value: 'rotate-key',
+                        enabled: !stream.isLive,
+                        child: Row(
+                          children: [
+                            const Icon(Icons.key_outlined),
+                            const SizedBox(width: 12),
+                            // Expanded : le libellé du cas « en direct » est
+                            // plus long que la largeur naturelle du menu.
+                            Expanded(
+                              child: Text(
+                                stream.isLive
+                                    ? 'Régénérer la clé\n(arrêtez la diffusion)'
+                                    : 'Régénérer la clé',
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
                     PopupMenuItem(
                       key: Key('dashboard_delete_item_${stream.id}'),
                       value: 'delete',

--- a/mobile/packages/streampulse_api/README.md
+++ b/mobile/packages/streampulse_api/README.md
@@ -102,6 +102,7 @@ Class | Method | HTTP request | Description
 [*StreamingApi*](doc/StreamingApi.md) | [**listMyStreams**](doc/StreamingApi.md#listmystreams) | **GET** /api/users/me/streams | List the authenticated user&#39;s own streams (broadcaster dashboard).
 [*StreamingApi*](doc/StreamingApi.md) | [**listStreams**](doc/StreamingApi.md#liststreams) | **GET** /api/streams | List public live streams (paginated).
 [*StreamingApi*](doc/StreamingApi.md) | [**removeFavorite**](doc/StreamingApi.md#removefavorite) | **DELETE** /api/streams/{id}/favorite | Remove a stream from the authenticated user&#39;s favorites.
+[*StreamingApi*](doc/StreamingApi.md) | [**rotateStreamKey**](doc/StreamingApi.md#rotatestreamkey) | **POST** /api/streams/{id}/key/rotate | Issue a new ingest key, invalidating the previous one (broadcaster owner only).
 [*StreamingApi*](doc/StreamingApi.md) | [**startStream**](doc/StreamingApi.md#startstream) | **PATCH** /api/streams/{id}/start | Start a stream — go live (broadcaster owner only).
 [*StreamingApi*](doc/StreamingApi.md) | [**stopStream**](doc/StreamingApi.md#stopstream) | **PATCH** /api/streams/{id}/stop | Stop a live stream — end it (broadcaster owner only).
 [*StreamingApi*](doc/StreamingApi.md) | [**streamEvents**](doc/StreamingApi.md#streamevents) | **GET** /api/streams/{id}/events | Subscribe to a live stream&#39;s events (SSE).

--- a/mobile/packages/streampulse_api/lib/src/api/streaming_api.dart
+++ b/mobile/packages/streampulse_api/lib/src/api/streaming_api.dart
@@ -727,6 +727,88 @@ class StreamingApi {
     return _response;
   }
 
+  /// Issue a new ingest key, invalidating the previous one (broadcaster owner only).
+  /// Recovery path for a leaked stream_key (STR-228). The key authenticates ingest on its own, so anyone holding it can broadcast in the owner&#39;s place; before this endpoint the only remedy was deleting the stream and losing its id, favourites and history.  The response carries the new secrets, which exist nowhere else. The broadcaster&#39;s encoder must be reconfigured with the new URL.  Rejected with 409 while the stream is live: the in-memory session is indexed by the key, so rotating mid-broadcast would cut the running ingest and leave the index on the old key. Logged to the audit trail on a best-effort basis, without ever recording the key itself.  The path is &#x60;/{id}/key/rotate&#x60; and not &#x60;/{id}/rotate-key&#x60; because the latter structurally conflicts with &#x60;/api/streams/ingest/{stream_key}&#x60; in Go&#39;s ServeMux — &#x60;/api/streams/ingest/rotate-key&#x60; would match both.
+  ///
+  /// Parameters:
+  /// * [id]
+  /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
+  /// * [headers] - Can be used to add additional headers to the request
+  /// * [extras] - Can be used to add flags to the request
+  /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
+  /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
+  /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
+  ///
+  /// Returns a [Future] containing a [Response] with a [StreamResponse] as data
+  /// Throws [DioException] if API call or serialization fails
+  Future<Response<StreamResponse>> rotateStreamKey({
+    required String id,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    final _path = r'/api/streams/{id}/key/rotate'.replaceAll(
+      '{'
+      r'id'
+      '}',
+      id.toString(),
+    );
+    final _options = Options(
+      method: r'POST',
+      headers: <String, dynamic>{...?headers},
+      extra: <String, dynamic>{
+        'secure': <Map<String, String>>[
+          {'type': 'http', 'scheme': 'bearer', 'name': 'bearerAuth'},
+        ],
+        ...?extra,
+      },
+      validateStatus: validateStatus,
+    );
+
+    final _response = await _dio.request<Object>(
+      _path,
+      options: _options,
+      cancelToken: cancelToken,
+      onSendProgress: onSendProgress,
+      onReceiveProgress: onReceiveProgress,
+    );
+
+    StreamResponse? _responseData;
+
+    try {
+      final rawData = _response.data;
+      _responseData = rawData == null
+          ? null
+          : deserialize<StreamResponse, StreamResponse>(
+              rawData,
+              'StreamResponse',
+              growable: true,
+            );
+    } catch (error, stackTrace) {
+      throw DioException(
+        requestOptions: _response.requestOptions,
+        response: _response,
+        type: DioExceptionType.unknown,
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+
+    return Response<StreamResponse>(
+      data: _responseData,
+      headers: _response.headers,
+      isRedirect: _response.isRedirect,
+      requestOptions: _response.requestOptions,
+      redirects: _response.redirects,
+      statusCode: _response.statusCode,
+      statusMessage: _response.statusMessage,
+      extra: _response.extra,
+    );
+  }
+
   /// Start a stream — go live (broadcaster owner only).
   ///
   ///

--- a/mobile/test/features/broadcast/data/broadcast_repository_impl_test.dart
+++ b/mobile/test/features/broadcast/data/broadcast_repository_impl_test.dart
@@ -210,6 +210,41 @@ void main() {
     });
   });
 
+  group('BroadcastRepositoryImpl.rotateStreamKey', () {
+    test('renvoie le flux porteur de la clé neuve', () async {
+      adapter.onPost(
+        '/api/streams/s-1/key/rotate',
+        (server) => server.reply(
+          200,
+          _streamJson(
+            's-1',
+            streamKey: 'cle-neuve',
+            sourceUrl: 'http://localhost:8080/api/streams/ingest/cle-neuve',
+          ),
+        ),
+      );
+
+      final rotated = await repository.rotateStreamKey('s-1');
+
+      expect(rotated.streamKey, 'cle-neuve');
+      expect(rotated.streamSourceUrl, contains('cle-neuve'));
+    });
+
+    test('409 sur un flux en direct -> ConflictException', () async {
+      adapter.onPost(
+        '/api/streams/s-2/key/rotate',
+        (server) => server.reply(409, {
+          'error': {'code': 'conflict', 'message': 'stream is live'},
+        }),
+      );
+
+      await expectLater(
+        repository.rotateStreamKey('s-2'),
+        throwsA(isA<ConflictException>()),
+      );
+    });
+  });
+
   group('streamCategoryToDto', () {
     test('traduit une catégorie de la liste blanche', () {
       expect(

--- a/mobile/test/features/broadcast/presentation/broadcast_notifier_test.dart
+++ b/mobile/test/features/broadcast/presentation/broadcast_notifier_test.dart
@@ -83,6 +83,24 @@ class _FakeBroadcastRepository implements BroadcastRepository {
   }
 
   @override
+  Future<BroadcastStream> rotateStreamKey(String id) async {
+    rotatedIds.add(id);
+    if (mutationError != null) throw mutationError!;
+    // La rotation ne touche pas au statut : seuls la clé et l'URL changent.
+    final current = streams.firstWhere((s) => s.id == id);
+    return BroadcastStream(
+      id: current.id,
+      title: current.title,
+      status: current.status,
+      isPublic: current.isPublic,
+      createdAt: current.createdAt,
+      startedAt: current.startedAt,
+      streamKey: 'cle-neuve-$id',
+      streamSourceUrl: 'http://localhost:8080/api/streams/ingest/cle-neuve-$id',
+    );
+  }
+
+  @override
   Future<void> deleteStream(String id) async {
     deletedIds.add(id);
     if (mutationError != null) throw mutationError!;
@@ -96,6 +114,7 @@ class _FakeBroadcastRepository implements BroadcastRepository {
   }
 
   final List<String> deletedIds = [];
+  final List<String> rotatedIds = [];
   int statsCalls = 0;
   int listeners = 3;
   Object? statsError;
@@ -132,6 +151,10 @@ class _DeferredRepository implements BroadcastRepository {
   Future<void> deleteStream(String id) => throw UnimplementedError();
 
   @override
+  Future<BroadcastStream> rotateStreamKey(String id) =>
+      throw UnimplementedError();
+
+  @override
   Future<BroadcastStats> streamStats(String id) => throw UnimplementedError();
 }
 
@@ -163,6 +186,10 @@ class _DeferredMutationRepository implements BroadcastRepository {
 
   @override
   Future<void> deleteStream(String id) => throw UnimplementedError();
+
+  @override
+  Future<BroadcastStream> rotateStreamKey(String id) =>
+      throw UnimplementedError();
 
   @override
   Future<BroadcastStats> streamStats(String id) => throw UnimplementedError();
@@ -497,6 +524,47 @@ void main() {
       final notifier = BroadcastNotifier(repository);
 
       expect(notifier.isMutating, isFalse);
+    });
+
+    test('rotateKey remplace le flux par sa version à clé neuve', () async {
+      final repository = _FakeBroadcastRepository(streams: [_stream('a')]);
+      final notifier = BroadcastNotifier(repository);
+      await notifier.load();
+
+      final rotated = await notifier.rotateKey('a');
+
+      expect(rotated, isTrue);
+      expect(repository.rotatedIds, ['a']);
+      expect(notifier.streams.single.streamKey, 'cle-neuve-a');
+      expect(notifier.streams.single.streamSourceUrl, contains('cle-neuve-a'));
+      // Le statut ne bouge pas : c'est ce qui distingue la rotation des autres
+      // mutations, et pourquoi elle ne resynchronise ni SSE ni audience.
+      expect(notifier.streams.single.isIdle, isTrue);
+      expect(notifier.mutatingId, isNull);
+    });
+
+    test('rotateKey est un no-op si une autre mutation est en vol', () async {
+      final repository = _DeferredMutationRepository();
+      final notifier = BroadcastNotifier(repository);
+      unawaited(notifier.start('a'));
+
+      expect(await notifier.rotateKey('a'), isFalse);
+
+      repository.pending.first.complete(_stream('a', status: 'live'));
+      notifier.dispose();
+    });
+
+    test('rotateKey relaie le 409 d\'un flux passé en direct', () async {
+      final repository = _FakeBroadcastRepository(streams: [_stream('a')])
+        ..mutationError = const ConflictException('stream is live');
+      final notifier = BroadcastNotifier(repository);
+      await notifier.load();
+
+      await expectLater(
+        notifier.rotateKey('a'),
+        throwsA(isA<ConflictException>()),
+      );
+      expect(notifier.mutatingId, isNull);
     });
 
     test('delete retire le flux de la liste', () async {

--- a/mobile/test/features/broadcast/presentation/broadcast_session_controller_test.dart
+++ b/mobile/test/features/broadcast/presentation/broadcast_session_controller_test.dart
@@ -53,6 +53,10 @@ class _FakeRepository implements BroadcastRepository {
   }) async => _stream('new');
 
   @override
+  Future<BroadcastStream> rotateStreamKey(String id) =>
+      throw UnimplementedError();
+
+  @override
   Future<void> deleteStream(String id) async {}
 
   @override

--- a/mobile/test/features/broadcast/presentation/screens/dashboard_screen_test.dart
+++ b/mobile/test/features/broadcast/presentation/screens/dashboard_screen_test.dart
@@ -78,6 +78,16 @@ class _FakeBroadcastRepository implements BroadcastRepository {
   }
 
   @override
+  Future<BroadcastStream> rotateStreamKey(String id) async {
+    rotatedIds.add(id);
+    if (rotateError != null) throw rotateError!;
+    return _stream(
+      id,
+      sourceUrl: 'http://localhost:8080/api/streams/ingest/cle-neuve-$id',
+    );
+  }
+
+  @override
   Future<void> deleteStream(String id) async {
     deletedIds.add(id);
   }
@@ -88,6 +98,10 @@ class _FakeBroadcastRepository implements BroadcastRepository {
 
   final List<String> deletedIds = [];
   final List<String> stoppedIds = [];
+  final List<String> rotatedIds = [];
+
+  /// Si non nul, `rotateStreamKey` échoue avec cette exception.
+  Object? rotateError;
   int listeners = 4;
   int peak = 9;
 }
@@ -549,6 +563,94 @@ void main() {
       // exposition inutile d'un secret.
       expect(find.byKey(const Key('dashboard_ingest_url_a')), findsNothing);
       expect(find.byKey(const Key('dashboard_ingest_url_b')), findsOneWidget);
+    });
+
+    testWidgets(
+      'régénérer la clé avertit puis remplace l\'URL d\'ingest',
+      (tester) async {
+        final repository = _FakeBroadcastRepository(streams: [_stream('a')]);
+        await tester.pumpWidget(_harness(repository));
+        await _settle(tester);
+
+        await tester.tap(find.byKey(const Key('dashboard_stream_menu_a')));
+        await tester.pumpAndSettle();
+        await tester.tap(find.byKey(const Key('dashboard_rotate_key_item_a')));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Régénérer la clé de diffusion ?'), findsOneWidget);
+        // L'avertissement sur l'encodeur externe est le cœur de la
+        // confirmation : sans lui, le diffuseur découvre la coupure en direct.
+        expect(find.textContaining('reconfigurez-le'), findsOneWidget);
+
+        await tester.tap(
+          find.byKey(const Key('dashboard_confirm_rotate_key_button')),
+        );
+        await _settle(tester);
+
+        expect(repository.rotatedIds, ['a']);
+        // La tuile porte bien la clé neuve : révélée, l'URL le montre.
+        await tester.tap(find.byKey(const Key('dashboard_reveal_key_a')));
+        await _settle(tester);
+        expect(find.textContaining('cle-neuve-a'), findsOneWidget);
+
+        toastification.dismissAll(delayForAnimation: false);
+        await tester.pump(const Duration(milliseconds: 700));
+      },
+    );
+
+    testWidgets('annuler la confirmation ne régénère rien', (tester) async {
+      final repository = _FakeBroadcastRepository(streams: [_stream('a')]);
+      await tester.pumpWidget(_harness(repository));
+      await _settle(tester);
+
+      await tester.tap(find.byKey(const Key('dashboard_stream_menu_a')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('dashboard_rotate_key_item_a')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Annuler'));
+      await _settle(tester);
+
+      expect(repository.rotatedIds, isEmpty);
+    });
+
+    // Le backend renvoie 409 sur un direct : plutôt que de laisser
+    // l'utilisateur le découvrir ainsi, l'entrée est visible mais inerte.
+    testWidgets('l\'entrée est neutralisée sur un flux en direct', (
+      tester,
+    ) async {
+      final repository = _FakeBroadcastRepository(
+        streams: [_stream('a', status: 'live', startedAt: DateTime.now())],
+      );
+      await tester.pumpWidget(_harness(repository));
+      await _settle(tester);
+
+      await tester.tap(find.byKey(const Key('dashboard_stream_menu_a')));
+      await tester.pumpAndSettle();
+
+      final item = tester.widget<PopupMenuItem<String>>(
+        find.byKey(const Key('dashboard_rotate_key_item_a')),
+      );
+      expect(item.enabled, isFalse);
+      expect(find.textContaining('arrêtez la diffusion'), findsOneWidget);
+    });
+
+    // Sur un flux terminé la clé n'est plus utilisable et l'URL n'est même pas
+    // affichée : proposer la rotation n'aurait aucun sens.
+    testWidgets('l\'entrée est absente sur un flux terminé', (tester) async {
+      final repository = _FakeBroadcastRepository(
+        streams: [_stream('a', status: 'ended')],
+      );
+      await tester.pumpWidget(_harness(repository));
+      await _settle(tester);
+
+      await tester.tap(find.byKey(const Key('dashboard_stream_menu_a')));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const Key('dashboard_rotate_key_item_a')),
+        findsNothing,
+      );
+      expect(find.byKey(const Key('dashboard_delete_item_a')), findsOneWidget);
     });
 
     testWidgets('supprimer un flux le retire après confirmation', (


### PR DESCRIPTION
## Contexte

`stream_key` authentifie l'ingest à elle seule — `POST /api/streams/ingest/{stream_key}` ne demande aucun JWT. Quiconque la détient diffuse à la place du propriétaire, et elle ne pouvait pas changer : en cas de fuite, le seul recours était de supprimer le flux et d'en recréer un, lui faisant perdre son identifiant, ses favoris et son historique. La limite était documentée dans l'ADR 024 § 6.

Refs: STR-228 — dernier ticket du milestone **Tableau de Bord Diffuseur**.

## Changements

- `POST /api/streams/{id}/key/rotate` — propriétaire diffuseur, 409 si le flux est en direct
- invalidation immédiate de l'ancienne clé, réponse porteuse de la nouvelle
- entrée `audit_logs` best-effort, sans jamais journaliser la clé
- `openapi.yaml` + client Dart régénéré
- action « Régénérer la clé » dans le tableau de bord, avec confirmation
- ADR 028, et ADR 024 § 6 mis à jour
- au passage : dernier `log.Printf` du backend passé en `zerolog` (STR-170)

## Deux écarts assumés par rapport au ticket

**Le chemin est `key/rotate` et non `rotate-key`.** Les deux formes ont quatre segments, et `/api/streams/ingest/rotate-key` matche à la fois `POST /api/streams/{id}/rotate-key` et `POST /api/streams/ingest/{stream_key}` sans qu'aucun ne soit plus spécifique : le `ServeMux` refuse d'enregistrer les patterns et **le serveur panique au démarrage**. Vérifié empiriquement — Go répond `both match some paths, like "/api/streams/ingest/rotate-key"`.

C'est le même écueil qui avait imposé `PUT` aux favoris. Départager par la longueur du chemin plutôt que par la méthode garde `POST`, correct ici puisque chaque appel frappe une clé neuve, et ne se recasse pas si une autre méthode est un jour montée sur `ingest/`.

**Le 409-si-live est garanti en SQL**, pas seulement dans le service. `LiveSessions` indexe la session par la clé : une rotation en cours de diffusion laisserait l'ancienne router l'ingest et la nouvelle renvoyer 404. La clause `WHERE` fait arbitrer la base, y compris face à un `start` concurrent.

## Notes d'implémentation

`audit_logs` appartient au domaine admin. Plutôt qu'un import croisé ou un second `INSERT` sqlc, `streaming` déclare l'interface étroite `AuditRecorder` et `main.go` — seul point de composition — lui injecte le repository admin. L'écriture est best-effort comme côté modération : une rotation est irréversible, échouer la requête sur un journal indisponible ne rendrait pas l'ancienne clé et laisserait croire que rien n'a bougé.

Pas de migration : `stream_key` (000014) et `audit_logs` (000017) existent déjà. Pas de retry sur collision de `uq_streams_stream_key` non plus — `CreateStream` n'en fait pas, et deux clés de 32 octets tirées d'un CSPRNG ne se rencontrent pas.

## Comment tester

1. `cd backend && go test ./...`
2. `cd backend && golangci-lint run ./...`
3. `cd mobile && flutter analyze && flutter test`
4. `docker compose up -d` puis rotation depuis le tableau de bord

## Vérifications

`go vet` et `golangci-lint` à 0 issue. Backend **455 tests**, mobile **305 tests**, `flutter analyze` propre.

E2E sur la stack Docker avec un vrai compte diffuseur :

| Vérification | Résultat |
|---|---|
| Démarrage de l'API, aucun panic ServeMux | ✅ |
| Rotation : clé et `stream_source_url` neuves, statut inchangé | ✅ `idle` |
| Ancienne clé sur `ingest/` | 404 |
| Nouvelle clé sur `ingest/` | 204 |
| Rotation pendant le direct | 409 |
| Diffuseur non propriétaire / flux inexistant | 404 / 404 — indiscernables |
| Ligne `audit_logs` | `stream.key_rotated`, acteur = propriétaire |
| Clé dans les logs applicatifs | 0 occurrence |

## QA appareil

Faite sur **Galaxy S20 Ultra (Android 13)**, app compilée et installée depuis la branche :

| Cas | Constaté |
|---|---|
| Flux terminé | entrée absente, seul « Supprimer » |
| Flux prêt | entrée active, mise en page propre |
| Confirmation | avertissement encodeur complet, pas de troncature |
| Après rotation | URL `…Qo1I` → `…diQk`, statut toujours PRÊT |
| Flux en direct | entrée grisée sur deux lignes, sans débordement |
| Tap sur l'entrée grisée | inerte, aucun dialogue |

Le direct démarré avec la clé régénérée affiche « Microphone diffusé » : la nouvelle clé route bien l'ingest audio réel — ce qui valide au passage la QA microphone sur appareil physique restée en suspens sur #278.

## Checklist

- [x] Les commits suivent Conventional Commits
- [x] Le titre de la PR suit Conventional Commits
- [x] La branche est à jour avec develop
- [x] Les tests passent localement
- [x] Aucun secret / .env committé
- [x] La doc est mise à jour si nécessaire