### PR TITLE
feat(api): transcodage à la volée des formats d'ingest non-AAC (STR-204)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,11 +240,12 @@ Domaine `internal/streaming/` (handler/service/repository). Détails dans [ADR 0
 | GET | `/api/users/me/streams` | `Handler.ListMine` | Oui (JWT) — tableau de bord diffuseur : **mes** flux (tous statuts, non archivés), **avec** `stream_key`/`stream_source_url` (le filtre porte sur le porteur du JWT) ; `[]` si aucun flux, jamais 403 (STR-153, ADR 024) |
 | GET | `/api/streams/{id}/stats` | `Handler.Stats` | Oui (JWT) — audience du flux : auditeurs **estimés**, pic, durée. Propriétaire uniquement → 404 sinon ; flux non live → 200 avec compteurs à zéro (STR-154, ADR 025) |
 | POST | `/api/streams/{id}/key/rotate` | `Handler.RotateKey` | Oui — rôle `broadcaster`, owner ; remet une `stream_key` neuve et invalide l'ancienne, 409 si le flux est **live** (l'index `byKey` de `LiveSessions` pointerait sur l'ancienne clé). Chemin en `key/rotate` et **non** `rotate-key` : ce dernier entre en conflit ServeMux avec `ingest/{stream_key}` (STR-228, ADR 028) |
-| POST | `/api/streams/ingest/{stream_key}` | `Handler.Ingest` | **Non (JWT)** — auth par `stream_key` dans le path ; push audio AAC segmenté en HLS (STR-70/71) |
+| POST | `/api/streams/ingest/{stream_key}` | `Handler.Ingest` | **Non (JWT)** — auth par `stream_key` dans le path ; push audio segmenté en HLS (STR-70/71). Tout `audio/*` est accepté : l'AAC (et un `Content-Type` absent) part direct dans le segmenteur, tout autre format (MP3, OGG, WAV, …) passe par un ffmpeg de transcodage intercalé devant (STR-204, ADR 030) ; 415 si le corps est indécodable |
 | GET | `/api/streams/{id}/playlist.m3u8` | `Handler.Playlist` | **Public** (`OptionalAuth`) — flux publics servis à un anonyme, privé → 404 ; owner authentifié voit ses flux privés — manifeste HLS, 409 si pas live/pas prêt (STR-108) ; 503 si capacité atteinte (`HLS_MAX_CONCURRENT`, STR-88) |
 | GET | `/api/streams/{id}/segments/{segment}` | `Handler.Segment` | **Public** (`OptionalAuth`) — idem playlist — segment `.ts` (nom validé anti-traversal) (STR-108) ; 503 si capacité atteinte (`HLS_MAX_CONCURRENT`, STR-88) |
 
 - Moteur HLS (STR-70) : le diffuseur pousse de l'AAC sur `ingest/{stream_key}` (auth par clé, 100 % mémoire) ; **ffmpeg** (`-c:a copy`) segmente en `.ts` de ~10 s + manifeste `.m3u8` glissant servi aux auditeurs. Un segmenteur par session live, tué + répertoire nettoyé à l'arrêt. Détails [ADR 015](docs/adr/015-moteur-hls-segmentation-ffmpeg.md).
+- Transcodage d'ingest (STR-204, [ADR 030](docs/adr/030-transcodage-a-la-volee-des-formats-dingest.md)) : un **second** ffmpeg (`-c:a aac -f adts`) est intercalé devant le segmenteur quand le `Content-Type` n'est pas de l'AAC, et vit le temps du push. Le segmenteur reste en `-c:a copy` — le chemin AAC ne paie ni process ni ré-encodage. Le démultiplexeur `-f` vient d'une table close (`resolveIngestFormat`), jamais d'une chaîne du diffuseur. Des octets entrés sans AAC en sortie → **415** (corps indécodable), pas 500.
 - Cycle de vie du direct (STR-77) : `start`/`stop` = endpoints dédiés (le PUT ne touche pas au statut) ; **un seul flux live par diffuseur** ; goroutines gérées par `LiveSessions` (context + mutex). Détails [ADR 013](docs/adr/013-domaine-streaming.md) §7.
 - Titre **non unique** (contrainte retirée en `000015`) : pas de 409 sur le titre.
 - `stream_key` (32 octets base64url, en clair) jamais exposé à un tiers ; URL source = `{STREAM_INGEST_BASE_URL}/api/streams/ingest/{stream_key}`.
@@ -567,7 +568,7 @@ xcrun simctl openurl booted \
 | `docs/adr/012-openapi-source-de-verite.md` | Décision : OpenAPI source de vérité du contrat HTTP + client Dart/Dio généré |
 
 **Règle :** toute nouvelle décision d'architecture significative → nouvel ADR dans `docs/adr/`
-avec le numéro suivant (prochain : `030-...`). Référencer le ticket Linear correspondant.
+avec le numéro suivant (prochain : `031-...`). Référencer le ticket Linear correspondant.
 
 ## Principes SOLID
 

--- a/backend/internal/openapi/openapi.yaml
+++ b/backend/internal/openapi/openapi.yaml
@@ -1171,6 +1171,10 @@ paths:
             would spin the HLS demuxer without producing segments), or the body
             could not be decoded as the announced format — bytes went in and no
             AAC came out. An absent Content-Type is accepted.
+
+            A push cut short by the network is *not* reported here even when it
+            produced no AAC: that is a transport failure and returns 500, so a
+            client can tell "your audio is invalid" from "retry".
           content:
             application/json:
               schema:

--- a/backend/internal/openapi/openapi.yaml
+++ b/backend/internal/openapi/openapi.yaml
@@ -1120,14 +1120,33 @@ paths:
       operationId: ingestStream
       summary: Push a live audio stream (broadcaster ingest).
       description: >-
-        Continuous AAC audio ingest for a live stream, authenticated by the
+        Continuous audio ingest for a live stream, authenticated by the
         `stream_key` in the path (no JWT). The request body is a continuous audio
         stream segmented into HLS by the backend (cf. ADR 015). The stream must be
         live (started) for the push to be accepted.
+
+
+        Any audio media type is accepted. `audio/aac` (raw ADTS) — and an absent
+        `Content-Type`, which is assumed to be the same — is muxed as-is with no
+        re-encoding. Every other format (MP3, OGG, WAV, FLAC, …) is transcoded to
+        AAC on the fly by an ffmpeg stage placed in front of the segmenter, adding
+        under 2 seconds of latency (cf. ADR 030). Listeners always receive AAC.
       requestBody:
         required: true
         content:
           audio/aac:
+            schema:
+              type: string
+              format: binary
+          audio/mpeg:
+            schema:
+              type: string
+              format: binary
+          audio/ogg:
+            schema:
+              type: string
+              format: binary
+          audio/wav:
             schema:
               type: string
               format: binary
@@ -1148,9 +1167,10 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "415":
           description: >-
-            Content-Type present but not audio/* (a non-audio push would spin the
-            HLS demuxer without producing segments). An absent Content-Type is
-            accepted.
+            Either the Content-Type is present but not audio/* (a non-audio push
+            would spin the HLS demuxer without producing segments), or the body
+            could not be decoded as the announced format — bytes went in and no
+            AAC came out. An absent Content-Type is accepted.
           content:
             application/json:
               schema:

--- a/backend/internal/streaming/handler.go
+++ b/backend/internal/streaming/handler.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"mime"
 	"net"
 	"net/http"
 
@@ -722,18 +721,39 @@ func (h *Handler) Ingest(w http.ResponseWriter, r *http.Request) {
 	}
 	defer release()
 
-	// Validation légère du Content-Type (après résolution de la clé pour préserver
-	// le 404 sur clé inconnue, avant io.Copy pour qu'aucun octet n'atteigne ffmpeg).
-	// Si présent, il doit être audio/* : coupe tôt un push manifestement non-audio
-	// (ex. curl --data-binary → application/x-www-form-urlencoded) qui ferait tourner
-	// ffmpeg dans le vide (le demuxer ADTS cherche des sync words sans jamais mourir).
-	// Un Content-Type absent reste accepté (clients bruts, cf. ADR 015).
-	if ct := r.Header.Get("Content-Type"); ct != "" {
-		if mt, _, perr := mime.ParseMediaType(ct); perr != nil || !strings.HasPrefix(mt, "audio/") {
-			httpjson.WriteError(w, r, httpjson.StatusError(
-				http.StatusUnsupportedMediaType, "unsupported_media_type", "content-type must be audio/aac"))
+	// Résolution du format d'entrée depuis le Content-Type (après résolution de la
+	// clé pour préserver le 404 sur clé inconnue, avant io.Copy pour qu'aucun octet
+	// n'atteigne ffmpeg). Seul audio/* est accepté : ça coupe tôt un push
+	// manifestement non-audio (ex. curl --data-binary → application/x-www-form-urlencoded)
+	// qui ferait tourner ffmpeg dans le vide (le demuxer ADTS cherche des sync words
+	// sans jamais mourir). Un Content-Type absent reste accepté (clients bruts, ADR 015).
+	format, ok := resolveIngestFormat(r.Header.Get("Content-Type"))
+	if !ok {
+		httpjson.WriteError(w, r, httpjson.StatusError(
+			http.StatusUnsupportedMediaType, "unsupported_media_type", "content-type must be audio/*"))
+		return
+	}
+
+	// Formats non-AAC (MP3, OGG, WAV, …) : un ffmpeg de transcodage est intercalé
+	// devant le segmenteur et convertit en AAC à la volée (STR-204, ADR 030). Un
+	// push AAC garde le chemin direct — aucun process ni ré-encodage en plus.
+	sink := writer
+	var trans *transcoder
+	if !format.passthrough {
+		trans, err = newTranscoder(writer, format.demuxer)
+		if err != nil {
+			zerolog.Ctx(r.Context()).Error().Err(err).
+				Str("media_type", format.mediaType).Msg("streaming: transcodeur indisponible")
+			httpjson.WriteError(w, r, apperror.Internal("transcoder unavailable", err))
 			return
 		}
+		// Filet de sécurité : close est idempotent, l'appel explicite plus bas
+		// reste celui qui décide du status de la réponse.
+		defer func() { _ = trans.close() }()
+		sink = trans
+		zerolog.Ctx(r.Context()).Info().
+			Str("media_type", format.mediaType).Str("demuxer", format.demuxer).
+			Msg("streaming: transcodage de l'ingest vers AAC")
 	}
 
 	// Push long : la deadline de lecture est glissante (renouvelée à chaque bloc
@@ -756,12 +776,31 @@ func (h *Handler) Ingest(w http.ResponseWriter, r *http.Request) {
 		controller: rc,
 		timeout:    h.ingestReconnectGrace,
 	}
-	if _, err := io.Copy(writer, reader); err != nil {
+	pushed, copyErr := io.Copy(sink, reader)
+
+	// Drainer le transcodeur AVANT de statuer : c'est lui qui explique un copyErr
+	// (ffmpeg mort d'une entrée indécodable → EPIPE côté io.Copy).
+	if trans != nil {
+		if cerr := trans.close(); cerr != nil {
+			zerolog.Ctx(r.Context()).Error().Err(cerr).
+				Str("media_type", format.mediaType).Msg("streaming: transcodage en échec")
+		}
+		if pushed > 0 && trans.produced() == 0 {
+			// Des octets sont entrés, aucun AAC n'en est sorti : le corps ne
+			// correspond pas au format annoncé. 415 plutôt qu'un 500 opaque.
+			httpjson.WriteError(w, r, httpjson.StatusError(
+				http.StatusUnsupportedMediaType, "unsupported_media_type",
+				"audio payload could not be decoded"))
+			return
+		}
+	}
+
+	if copyErr != nil {
 		// Push interrompu par une erreur : refléter l'échec plutôt qu'un 204
 		// trompeur (un broadcast avorté ≠ déconnexion propre). Ne jamais logger le
 		// stream_key (secret). Si le client est déjà parti, l'écriture est un no-op.
-		zerolog.Ctx(r.Context()).Error().Err(err).Msg("streaming: ingest interrompu")
-		httpjson.WriteError(w, r, apperror.Internal("ingest interrupted", err))
+		zerolog.Ctx(r.Context()).Error().Err(copyErr).Msg("streaming: ingest interrompu")
+		httpjson.WriteError(w, r, apperror.Internal("ingest interrupted", copyErr))
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/backend/internal/streaming/handler.go
+++ b/backend/internal/streaming/handler.go
@@ -34,15 +34,26 @@ type ingestDeadlineReader struct {
 	body       io.Reader
 	controller *http.ResponseController
 	timeout    time.Duration
+
+	// readErr mémorise l'échec de lecture du corps (hors EOF, qui est la fin
+	// normale d'un push). io.Copy renvoie une erreur unique sans dire de quel
+	// côté elle vient : sans ce témoin, un diffuseur déconnecté par le réseau
+	// serait indiscernable d'un ffmpeg mort sur une entrée indécodable, et le
+	// handler leur donnerait le même status.
+	readErr error
 }
 
 // Read renouvelle la deadline avant chaque attente d'octets. Une connexion TCP
 // half-open ne peut ainsi pas réserver indéfiniment l'unique slot d'ingest.
-func (r ingestDeadlineReader) Read(p []byte) (int, error) {
+func (r *ingestDeadlineReader) Read(p []byte) (int, error) {
 	if r.timeout > 0 {
 		_ = r.controller.SetReadDeadline(time.Now().Add(r.timeout))
 	}
-	return r.body.Read(p)
+	n, err := r.body.Read(p)
+	if err != nil && !errors.Is(err, io.EOF) {
+		r.readErr = err
+	}
+	return n, err
 }
 
 // StreamService est l'interface requise par le handler (ISP) : *Service la satisfait.
@@ -771,7 +782,7 @@ func (h *Handler) Ingest(w http.ResponseWriter, r *http.Request) {
 	// Copie bloquante jusqu'à la fin du push (EOF = diffuseur déconnecté). On ne
 	// ferme PAS l'entrée du segmenteur : la session reste live (fenêtre de
 	// segments disponible) jusqu'au stop explicite.
-	reader := ingestDeadlineReader{
+	reader := &ingestDeadlineReader{
 		body:       r.Body,
 		controller: rc,
 		timeout:    h.ingestReconnectGrace,
@@ -781,13 +792,30 @@ func (h *Handler) Ingest(w http.ResponseWriter, r *http.Request) {
 	// Drainer le transcodeur AVANT de statuer : c'est lui qui explique un copyErr
 	// (ffmpeg mort d'une entrée indécodable → EPIPE côté io.Copy).
 	if trans != nil {
-		if cerr := trans.close(); cerr != nil {
+		cerr := trans.close()
+		if cerr != nil {
 			zerolog.Ctx(r.Context()).Error().Err(cerr).
 				Str("media_type", format.mediaType).Msg("streaming: transcodage en échec")
 		}
-		if pushed > 0 && trans.produced() == 0 {
-			// Des octets sont entrés, aucun AAC n'en est sorti : le corps ne
-			// correspond pas au format annoncé. 415 plutôt qu'un 500 opaque.
+		if errors.Is(cerr, errTranscodeRelayStalled) {
+			// Défaillance serveur (segmenteur qui ne consomme plus), pas un
+			// problème de corps : ne pas la maquiller en 415.
+			httpjson.WriteError(w, r, apperror.Internal("ingest relay stalled", cerr))
+			return
+		}
+		// Le corps a été lu en entier sans incident réseau, des octets sont
+		// entrés, et aucun AAC n'en est sorti : le corps ne correspond pas au
+		// format annoncé. 415 plutôt qu'un 500 opaque.
+		//
+		// La condition porte sur reader.readErr et non sur copyErr : sur une
+		// entrée indécodable un peu longue, ffmpeg meurt avant la fin du corps
+		// et l'écriture suivante rend un EPIPE — copyErr est alors non nul pour
+		// un push dont la cause reste bien le payload. À l'inverse, un
+		// diffuseur coupé par le réseau avant la première frame AAC produit
+		// lui aussi pushed>0 et produced==0, mais c'est un échec de transport :
+		// il doit ressortir en 500 « interrupted », pas en 415, sans quoi on
+		// mentirait sur la cause à un client qui décide de réessayer ou non.
+		if reader.readErr == nil && pushed > 0 && trans.produced() == 0 {
 			httpjson.WriteError(w, r, httpjson.StatusError(
 				http.StatusUnsupportedMediaType, "unsupported_media_type",
 				"audio payload could not be decoded"))

--- a/backend/internal/streaming/handler_test.go
+++ b/backend/internal/streaming/handler_test.go
@@ -1,6 +1,7 @@
 package streaming
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"net/http"
@@ -712,6 +713,95 @@ func TestHandler_Ingest_AllowsAbsentContentType(t *testing.T) {
 
 	if rec.Code != http.StatusNoContent {
 		t.Fatalf("want 204 (content-type absent accepté), got %d: %s", rec.Code, rec.Body)
+	}
+}
+
+// US-09-05 : un diffuseur qui pousse du MP3 doit être accepté, et le segmenteur
+// ne doit recevoir que de l'AAC (il tourne en `-c:a copy`).
+func TestHandler_Ingest_TranscodesMP3ToAAC(t *testing.T) {
+	requireFFmpeg(t)
+
+	var received syncWriter
+	ls := NewLiveSessions(context.Background())
+	ls.newSeg = func() (*hlsSegmenter, error) {
+		seg := fakeSegmenter(t)
+		seg.stdin = nopWriteCloser{&received}
+		return seg, nil
+	}
+	ls.Start("sid-mp3", "KEYMP3")
+	defer ls.StopAll()
+	h := NewHandler(&stubService{}, testIngestURL, ls)
+
+	mp3 := generateTestAudio(t, "mp3", "libmp3lame", 3)
+	req := httptest.NewRequest(http.MethodPost, "/api/streams/ingest/KEYMP3", bytes.NewReader(mp3))
+	req.SetPathValue("stream_key", "KEYMP3")
+	req.Header.Set("Content-Type", "audio/mpeg")
+	rec := httptest.NewRecorder()
+
+	h.Ingest(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("want 204 pour un push MP3, got %d: %s", rec.Code, rec.Body)
+	}
+	out := received.Bytes()
+	if len(out) == 0 {
+		t.Fatal("le segmenteur n'a reçu aucun octet")
+	}
+	if !isADTS(out) {
+		t.Fatalf("le segmenteur doit recevoir de l'ADTS AAC, premiers octets %x", out[:min(4, len(out))])
+	}
+}
+
+// Un corps qui ne correspond pas au Content-Type annoncé produit zéro AAC : le
+// handler doit répondre 415 plutôt qu'un 500 opaque.
+func TestHandler_Ingest_RejectsUndecodablePayload(t *testing.T) {
+	requireFFmpeg(t)
+
+	ls := sessionsWithFakeSeg(t)
+	ls.Start("sid-bad", "KEYBAD")
+	defer ls.StopAll()
+	h := NewHandler(&stubService{}, testIngestURL, ls)
+
+	body := strings.NewReader(strings.Repeat("pas de l'audio du tout", 4096))
+	req := httptest.NewRequest(http.MethodPost, "/api/streams/ingest/KEYBAD", body)
+	req.SetPathValue("stream_key", "KEYBAD")
+	req.Header.Set("Content-Type", "audio/mpeg")
+	rec := httptest.NewRecorder()
+
+	h.Ingest(rec, req)
+
+	if rec.Code != http.StatusUnsupportedMediaType {
+		t.Fatalf("want 415 pour un corps indécodable, got %d: %s", rec.Code, rec.Body)
+	}
+}
+
+// Le chemin AAC reste inchangé : aucun transcodeur, l'audio arrive tel quel au
+// segmenteur (pas de ré-encodage, pas de latence ajoutée).
+func TestHandler_Ingest_AACIsPassedThroughUntouched(t *testing.T) {
+	var received syncWriter
+	ls := NewLiveSessions(context.Background())
+	ls.newSeg = func() (*hlsSegmenter, error) {
+		seg := fakeSegmenter(t)
+		seg.stdin = nopWriteCloser{&received}
+		return seg, nil
+	}
+	ls.Start("sid-aac", "KEYAAC")
+	defer ls.StopAll()
+	h := NewHandler(&stubService{}, testIngestURL, ls)
+
+	payload := []byte("octets-opaques-cotes-diffuseur")
+	req := httptest.NewRequest(http.MethodPost, "/api/streams/ingest/KEYAAC", bytes.NewReader(payload))
+	req.SetPathValue("stream_key", "KEYAAC")
+	req.Header.Set("Content-Type", "audio/aac")
+	rec := httptest.NewRecorder()
+
+	h.Ingest(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("want 204, got %d: %s", rec.Code, rec.Body)
+	}
+	if got := received.Bytes(); !bytes.Equal(got, payload) {
+		t.Fatalf("l'AAC doit arriver intact au segmenteur: got %q, want %q", got, payload)
 	}
 }
 

--- a/backend/internal/streaming/handler_test.go
+++ b/backend/internal/streaming/handler_test.go
@@ -3,6 +3,7 @@ package streaming
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -772,6 +773,54 @@ func TestHandler_Ingest_RejectsUndecodablePayload(t *testing.T) {
 
 	if rec.Code != http.StatusUnsupportedMediaType {
 		t.Fatalf("want 415 pour un corps indécodable, got %d: %s", rec.Code, rec.Body)
+	}
+}
+
+// errReader rend `payload` puis échoue : simule un diffuseur coupé par le
+// réseau en plein push (la lecture du corps casse, pas le corps lui-même).
+type errReader struct {
+	payload []byte
+	off     int
+	err     error
+}
+
+func (r *errReader) Read(p []byte) (int, error) {
+	if r.off >= len(r.payload) {
+		return 0, r.err
+	}
+	n := copy(p, r.payload[r.off:])
+	r.off += n
+	return n, nil
+}
+
+// Une coupure réseau avant la première frame AAC produit la même signature
+// qu'un corps indécodable — des octets entrés, aucun sorti — mais la cause est
+// le transport. Elle doit ressortir en 500, sinon on annonce à un client que
+// son audio est invalide alors qu'il lui suffisait de réessayer.
+func TestHandler_Ingest_TransportErrorIsNotReportedAs415(t *testing.T) {
+	requireFFmpeg(t)
+
+	ls := sessionsWithFakeSeg(t)
+	ls.Start("sid-cut", "KEYCUT")
+	defer ls.StopAll()
+	h := NewHandler(&stubService{}, testIngestURL, ls)
+
+	body := &errReader{
+		payload: bytes.Repeat([]byte{0x00}, 512),
+		err:     errors.New("connexion réinitialisée"),
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/streams/ingest/KEYCUT", body)
+	req.SetPathValue("stream_key", "KEYCUT")
+	req.Header.Set("Content-Type", "audio/mpeg")
+	rec := httptest.NewRecorder()
+
+	h.Ingest(rec, req)
+
+	if rec.Code == http.StatusUnsupportedMediaType {
+		t.Fatalf("une coupure réseau ne doit pas être maquillée en 415: %s", rec.Body)
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("want 500 pour un push interrompu, got %d: %s", rec.Code, rec.Body)
 	}
 }
 

--- a/backend/internal/streaming/transcode.go
+++ b/backend/internal/streaming/transcode.go
@@ -1,6 +1,7 @@
 package streaming
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -8,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -32,7 +34,21 @@ const (
 	// Taille max du stderr ffmpeg conservé pour le diagnostic (les warnings
 	// d'un push de plusieurs heures ne doivent pas gonfler la mémoire).
 	transcodeStderrMaxBytes = 8 << 10
+
+	// Borne l'attente de fin du relais stdout -> segmenteur dans close().
+	// Tuer ffmpeg ferme son stdout et débloque une recopie coincée en LECTURE,
+	// mais pas une recopie coincée en ÉCRITURE vers un segmenteur vivant qui ne
+	// consomme plus (le tampon du pipe est plein). Sans cette borne, close() ne
+	// rendrait jamais la main : le handler ne retournerait pas, release() ne
+	// s'exécuterait pas, et le slot d'ingest du flux resterait pris.
+	transcodeRelayTimeout = 2 * hlsShutdownGrace
 )
+
+// errTranscodeRelayStalled signale que le relais vers le segmenteur n'a pas pu
+// être drainé dans les temps. C'est une défaillance serveur — le corps du
+// diffuseur n'est pas en cause — d'où un traitement distinct du payload
+// indécodable côté handler.
+var errTranscodeRelayStalled = errors.New("transcode: relais vers le segmenteur bloqué")
 
 // ingestFormat décrit comment traiter le corps d'un push d'ingest.
 //
@@ -50,6 +66,14 @@ type ingestFormat struct {
 // correspondant. Forcer `-f` plutôt que laisser ffmpeg sonder évite une attente
 // d'analyse au démarrage du flux, et garantit que la ligne de commande ne
 // contient que des constantes serveur (cf. le #nosec de newTranscoder).
+//
+// Les entrées conteneur (mp4, webm, matroska) sont **best-effort** : l'ingest
+// est un pipe non-seekable, seules leurs variantes fragmentées y sont lisibles.
+// Un MP4 classique, dont l'index (`moov`) est écrit en fin de fichier, échoue
+// donc — proprement, en 415 « audio payload could not be decoded », jamais en
+// blocage. C'est le comportement voulu : refuser d'avance ces types priverait
+// les diffuseurs qui poussent du fMP4 ou du WebM en direct, cas parfaitement
+// courant (cf. ADR 030 § « Formats acceptés »).
 var ingestDemuxers = map[string]string{
 	"audio/mpeg":     "mp3",
 	"audio/mp3":      "mp3",
@@ -124,9 +148,15 @@ type transcoder struct {
 	stdin  io.WriteCloser
 	stderr *tailBuffer
 
-	copied  chan struct{} // fermé quand la recopie stdout -> dst est terminée
-	copyN   int64         // octets AAC produits (lu après <-copied)
-	copyErr error
+	copied chan struct{} // fermé quand la recopie stdout -> dst est terminée
+	// Atomique : sur relais bloqué, close() rend la main avant la fin de la
+	// goroutine de recopie, et le handler lit produced() pendant qu'elle tourne.
+	copyN   atomic.Int64
+	copyErr error // écrit avant close(copied), à ne lire qu'ensuite
+
+	// relayTimeout vaut transcodeRelayTimeout ; surchargeable par les tests
+	// pour ne pas leur imposer d'attendre le délai de production.
+	relayTimeout time.Duration
 
 	closeOnce sync.Once
 	closeErr  error
@@ -178,10 +208,18 @@ func newTranscoder(dst io.Writer, demuxer string) (*transcoder, error) {
 		return nil, fmt.Errorf("transcode: start ffmpeg: %w", err)
 	}
 
-	t := &transcoder{cmd: cmd, stdin: stdin, stderr: stderr, copied: make(chan struct{})}
+	t := &transcoder{
+		cmd:          cmd,
+		stdin:        stdin,
+		stderr:       stderr,
+		copied:       make(chan struct{}),
+		relayTimeout: transcodeRelayTimeout,
+	}
 	go func() {
 		defer close(t.copied)
-		t.copyN, t.copyErr = io.Copy(dst, stdout)
+		n, err := io.Copy(dst, stdout)
+		t.copyN.Store(n)
+		t.copyErr = err
 	}()
 	return t, nil
 }
@@ -191,8 +229,8 @@ func newTranscoder(dst io.Writer, demuxer string) (*transcoder, error) {
 func (t *transcoder) Write(p []byte) (int, error) { return t.stdin.Write(p) }
 
 // produced retourne le nombre d'octets AAC effectivement transmis au
-// segmenteur. Valide seulement après close ; zéro sur un push non décodable.
-func (t *transcoder) produced() int64 { return t.copyN }
+// segmenteur. À lire après close ; zéro sur un push non décodable.
+func (t *transcoder) produced() int64 { return t.copyN.Load() }
 
 // close termine le transcodage : fermeture de stdin (ffmpeg vide ses tampons et
 // s'arrête), attente bornée du process puis de la recopie de sortie. L'entrée du
@@ -207,15 +245,32 @@ func (t *transcoder) close() error {
 		// attend donc l'EOF de stdout, qu'un ffmpeg bloqué se voit imposer par le
 		// kill différé (fermer son stdout débloque la recopie).
 		kill := time.AfterFunc(hlsShutdownGrace, func() { _ = t.cmd.Process.Kill() })
-		<-t.copied
-		kill.Stop()
-		err := t.cmd.Wait()
 
-		switch {
-		case err != nil:
-			t.closeErr = fmt.Errorf("transcode: ffmpeg: %w: %s", err, t.stderr.String())
-		case t.copyErr != nil:
-			t.closeErr = fmt.Errorf("transcode: relais vers le segmenteur: %w", t.copyErr)
+		select {
+		case <-t.copied:
+			kill.Stop()
+			err := t.cmd.Wait()
+			switch {
+			case err != nil:
+				t.closeErr = fmt.Errorf("transcode: ffmpeg: %w: %s", err, t.stderr.String())
+			case t.copyErr != nil:
+				t.closeErr = fmt.Errorf("transcode: relais vers le segmenteur: %w", t.copyErr)
+			}
+
+		case <-time.After(t.relayTimeout):
+			// Le kill n'a pas suffi : la recopie est bloquée en écriture vers un
+			// segmenteur qui ne consomme plus. On rend la main pour libérer le
+			// slot d'ingest plutôt que de tenir le handler indéfiniment.
+			kill.Stop()
+			_ = t.cmd.Process.Kill()
+			t.closeErr = errTranscodeRelayStalled
+			// Récolte différée : appeler Wait ici fermerait le pipe pendant que
+			// la goroutine y lit encore. Le process est récolté dès que
+			// l'écriture se débloque (typiquement à la mort du segmenteur).
+			go func() {
+				<-t.copied
+				_ = t.cmd.Wait()
+			}()
 		}
 	})
 	return t.closeErr

--- a/backend/internal/streaming/transcode.go
+++ b/backend/internal/streaming/transcode.go
@@ -1,0 +1,247 @@
+package streaming
+
+import (
+	"fmt"
+	"io"
+	"mime"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Paramètres du transcodage d'ingest (cf. ADR 030).
+//
+// Le transcodeur est un process ffmpeg intercalé DEVANT le segmenteur : il lit le
+// format du diffuseur sur stdin et écrit de l'AAC/ADTS sur stdout, que l'on
+// recopie dans l'entrée du segmenteur. Celui-ci reste donc en `-c:a copy` — un
+// push AAC ne paie strictement rien (aucun process en plus, aucun ré-encodage).
+const (
+	transcodeCodec      = "aac"
+	transcodeBitrate    = "128k"
+	transcodeSampleRate = 44100
+	transcodeChannels   = 2
+
+	// Bornes d'analyse de l'entrée. Les valeurs par défaut de ffmpeg (5 Mo /
+	// 5 s) suffiraient à faire dépasser le budget de latence de l'US ; 128 Kio
+	// et 1 s couvrent largement les en-têtes MP3/OGG/WAV/FLAC.
+	transcodeProbeSize       = 128 << 10 // octets
+	transcodeAnalyzeDuration = 1_000_000 // microsecondes
+
+	// Taille max du stderr ffmpeg conservé pour le diagnostic (les warnings
+	// d'un push de plusieurs heures ne doivent pas gonfler la mémoire).
+	transcodeStderrMaxBytes = 8 << 10
+)
+
+// ingestFormat décrit comment traiter le corps d'un push d'ingest.
+//
+// passthrough : l'audio est déjà de l'AAC/ADTS, il part tel quel dans le
+// segmenteur (chemin historique, latence ajoutée nulle).
+// demuxer : nom du démultiplexeur ffmpeg à forcer via `-f` ; vide = laisser
+// ffmpeg sonder l'entrée (formats audio non listés).
+type ingestFormat struct {
+	passthrough bool
+	demuxer     string
+	mediaType   string
+}
+
+// ingestDemuxers associe les types MIME acceptés au démultiplexeur ffmpeg
+// correspondant. Forcer `-f` plutôt que laisser ffmpeg sonder évite une attente
+// d'analyse au démarrage du flux, et garantit que la ligne de commande ne
+// contient que des constantes serveur (cf. le #nosec de newTranscoder).
+var ingestDemuxers = map[string]string{
+	"audio/mpeg":     "mp3",
+	"audio/mp3":      "mp3",
+	"audio/x-mpeg":   "mp3",
+	"audio/mpeg3":    "mp3",
+	"audio/x-mpeg-3": "mp3",
+
+	"audio/ogg":    "ogg",
+	"audio/x-ogg":  "ogg",
+	"audio/vorbis": "ogg",
+	"audio/opus":   "ogg",
+
+	"audio/wav":        "wav",
+	"audio/x-wav":      "wav",
+	"audio/wave":       "wav",
+	"audio/vnd.wave":   "wav",
+	"audio/x-pn-wav":   "wav",
+	"audio/flac":       "flac",
+	"audio/x-flac":     "flac",
+	"audio/aiff":       "aiff",
+	"audio/x-aiff":     "aiff",
+	"audio/webm":       "webm",
+	"audio/mp4":        "mp4",
+	"audio/x-m4a":      "mp4",
+	"audio/matroska":   "matroska",
+	"audio/x-matroska": "matroska",
+}
+
+// ingestPassthrough liste les types MIME déjà en AAC brut (ADTS) : ceux-là
+// n'ont rien à transcoder. `audio/mp4` en est volontairement absent — c'est un
+// conteneur MP4, qui doit être démuxé avant d'atteindre le segmenteur.
+var ingestPassthrough = map[string]struct{}{
+	"audio/aac":           {},
+	"audio/aacp":          {},
+	"audio/x-aac":         {},
+	"audio/x-hx-aac-adts": {},
+}
+
+// resolveIngestFormat décide du traitement à appliquer au corps d'un push à
+// partir de son Content-Type.
+//
+// Content-Type absent -> passthrough : le contrat historique reste celui d'un
+// push AAC brut (clients bruts, cf. ADR 015). Un type audio/* inconnu est
+// accepté et confié au sondage de ffmpeg, conformément à l'US « accepter
+// n'importe quel format entrant ». Tout ce qui n'est pas audio/* est refusé
+// avant qu'un seul octet n'atteigne un process ffmpeg.
+func resolveIngestFormat(contentType string) (ingestFormat, bool) {
+	if contentType == "" {
+		return ingestFormat{passthrough: true}, true
+	}
+	mt, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return ingestFormat{}, false
+	}
+	mt = strings.ToLower(mt)
+	if !strings.HasPrefix(mt, "audio/") {
+		return ingestFormat{}, false
+	}
+	if _, ok := ingestPassthrough[mt]; ok {
+		return ingestFormat{passthrough: true, mediaType: mt}, true
+	}
+	// demuxer vide pour un audio/* non répertorié : ffmpeg sondera l'entrée.
+	return ingestFormat{demuxer: ingestDemuxers[mt], mediaType: mt}, true
+}
+
+// transcoder est un process ffmpeg qui convertit à la volée le flux du
+// diffuseur en AAC/ADTS et le recopie dans dst (l'entrée du segmenteur HLS).
+// Il implémente io.Writer : le handler d'ingest y copie le corps de la requête
+// exactement comme il copiait dans le segmenteur.
+type transcoder struct {
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stderr *tailBuffer
+
+	copied  chan struct{} // fermé quand la recopie stdout -> dst est terminée
+	copyN   int64         // octets AAC produits (lu après <-copied)
+	copyErr error
+
+	closeOnce sync.Once
+	closeErr  error
+}
+
+// newTranscoder démarre ffmpeg et branche sa sortie sur dst. demuxer force le
+// format d'entrée ; vide, ffmpeg sonde l'entrée.
+func newTranscoder(dst io.Writer, demuxer string) (*transcoder, error) {
+	// Arguments 100 % constants côté serveur : `demuxer` ne peut valoir qu'une
+	// des valeurs de la table ingestDemuxers, jamais une chaîne du diffuseur.
+	// L'audio arrive par stdin (pipe:0). Le G204 de gosec est un faux positif.
+	args := []string{"-hide_banner", "-loglevel", "warning"}
+	args = append(args,
+		"-fflags", "+nobuffer",
+		"-probesize", strconv.Itoa(transcodeProbeSize),
+		"-analyzeduration", strconv.Itoa(transcodeAnalyzeDuration),
+	)
+	if demuxer != "" {
+		args = append(args, "-f", demuxer)
+	}
+	args = append(args,
+		"-i", "pipe:0",
+		"-vn", // ignore une éventuelle pochette embarquée (ID3 APIC)
+		"-c:a", transcodeCodec,
+		"-b:a", transcodeBitrate,
+		"-ar", strconv.Itoa(transcodeSampleRate),
+		"-ac", strconv.Itoa(transcodeChannels),
+		"-f", "adts",
+		"-flush_packets", "1", // pousser chaque paquet : pas de rétention en sortie
+		"pipe:1",
+	)
+
+	cmd := exec.Command("ffmpeg", args...) // #nosec G204 -- args constants serveur, aucune entrée diffuseur
+	stderr := &tailBuffer{max: transcodeStderrMaxBytes}
+	cmd.Stderr = stderr
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("transcode: stdin pipe: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		_ = stdin.Close()
+		return nil, fmt.Errorf("transcode: stdout pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
+		_ = stdout.Close()
+		return nil, fmt.Errorf("transcode: start ffmpeg: %w", err)
+	}
+
+	t := &transcoder{cmd: cmd, stdin: stdin, stderr: stderr, copied: make(chan struct{})}
+	go func() {
+		defer close(t.copied)
+		t.copyN, t.copyErr = io.Copy(dst, stdout)
+	}()
+	return t, nil
+}
+
+// Write pousse l'audio du diffuseur vers ffmpeg. Si le process est mort
+// (entrée indécodable), l'écriture échoue — l'io.Copy de l'ingest s'arrête.
+func (t *transcoder) Write(p []byte) (int, error) { return t.stdin.Write(p) }
+
+// produced retourne le nombre d'octets AAC effectivement transmis au
+// segmenteur. Valide seulement après close ; zéro sur un push non décodable.
+func (t *transcoder) produced() int64 { return t.copyN }
+
+// close termine le transcodage : fermeture de stdin (ffmpeg vide ses tampons et
+// s'arrête), attente bornée du process puis de la recopie de sortie. L'entrée du
+// segmenteur n'est PAS fermée : la session reste live après la déconnexion du
+// diffuseur, comme sur le chemin passthrough. Idempotent.
+func (t *transcoder) close() error {
+	t.closeOnce.Do(func() {
+		_ = t.stdin.Close()
+
+		// cmd.Wait ferme le pipe de sortie : il ne doit être appelé qu'une fois la
+		// recopie terminée, sinon les derniers octets AAC seraient tronqués. On
+		// attend donc l'EOF de stdout, qu'un ffmpeg bloqué se voit imposer par le
+		// kill différé (fermer son stdout débloque la recopie).
+		kill := time.AfterFunc(hlsShutdownGrace, func() { _ = t.cmd.Process.Kill() })
+		<-t.copied
+		kill.Stop()
+		err := t.cmd.Wait()
+
+		switch {
+		case err != nil:
+			t.closeErr = fmt.Errorf("transcode: ffmpeg: %w: %s", err, t.stderr.String())
+		case t.copyErr != nil:
+			t.closeErr = fmt.Errorf("transcode: relais vers le segmenteur: %w", t.copyErr)
+		}
+	})
+	return t.closeErr
+}
+
+// tailBuffer conserve au plus max octets d'une sortie (les derniers écrits) :
+// le stderr d'un ffmpeg qui tourne des heures ne doit pas croître sans borne.
+// Sûr en concurrence : cmd.Stderr est écrit par la goroutine de copie d'exec.
+type tailBuffer struct {
+	mu  sync.Mutex
+	max int
+	buf []byte
+}
+
+func (b *tailBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.buf = append(b.buf, p...)
+	if over := len(b.buf) - b.max; over > 0 {
+		b.buf = b.buf[over:]
+	}
+	return len(p), nil
+}
+
+func (b *tailBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return strings.TrimSpace(string(b.buf))
+}

--- a/backend/internal/streaming/transcode_test.go
+++ b/backend/internal/streaming/transcode_test.go
@@ -2,6 +2,7 @@ package streaming
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -196,6 +197,105 @@ func TestTranscoder_UndecodablePayloadProducesNothing(t *testing.T) {
 	}
 	if tr.produced() != 0 {
 		t.Errorf("produced() = %d, want 0 pour une entrée indécodable", tr.produced())
+	}
+}
+
+// Les entrées conteneur sont annoncées best-effort : l'ingest est un pipe non
+// seekable. Ce test fixe l'invariant qui compte — le push se termine, il ne
+// bloque pas — et documente le comportement réel, qui est meilleur qu'attendu :
+// ffmpeg démuxe un MP4 non fragmenté (index `moov` en fin) tant qu'il tient
+// dans ce qu'il peut bufferiser, et produit bien de l'ADTS. Le cas où ça casse
+// (entrée trop grande pour être bufferisée) ressort en 415, couvert par
+// TestTranscoder_UndecodablePayloadProducesNothing.
+func TestTranscoder_NonStreamableContainerTerminates(t *testing.T) {
+	requireFFmpeg(t)
+
+	// -f mp4 vers un fichier : l'index `moov` est écrit à la fin, donc illisible
+	// en flux. C'est exactement ce qu'enverrait un diffuseur qui pousse un .m4a.
+	path := filepath.Join(t.TempDir(), "sample.m4a")
+	cmd := exec.Command("ffmpeg", "-hide_banner", "-loglevel", "error",
+		"-f", "lavfi", "-i", "sine=frequency=440:duration=3",
+		"-c:a", "aac", "-b:a", "128k", "-f", "mp4", path)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("génération du mp4 de test: %v", err)
+	}
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("lecture du mp4 de test: %v", err)
+	}
+
+	var dst syncWriter
+	tr, err := newTranscoder(&dst, "mp4")
+	if err != nil {
+		t.Fatalf("newTranscoder: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = io.Copy(tr, bytes.NewReader(src))
+		_ = tr.close()
+	}()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("le push d'un conteneur non seekable a bloqué au lieu de se terminer")
+	}
+
+	// Rien produit = échec propre, que le handler traduit en 415. Sinon, ce qui
+	// sort doit être de l'ADTS : le segmenteur tourne en `-c:a copy`, un
+	// conteneur relayé tel quel le casserait.
+	if out := dst.Bytes(); len(out) > 0 && !isADTS(out) {
+		t.Fatalf("sortie non-ADTS pour un conteneur mp4 (premiers octets %x)", out[:min(4, len(out))])
+	}
+}
+
+// Le relais vers le segmenteur peut se bloquer en ÉCRITURE (segmenteur vivant
+// qui ne consomme plus) : tuer ffmpeg ne débloque que la LECTURE de son stdout.
+// close() doit alors rendre la main sur un délai borné, sinon le handler ne
+// retourne jamais et le slot d'ingest du flux reste pris.
+func TestTranscoder_StalledRelayDoesNotHangClose(t *testing.T) {
+	requireFFmpeg(t)
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) }) // libère la goroutine de recopie en fin de test
+
+	blocked := make(chan struct{}, 1)
+	dst := writerFunc(func(p []byte) (int, error) {
+		select {
+		case blocked <- struct{}{}:
+		default:
+		}
+		<-release // ne consomme jamais : simule un segmenteur figé
+		return len(p), nil
+	})
+
+	tr, err := newTranscoder(dst, "wav")
+	if err != nil {
+		t.Fatalf("newTranscoder: %v", err)
+	}
+	tr.relayTimeout = 300 * time.Millisecond // évite d'attendre la borne de production
+
+	if _, err := io.Copy(tr, bytes.NewReader(generateTestAudio(t, "wav", "pcm_s16le", 2))); err != nil {
+		t.Fatalf("copie vers le transcodeur: %v", err)
+	}
+	select {
+	case <-blocked:
+	case <-time.After(10 * time.Second):
+		t.Fatal("le transcodeur n'a rien écrit vers le segmenteur : test non concluant")
+	}
+
+	closed := make(chan error, 1)
+	go func() { closed <- tr.close() }()
+
+	select {
+	case err := <-closed:
+		if !errors.Is(err, errTranscodeRelayStalled) {
+			t.Fatalf("close: want errTranscodeRelayStalled, got %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("close() ne rend pas la main sur un relais bloqué (slot d'ingest tenu)")
 	}
 }
 

--- a/backend/internal/streaming/transcode_test.go
+++ b/backend/internal/streaming/transcode_test.go
@@ -1,0 +1,335 @@
+package streaming
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestResolveIngestFormat(t *testing.T) {
+	cases := []struct {
+		contentType string
+		wantOK      bool
+		wantPass    bool
+		wantDemuxer string
+	}{
+		// Chemin historique : AAC brut ou client sans Content-Type.
+		{contentType: "", wantOK: true, wantPass: true},
+		{contentType: "audio/aac", wantOK: true, wantPass: true},
+		{contentType: "AUDIO/AAC", wantOK: true, wantPass: true},
+		{contentType: "audio/aac; charset=binary", wantOK: true, wantPass: true},
+
+		// Formats transcodés (US-09-05).
+		{contentType: "audio/mpeg", wantOK: true, wantDemuxer: "mp3"},
+		{contentType: "audio/mp3", wantOK: true, wantDemuxer: "mp3"},
+		{contentType: "audio/ogg", wantOK: true, wantDemuxer: "ogg"},
+		{contentType: "audio/wav", wantOK: true, wantDemuxer: "wav"},
+		{contentType: "audio/x-wav", wantOK: true, wantDemuxer: "wav"},
+		{contentType: "audio/flac", wantOK: true, wantDemuxer: "flac"},
+
+		// audio/* inconnu : accepté, ffmpeg sondera l'entrée (demuxer vide).
+		{contentType: "audio/exotique", wantOK: true, wantDemuxer: ""},
+
+		// Non-audio ou en-tête illisible : refusé avant tout process ffmpeg.
+		{contentType: "application/x-www-form-urlencoded", wantOK: false},
+		{contentType: "video/mp4", wantOK: false},
+		{contentType: "text/plain", wantOK: false},
+		{contentType: "audio/", wantOK: false},
+		{contentType: "@@@", wantOK: false},
+	}
+
+	for _, tc := range cases {
+		got, ok := resolveIngestFormat(tc.contentType)
+		if ok != tc.wantOK {
+			t.Errorf("resolveIngestFormat(%q): ok = %v, want %v", tc.contentType, ok, tc.wantOK)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		if got.passthrough != tc.wantPass {
+			t.Errorf("resolveIngestFormat(%q): passthrough = %v, want %v",
+				tc.contentType, got.passthrough, tc.wantPass)
+		}
+		if !tc.wantPass && got.demuxer != tc.wantDemuxer {
+			t.Errorf("resolveIngestFormat(%q): demuxer = %q, want %q",
+				tc.contentType, got.demuxer, tc.wantDemuxer)
+		}
+	}
+}
+
+// resolveIngestFormat ne doit jamais annoncer un passthrough pour un conteneur :
+// l'audio irait tel quel dans un segmenteur en `-c:a copy` incapable de le muxer.
+func TestResolveIngestFormat_ContainersAreTranscoded(t *testing.T) {
+	for _, ct := range []string{"audio/mp4", "audio/x-m4a", "audio/webm", "audio/ogg"} {
+		got, ok := resolveIngestFormat(ct)
+		if !ok {
+			t.Fatalf("%s devrait être accepté", ct)
+		}
+		if got.passthrough {
+			t.Errorf("%s: passthrough = true, un conteneur doit être démuxé", ct)
+		}
+	}
+}
+
+// syncWriter sérialise les écritures reçues du transcodeur : la recopie de la
+// sortie ffmpeg se fait dans une goroutine, le test lit le buffer après close.
+type syncWriter struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (w *syncWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
+func (w *syncWriter) Bytes() []byte {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return append([]byte(nil), w.buf.Bytes()...)
+}
+
+// isADTS vérifie la présence du sync word ADTS (12 bits à 1) en tête de flux :
+// c'est ce que le segmenteur attend en `-c:a copy`.
+func isADTS(b []byte) bool {
+	return len(b) >= 2 && b[0] == 0xFF && b[1]&0xF0 == 0xF0
+}
+
+func requireFFmpeg(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg absent du PATH : test de transcodage ignoré")
+	}
+}
+
+// generateTestAudio synthétise `seconds` secondes d'audio dans le format
+// demandé (muxer ffmpeg + codec), pour alimenter le transcodeur sans embarquer
+// de fichier binaire dans le dépôt.
+func generateTestAudio(t *testing.T, muxer, codec string, seconds int) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	cmd := exec.Command("ffmpeg", "-hide_banner", "-loglevel", "error",
+		"-f", "lavfi", "-i", fmt.Sprintf("sine=frequency=440:duration=%d", seconds),
+		"-c:a", codec, "-b:a", "128k", "-f", muxer, "pipe:1")
+	cmd.Stdout = &buf
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("génération de l'audio de test (%s/%s): %v", muxer, codec, err)
+	}
+	if buf.Len() == 0 {
+		t.Fatalf("audio de test vide (%s/%s)", muxer, codec)
+	}
+	return buf.Bytes()
+}
+
+// TestTranscoder_ConvertsToAAC exerce le transcodage des formats visés par
+// l'US-09-05 : chaque entrée non-AAC doit ressortir en AAC/ADTS, prête pour le
+// segmenteur en `-c:a copy`.
+func TestTranscoder_ConvertsToAAC(t *testing.T) {
+	requireFFmpeg(t)
+
+	cases := []struct {
+		name    string
+		muxer   string
+		codec   string
+		demuxer string
+	}{
+		{name: "mp3", muxer: "mp3", codec: "libmp3lame", demuxer: "mp3"},
+		{name: "ogg", muxer: "ogg", codec: "libopus", demuxer: "ogg"},
+		{name: "wav", muxer: "wav", codec: "pcm_s16le", demuxer: "wav"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := generateTestAudio(t, tc.muxer, tc.codec, 3)
+
+			var dst syncWriter
+			tr, err := newTranscoder(&dst, tc.demuxer)
+			if err != nil {
+				t.Fatalf("newTranscoder: %v", err)
+			}
+			if _, err := io.Copy(tr, bytes.NewReader(src)); err != nil {
+				t.Fatalf("copie vers le transcodeur: %v", err)
+			}
+			if err := tr.close(); err != nil {
+				t.Fatalf("close: %v", err)
+			}
+
+			out := dst.Bytes()
+			if len(out) == 0 {
+				t.Fatal("aucun octet AAC produit")
+			}
+			if tr.produced() != int64(len(out)) {
+				t.Errorf("produced() = %d, écrit = %d", tr.produced(), len(out))
+			}
+			if !isADTS(out) {
+				t.Errorf("la sortie n'est pas de l'ADTS (premiers octets %x)", out[:min(4, len(out))])
+			}
+		})
+	}
+}
+
+// Un corps qui ne correspond pas au format annoncé ne doit produire aucun octet :
+// c'est ce que le handler traduit en 415 plutôt qu'en 500 opaque.
+func TestTranscoder_UndecodablePayloadProducesNothing(t *testing.T) {
+	requireFFmpeg(t)
+
+	var dst syncWriter
+	tr, err := newTranscoder(&dst, "mp3")
+	if err != nil {
+		t.Fatalf("newTranscoder: %v", err)
+	}
+	// L'écriture peut échouer (ffmpeg meurt sur l'entrée invalide) : c'est
+	// attendu, seul le résultat du transcodage nous intéresse ici.
+	_, _ = io.Copy(tr, strings.NewReader(strings.Repeat("ceci n'est pas de l'audio", 4096)))
+	if err := tr.close(); err == nil {
+		t.Error("close: une entrée indécodable doit remonter l'échec de ffmpeg")
+	}
+	if tr.produced() != 0 {
+		t.Errorf("produced() = %d, want 0 pour une entrée indécodable", tr.produced())
+	}
+}
+
+func TestTranscoder_CloseIsIdempotent(t *testing.T) {
+	requireFFmpeg(t)
+
+	var dst syncWriter
+	tr, err := newTranscoder(&dst, "wav")
+	if err != nil {
+		t.Fatalf("newTranscoder: %v", err)
+	}
+	if _, err := io.Copy(tr, bytes.NewReader(generateTestAudio(t, "wav", "pcm_s16le", 1))); err != nil {
+		t.Fatalf("copie vers le transcodeur: %v", err)
+	}
+	first := tr.close()
+	if second := tr.close(); second != first {
+		t.Fatalf("close non idempotent: %v puis %v", first, second)
+	}
+}
+
+// TestTranscoder_AddedLatency mesure le critère d'acceptation de l'US-09-05 :
+// le délai entre le premier octet poussé par le diffuseur et le premier octet
+// AAC transmis au segmenteur doit rester sous 2 secondes.
+func TestTranscoder_AddedLatency(t *testing.T) {
+	requireFFmpeg(t)
+
+	src := generateTestAudio(t, "mp3", "libmp3lame", 10)
+
+	firstOut := make(chan time.Time, 1)
+	dst := writerFunc(func(p []byte) (int, error) {
+		select {
+		case firstOut <- time.Now():
+		default:
+		}
+		return len(p), nil
+	})
+
+	tr, err := newTranscoder(dst, "mp3")
+	if err != nil {
+		t.Fatalf("newTranscoder: %v", err)
+	}
+	defer func() { _ = tr.close() }()
+
+	start := time.Now()
+	// Pousser en petits blocs, comme un diffuseur en direct : ffmpeg ne doit pas
+	// attendre la fin de l'entrée pour commencer à produire.
+	go func() {
+		for off := 0; off < len(src); off += 4096 {
+			end := min(off+4096, len(src))
+			if _, err := tr.Write(src[off:end]); err != nil {
+				return
+			}
+		}
+	}()
+
+	select {
+	case at := <-firstOut:
+		d := at.Sub(start)
+		t.Logf("latence ajoutée par le transcodage: %v", d)
+		if d >= 2*time.Second {
+			t.Fatalf("latence de transcodage %v, budget de l'US = 2s", d)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("aucun octet AAC produit dans les 5 s")
+	}
+}
+
+type writerFunc func([]byte) (int, error)
+
+func (f writerFunc) Write(p []byte) (int, error) { return f(p) }
+
+// TestTranscodePipeline_MP3ToHLS exerce la chaîne complète de l'US-09-05 :
+// MP3 du diffuseur -> transcodeur -> segmenteur HLS -> manifeste + segments, et
+// vérifie que les auditeurs reçoivent bien de l'AAC (et non du MP3 remuxé).
+func TestTranscodePipeline_MP3ToHLS(t *testing.T) {
+	requireFFmpeg(t)
+	if _, err := exec.LookPath("ffprobe"); err != nil {
+		t.Skip("ffprobe absent du PATH : vérification du codec de sortie ignorée")
+	}
+
+	mp3 := generateTestAudio(t, "mp3", "libmp3lame", 25)
+
+	seg, err := newHLSSegmenter()
+	if err != nil {
+		t.Fatalf("newHLSSegmenter: %v", err)
+	}
+	defer seg.close()
+
+	tr, err := newTranscoder(seg.input(), "mp3")
+	if err != nil {
+		t.Fatalf("newTranscoder: %v", err)
+	}
+	if _, err := io.Copy(tr, bytes.NewReader(mp3)); err != nil {
+		t.Fatalf("copie du MP3 vers le transcodeur: %v", err)
+	}
+	if err := tr.close(); err != nil {
+		t.Fatalf("close du transcodeur: %v", err)
+	}
+
+	// Fin du direct : fermer l'entrée du segmenteur pour qu'il finalise.
+	if err := seg.stdin.Close(); err != nil {
+		t.Fatalf("close stdin du segmenteur: %v", err)
+	}
+	select {
+	case <-seg.done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("le segmenteur n'a pas terminé après la fin de l'entrée")
+	}
+
+	manifest, err := os.ReadFile(seg.playlistPath())
+	if err != nil {
+		t.Fatalf("lecture du manifeste: %v", err)
+	}
+	if n := strings.Count(string(manifest), ".ts"); n < 2 {
+		t.Fatalf("attendu >= 2 segments pour 25 s de MP3, obtenu %d:\n%s", n, manifest)
+	}
+
+	first := filepath.Join(seg.dir, "seg_00000.ts")
+	if codec := probeAudioCodec(t, first); codec != "aac" {
+		t.Fatalf("les auditeurs doivent recevoir de l'AAC, segment encodé en %q", codec)
+	}
+}
+
+// probeAudioCodec retourne le codec de la première piste audio d'un fichier.
+// ffprobe peut lister le même flux deux fois sur un segment MPEG-TS (programme +
+// flux élémentaire) : on ne garde que la première ligne.
+func probeAudioCodec(t *testing.T, path string) string {
+	t.Helper()
+	out, err := exec.Command("ffprobe", "-v", "error",
+		"-select_streams", "a:0", "-show_entries", "stream=codec_name",
+		"-of", "default=nokey=1:noprint_wrappers=1", path).Output()
+	if err != nil {
+		t.Fatalf("ffprobe %s: %v", path, err)
+	}
+	first, _, _ := strings.Cut(strings.TrimSpace(string(out)), "\n")
+	return strings.TrimSpace(first)
+}

--- a/docs/adr/030-transcodage-a-la-volee-des-formats-dingest.md
+++ b/docs/adr/030-transcodage-a-la-volee-des-formats-dingest.md
@@ -1,0 +1,145 @@
+# ADR 030 — Transcodage à la volée des formats d'ingest
+
+**Date** : 2026-08-06
+**Statut** : Accepté
+**Ticket** : [STR-204](https://linear.app/streampulse/issue/STR-204)
+
+---
+
+## Contexte
+
+Le moteur HLS ([ADR 015](015-moteur-hls-segmentation-ffmpeg.md)) fait tourner **un** process ffmpeg
+par direct : le diffuseur pousse son audio sur `POST /api/streams/ingest/{stream_key}`, le
+segmenteur le remuxe en `.ts` avec `-c:a copy` et publie un manifeste glissant.
+
+`-c:a copy` ne recode rien — c'est précisément ce qui rend le chemin gratuit en CPU et en latence.
+Mais cela impose au diffuseur d'arriver déjà en **AAC/ADTS**. C'est le cas de l'application mobile
+([ADR 027](027-capture-microphone-et-push-aac-mobile.md)), et de personne d'autre : un encodeur
+externe (Icecast, un `ffmpeg` en ligne de commande, un vieux script) pousse volontiers du MP3, de
+l'OGG ou du WAV. Ces flux passaient la validation `audio/*` du handler, atteignaient le segmenteur,
+et produisaient soit du silence, soit un manifeste vide — sans message exploitable.
+
+L'US demande d'accepter n'importe quel format entrant, avec moins de 2 secondes de latence ajoutée.
+
+## Décision
+
+### 1. Un second ffmpeg **devant** le segmenteur, plutôt qu'un segmenteur reconfigurable
+
+La solution qui vient d'abord est de choisir le codec du segmenteur (`copy` ou `aac`) selon le
+format entrant. Elle ne tient pas : le segmenteur est démarré par `LiveSessions.Start`, au moment
+du `PATCH /start`, alors que le format n'est connu qu'au premier push — et une session vit
+plusieurs pushes successifs (reconnexions du mobile, cf. le bail d'ingest de l'ADR 024). Le
+remplacer à chaud reviendrait à faire boucler `session.run` sur des générations de segmenteurs,
+alors que la fermeture d'un segmenteur est aujourd'hui le signal « ffmpeg est mort seul, récolte la
+session ».
+
+Le transcodeur est donc un **process séparé, intercalé dans le tuyau d'ingest** :
+
+```
+corps HTTP → [ffmpeg -i pipe:0 -c:a aac -f adts pipe:1] → stdin du segmenteur (-c:a copy) → .ts
+             └──────────── durée de vie = celle du push ────────────┘
+```
+
+Trois propriétés en découlent :
+
+- **Le segmenteur ne change pas.** Il reçoit toujours de l'ADTS, ses gardes, son reaping et ses
+  tests restent intacts. Aucune ligne de `session.go` ni de `hls.go` n'a été touchée.
+- **Le chemin AAC ne paie rien.** Pas de process en plus, pas de ré-encodage, pas d'octet copié en
+  plus : `sink` reste l'entrée du segmenteur. C'est le cas nominal (le mobile), il ne devait pas
+  régresser pour couvrir un cas de bord.
+- **Le cycle de vie est le bon.** Le transcodeur meurt avec le push ; le segmenteur, lui, survit à
+  la déconnexion du diffuseur — la fenêtre de segments reste servie jusqu'au `stop` explicite.
+  C'est exactement la sémantique existante, et c'est pourquoi le transcodeur ne ferme **jamais**
+  l'entrée du segmenteur.
+
+### 2. Le Content-Type choisit le démultiplexeur, il ne le construit pas
+
+`resolveIngestFormat` mappe le type MIME déclaré vers un nom de démultiplexeur ffmpeg tiré d'une
+table close (`mp3`, `ogg`, `wav`, `flac`, `mp4`…). La valeur qui atteint la ligne de commande vient
+donc du serveur, jamais du diffuseur — la propriété qui justifiait déjà le `#nosec G204` du
+segmenteur reste vraie du transcodeur.
+
+Forcer `-f` plutôt que laisser ffmpeg sonder n'est pas qu'une question de sûreté : le sondage
+consomme des octets et du temps avant de produire quoi que ce soit, et c'est directement du budget
+de latence.
+
+Trois cas, dans cet ordre :
+
+| Content-Type | Traitement |
+|---|---|
+| absent, `audio/aac` et variantes | passthrough — contrat historique, latence ajoutée nulle |
+| `audio/*` répertorié | transcodage avec `-f <demuxer>` |
+| `audio/*` inconnu | transcodage avec sondage borné (l'US dit « n'importe quel format ») |
+| tout le reste | 415 avant qu'un octet n'atteigne un process |
+
+`audio/mp4` et `audio/webm` sont volontairement **hors** de la liste passthrough : ce sont des
+conteneurs, pas de l'ADTS. Les laisser passer tels quels enverrait au segmenteur un flux qu'il ne
+sait pas muxer — un test les garde du bon côté de la frontière.
+
+### 3. Le budget de latence est tenu par des bornes explicites
+
+Les valeurs par défaut de ffmpeg (`probesize` 5 Mo, `analyzeduration` 5 s) suffisent à elles seules
+à faire sauter le critère des 2 secondes sur une entrée à faible débit. Le transcodeur les ramène à
+128 Kio et 1 s — largement de quoi couvrir un en-tête MP3, OGG, WAV ou FLAC — et ajoute
+`-fflags +nobuffer` en entrée et `-flush_packets 1` en sortie pour qu'aucun paquet ne soit retenu.
+
+Un test mesure ce qui est réellement promis : le délai entre le premier octet poussé par le
+diffuseur et le premier octet AAC transmis au segmenteur, sur un push découpé en blocs de 4 Kio
+comme un vrai direct. Mesuré à ~21 ms en local (ffmpeg 8.1, MP3 128 kb/s), deux ordres de
+grandeur sous le budget.
+
+La sortie est normalisée en 128 kb/s, 44,1 kHz, stéréo. Un flux d'entrée mono à 8 kHz produirait un
+ADTS valide sans normalisation, mais la constance du profil sur toute la durée du direct est ce qui
+garantit que les segments restent concaténables par le lecteur.
+
+### 4. « Zéro octet produit » vaut 415, pas 500
+
+Quand le corps ne correspond pas au type annoncé, ffmpeg meurt, l'écriture suivante prend un EPIPE
+et `io.Copy` remonte une erreur — indiscernable, telle quelle, d'une coupure réseau. Le handler
+ferme donc le transcodeur **avant** de statuer et regarde un signal sans ambiguïté : des octets sont
+entrés, aucun AAC n'est sorti.
+
+Ce cas devient un **415** avec `audio payload could not be decoded`, pas un 500 : c'est le push qui
+est en cause, pas le serveur, et le diffuseur peut agir. Le stderr de ffmpeg est conservé dans un
+tampon borné (8 Kio, les derniers octets) et journalisé — un direct de plusieurs heures ne doit pas
+accumuler ses warnings en mémoire.
+
+### 5. `cmd.Wait` après la recopie, pas en parallèle
+
+Détail d'implémentation qui mérite d'être écrit parce qu'il se casse silencieusement : `cmd.Wait`
+ferme le pipe de sortie. L'appeler pendant que la goroutine de recopie lit encore tronquerait les
+derniers octets AAC. `close` attend donc l'EOF de stdout, puis `Wait` — et le délai de grâce n'est
+plus un `select` sur `Wait` mais un `time.AfterFunc` qui tue le process, ce qui ferme son stdout et
+débloque la recopie par le même chemin.
+
+## Alternatives écartées
+
+- **Transcoder systématiquement** (`-c:a aac` dans le segmenteur, plus de `copy`). Une ligne à
+  changer, mais tout le trafic nominal — du mobile qui envoie déjà de l'AAC — paierait un
+  ré-encodage AAC→AAC : perte de génération sur la qualité et CPU brûlé sur le seul chemin qui
+  compte vraiment.
+- **Remplacer le segmenteur au premier push**, une fois le format connu. Oblige `session.run` à
+  gérer plusieurs générations de segmenteurs, alors que la mort d'un segmenteur est le signal de
+  récolte de la session. Beaucoup de complexité dans le code le plus concurrent du domaine, pour
+  gagner un process sur un cas de bord.
+- **Créer le segmenteur paresseusement au premier ingest**, avec le bon codec. Plus propre en
+  théorie, mais `Playlist`, `Segment` et `AttachIngest` s'appuient tous sur la présence du
+  segmenteur dès `Start` : c'est un changement de sémantique diffus pour toute la lecture HLS.
+- **Refuser en 415 tout `audio/*` non répertorié.** Contrat plus net, mais l'US demande d'accepter
+  n'importe quel format entrant ; le sondage borné coûte une analyse au démarrage du flux, pas par
+  segment.
+- **Une métrique Prometheus par format transcodé.** La famille aurait un label de cardinalité
+  bornée et serait légitime, mais l'US ne la demande pas ; un log structuré (`media_type`,
+  `demuxer`) suffit à répondre à « qui pousse du MP3 ? ».
+
+## Conséquences
+
+- N'importe quel format audio lisible par ffmpeg est diffusable ; les auditeurs reçoivent
+  toujours de l'AAC, quel que soit ce que le diffuseur a poussé.
+- Un direct non-AAC coûte **deux** process ffmpeg au lieu d'un. `HLS_MAX_CONCURRENT`
+  ([ADR 016](016-scalabilite-test-de-charge-et-limiteur-hls.md)) borne les lecteurs, pas les
+  diffuseurs : la charge CPU d'un parc de diffuseurs non-AAC est à surveiller sur le dashboard
+  machine avant d'être un problème.
+- Un push mal étiqueté reçoit désormais un 415 explicite au lieu d'un direct silencieux — c'est un
+  changement de comportement visible pour un client qui poussait du MP3 en croyant que ça marchait.
+- L'application mobile n'est pas touchée : elle pousse de l'AAC, elle reste sur le chemin direct.

--- a/docs/adr/030-transcodage-a-la-volee-des-formats-dingest.md
+++ b/docs/adr/030-transcodage-a-la-volee-des-formats-dingest.md
@@ -76,6 +76,19 @@ Trois cas, dans cet ordre :
 conteneurs, pas de l'ADTS. Les laisser passer tels quels enverrait au segmenteur un flux qu'il ne
 sait pas muxer — un test les garde du bon côté de la frontière.
 
+#### Formats acceptés : les conteneurs sont best-effort
+
+L'ingest est un pipe non seekable, ce qui restreint en théorie les conteneurs à leurs variantes
+fragmentées : un MP4 classique écrit son index (`moov`) en fin de fichier, donc après l'audio.
+
+En pratique, mesuré plutôt que supposé : ffmpeg démuxe sans problème un MP4 non fragmenté poussé
+sur `pipe:0`, tant que l'entrée tient dans ce qu'il bufferise. Le cas qui casse est une entrée trop
+grande pour ça — et il casse **proprement**, en 415, jamais en blocage. Un test fixe cet invariant
+(le push se termine ; ce qui sort est de l'ADTS ou rien).
+
+Ces types restent donc acceptés : les retirer priverait les diffuseurs qui poussent du fMP4 ou du
+WebM en direct, cas courant, pour se prémunir d'un échec déjà géré.
+
 ### 3. Le budget de latence est tenu par des bornes explicites
 
 Les valeurs par défaut de ffmpeg (`probesize` 5 Mo, `analyzeduration` 5 s) suffisent à elles seules
@@ -104,6 +117,22 @@ est en cause, pas le serveur, et le diffuseur peut agir. Le stderr de ffmpeg est
 tampon borné (8 Kio, les derniers octets) et journalisé — un direct de plusieurs heures ne doit pas
 accumuler ses warnings en mémoire.
 
+Le signal « zéro octet produit » ne suffit pourtant pas seul, et c'est le piège : un diffuseur coupé
+par le réseau **avant la première frame AAC** présente exactement la même signature — des octets
+entrés, aucun sorti — alors que la cause est le transport. Répondre 415 lui annoncerait que son
+audio est invalide, quand il lui suffisait de réessayer.
+
+Le discriminant ne peut pas être `copyErr` : sur une entrée indécodable un peu longue, ffmpeg meurt
+avant la fin du corps et l'écriture suivante rend un EPIPE, donc `copyErr` est non nul pour un push
+dont la cause est bien le payload. `ingestDeadlineReader` mémorise donc séparément les échecs de
+**lecture** du corps (hors EOF). Le 415 exige `readErr == nil` ; sinon c'est un 500 « interrupted ».
+
+| Situation | `readErr` | `produced` | Réponse |
+|---|---|---|---|
+| corps indécodable, court ou long | nil | 0 | 415 |
+| coupure réseau avant la 1ʳᵉ frame | non nil | 0 | 500 |
+| push sain | nil | > 0 | 204 |
+
 ### 5. `cmd.Wait` après la recopie, pas en parallèle
 
 Détail d'implémentation qui mérite d'être écrit parce qu'il se casse silencieusement : `cmd.Wait`
@@ -111,6 +140,23 @@ ferme le pipe de sortie. L'appeler pendant que la goroutine de recopie lit encor
 derniers octets AAC. `close` attend donc l'EOF de stdout, puis `Wait` — et le délai de grâce n'est
 plus un `select` sur `Wait` mais un `time.AfterFunc` qui tue le process, ce qui ferme son stdout et
 débloque la recopie par le même chemin.
+
+### 6. L'attente du relais est bornée
+
+Tuer ffmpeg débloque une recopie coincée en **lecture** de son stdout. Ça ne débloque pas une
+recopie coincée en **écriture** vers le segmenteur — cas d'un segmenteur vivant qui ne consomme
+plus, dont le tampon de pipe est plein. `close` attendrait alors indéfiniment : le handler ne
+retournerait jamais, `release()` ne s'exécuterait pas, et le slot d'ingest du flux resterait pris
+jusqu'au redémarrage.
+
+En pratique un segmenteur mort rend un EPIPE et tout se débloque, et le risque préexiste sur le
+chemin passthrough — mais le transcodage ajoute un maillon `io.Copy` sur ce chemin, et surtout une
+attente là où le handler rendait la main. L'attente est donc bornée à `2 × hlsShutdownGrace`, avec
+récolte différée du process (`Wait` ne peut pas être appelé tant que la goroutine lit encore).
+
+Le dépassement remonte `errTranscodeRelayStalled`, que le handler traduit en **500** : c'est une
+défaillance serveur, pas un corps invalide, et la maquiller en 415 renverrait le diffuseur chercher
+un problème chez lui.
 
 ## Alternatives écartées
 

--- a/mobile/packages/streampulse_api/lib/src/api/streaming_api.dart
+++ b/mobile/packages/streampulse_api/lib/src/api/streaming_api.dart
@@ -382,7 +382,7 @@ class StreamingApi {
   }
 
   /// Push a live audio stream (broadcaster ingest).
-  /// Continuous AAC audio ingest for a live stream, authenticated by the &#x60;stream_key&#x60; in the path (no JWT). The request body is a continuous audio stream segmented into HLS by the backend (cf. ADR 015). The stream must be live (started) for the push to be accepted.
+  /// Continuous audio ingest for a live stream, authenticated by the &#x60;stream_key&#x60; in the path (no JWT). The request body is a continuous audio stream segmented into HLS by the backend (cf. ADR 015). The stream must be live (started) for the push to be accepted.  Any audio media type is accepted. &#x60;audio/aac&#x60; (raw ADTS) — and an absent &#x60;Content-Type&#x60;, which is assumed to be the same — is muxed as-is with no re-encoding. Every other format (MP3, OGG, WAV, FLAC, …) is transcoded to AAC on the fly by an ffmpeg stage placed in front of the segmenter, adding under 2 seconds of latency (cf. ADR 030). Listeners always receive AAC.
   ///
   /// Parameters:
   /// * [streamKey] - The broadcaster's secret stream key (from stream_source_url).


### PR DESCRIPTION
Closes #233 — [STR-204](https://linear.app/streampulse/issue/STR-204/us-09-05-transcodage-a-la-volee-ffmpeg)

## Problème

Le segmenteur HLS tourne en `-c:a copy` : il n'ajoute aucune latence, mais impose au diffuseur d'arriver déjà en **AAC/ADTS**. C'est le cas de l'app mobile, et de personne d'autre — un encodeur externe (Icecast, script ffmpeg) pousse volontiers du MP3, de l'OGG ou du WAV. Ces flux passaient la validation `audio/*`, atteignaient le segmenteur et produisaient un manifeste vide, sans message exploitable.

## Approche

Un **second ffmpeg intercalé devant le segmenteur**, vivant le temps du push :

```
corps HTTP → [ffmpeg -i pipe:0 -c:a aac -f adts pipe:1] → stdin segmenteur (-c:a copy) → .ts
             └──────────── durée de vie = celle du push ────────────┘
```

Pourquoi pas simplement choisir le codec du segmenteur : il démarre au `PATCH /start`, alors que le format n'est connu qu'au premier push — et une session vit plusieurs pushes successifs (reconnexions du mobile). Le remplacer à chaud ferait boucler `session.run` sur des générations de segmenteurs, alors que la fermeture d'un segmenteur est aujourd'hui le signal « ffmpeg est mort seul, récolte la session ».

Trois propriétés en découlent :

- **`session.go` et `hls.go` ne sont pas touchés** — le segmenteur reçoit toujours de l'ADTS, ses gardes et son reaping restent intacts.
- **Le chemin AAC ne paie rien** : ni process en plus, ni ré-encodage. C'est le cas nominal, il ne devait pas régresser pour couvrir un cas de bord.
- **Le cycle de vie est le bon** : le transcodeur meurt avec le push, le segmenteur survit à la déconnexion — le transcodeur ne ferme jamais l'entrée du segmenteur.

Décision détaillée dans [ADR 030](docs/adr/030-transcodage-a-la-volee-des-formats-dingest.md).

## Points qui méritent un œil en review

**Sûreté de la ligne de commande** — `resolveIngestFormat` mappe le type MIME vers un démultiplexeur tiré d'une **table close**. La valeur qui atteint `exec.Command` vient du serveur, jamais d'une chaîne du diffuseur : c'est la propriété qui justifiait déjà le `#nosec G204` du segmenteur, elle reste vraie ici.

**415 plutôt que 500 sur corps indécodable** — ffmpeg meurt, l'écriture suivante prend un EPIPE, et `io.Copy` remonte une erreur indiscernable d'une coupure réseau. Le handler ferme donc le transcodeur *avant* de statuer et regarde un signal sans ambiguïté : des octets sont entrés, aucun AAC n'est sorti. C'est le push qui est en cause, pas le serveur.

**`cmd.Wait` après l'EOF de stdout, pas en parallèle** — `Wait` ferme le pipe de sortie ; l'appeler pendant que la recopie lit encore tronquerait les derniers octets AAC. Le délai de grâce n'est donc plus un `select` sur `Wait` mais un `time.AfterFunc` qui tue le process, ce qui ferme son stdout et débloque la recopie par le même chemin.

**`audio/mp4` et `audio/webm` hors passthrough** — ce sont des conteneurs, pas de l'ADTS ; les laisser passer tels quels enverrait au segmenteur un flux qu'il ne sait pas muxer. Un test garde la frontière.

## Vérification

Tests automatisés — `488 passed in 23 packages` (`-race`), `golangci-lint` sans finding. Les tests d'intégration exercent le vrai ffmpeg (MP3/OGG/WAV → transcodeur → segmenteur, `ffprobe` sur le `.ts` produit) et sont ignorés proprement si ffmpeg est absent du PATH.

Critère d'acceptation **mesuré, pas estimé** : premier octet poussé → premier octet AAC transmis au segmenteur, sur un push découpé en blocs de 4 Kio comme un vrai direct.

```
latence ajoutée par le transcodage: 21.1ms   (budget de l'US : 2 s)
```

QA manuel sur la stack Docker, avec un ffmpeg en `-re` jouant le rôle d'un encodeur externe :

| Cas | Résultat |
|---|---|
| Push MP3 30 s en temps réel | 204 |
| Manifeste servi à l'auditeur | 2 segments |
| `ffprobe` sur le `.ts` téléchargé | `aac` |
| Push AAC (non-régression mobile) | 204, passthrough |
| Corps aléatoire annoncé `audio/mpeg` | 415 |

## Conséquences

- Un direct non-AAC coûte **deux** process ffmpeg au lieu d'un. `HLS_MAX_CONCURRENT` borne les auditeurs, pas les diffuseurs : la charge CPU d'un parc de diffuseurs non-AAC est à surveiller avant d'être un problème.
- Un push mal étiqueté reçoit désormais un 415 explicite au lieu d'un direct silencieux — changement de comportement visible pour un client qui poussait du MP3 en croyant que ça marchait.
- L'app mobile n'est pas touchée : elle pousse de l'AAC, elle reste sur le chemin direct. Le seul diff côté `mobile/` est un commentaire de doc dans le client généré.