### PR TITLE
feat(mobile): lecture audio en arrière-plan (US-04-03)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -380,7 +380,7 @@ Créer l'arborescence suivante dans `mobile/lib/features/<nom>/` :
 ### Lecture audio auditeur (STR-108/109)
 
 Voir [ADR 023](docs/adr/023-lecteur-audio-hls-mobile.md) (lecteur HLS) et
-[ADR 030](docs/adr/030-lecture-audio-en-arriere-plan.md) (arrière-plan).
+[ADR 031](docs/adr/031-lecture-audio-en-arriere-plan.md) (arrière-plan).
 
 - **Service partagé, app-level** : un unique `AudioPlayer` vit dans `StreamAudioHandler`
   (`core/audio/`, `audio_service` + just_audio), initialisé dans `main()` via `AudioService.init`
@@ -594,7 +594,7 @@ xcrun simctl openurl booted \
 | `docs/adr/012-openapi-source-de-verite.md` | Décision : OpenAPI source de vérité du contrat HTTP + client Dart/Dio généré |
 
 **Règle :** toute nouvelle décision d'architecture significative → nouvel ADR dans `docs/adr/`
-avec le numéro suivant (prochain : `031-...`). Référencer le ticket Linear correspondant.
+avec le numéro suivant (prochain : `032-...`). Référencer le ticket Linear correspondant.
 
 ## Principes SOLID
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -377,6 +377,32 @@ Créer l'arborescence suivante dans `mobile/lib/features/<nom>/` :
 - **IP LAN (sans câble)** : `--dart-define=API_BASE_URL=http://192.168.x.x:8080` (IP locale du Mac, `ipconfig getifaddr en0`). Nécessite même Wi-Fi + bind Docker sur `0.0.0.0` + firewall macOS ouvert sur 8080.
 - Configurable via `--dart-define=API_BASE_URL=http://...` ou variable d'environnement
 
+### Lecture audio auditeur (STR-108/109)
+
+Voir [ADR 023](docs/adr/023-lecteur-audio-hls-mobile.md) (lecteur HLS) et
+[ADR 030](docs/adr/030-lecture-audio-en-arriere-plan.md) (arrière-plan).
+
+- **Service partagé, app-level** : un unique `AudioPlayer` vit dans `StreamAudioHandler`
+  (`core/audio/`, `audio_service` + just_audio), initialisé dans `main()` via `AudioService.init`
+  et fourni par `app_providers.dart`. La lecture **survit à la navigation** et à l'arrière-plan /
+  verrouillage (notification + contrôles système).
+- **DIP** : le `AudioPlayerController` (app-level, `ChangeNotifierProvider`) dépend de l'abstraction
+  `AudioPlaybackService`, jamais de just_audio/audio_service directement → testable avec un fake
+  (`test/support/fake_audio_playback_service.dart`).
+- **Répartition** : le handler mappe l'état → notification et **transmet** les erreurs ; le
+  contrôleur garde l'arbitrage STR-118 (reconnexion bornée 1/2/4/8 s, gardes `_disposed`/`ended`).
+  État terminal → `stop()` retire la notification.
+- **Ambiguïté du 409** : le manifeste renvoie 409 pour un flux **terminé** *comme* pour un flux live
+  **pas encore prêt** (démarrage ~10 s). Le contrôleur ne conclut « terminé » via
+  `isManifestUnavailable` que si la lecture avait démarré (`_hasPlayed`) ; sinon il reconnecte
+  d'abord. La sonde utilise `validateStatus` (<500) pour ne pas logger de faux « erreur ».
+- **Mini-player** : `MiniPlayer` (dans `MainShell`) lit le même contrôleur (titre/diffuseur,
+  play/pause, croix = `stop`), masqué à l'état `idle`. Le plein écran (`StreamPlayerScreen`) lit
+  aussi ce contrôleur partagé et **ne le détruit pas**.
+- **Natif** : `MainActivity` étend `AudioServiceActivity` ; le manifeste déclare
+  `com.ryanheise.audioservice.AudioService` (`mediaPlayback`) + `MediaButtonReceiver` ; iOS a
+  `UIBackgroundModes: audio`. L'arrière-plan ne se teste **que sur device** (pas sur web).
+
 ### Authentification (mobile)
 
 Voir [ADR 009](docs/adr/009-authentification-flutter.md) pour les décisions détaillées.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -594,7 +594,7 @@ xcrun simctl openurl booted \
 | `docs/adr/012-openapi-source-de-verite.md` | Décision : OpenAPI source de vérité du contrat HTTP + client Dart/Dio généré |
 
 **Règle :** toute nouvelle décision d'architecture significative → nouvel ADR dans `docs/adr/`
-avec le numéro suivant (prochain : `032-...`). Référencer le ticket Linear correspondant.
+avec le numéro suivant (prochain : `033-...`). Référencer le ticket Linear correspondant.
 
 ## Principes SOLID
 

--- a/docs/adr/030-lecture-audio-en-arriere-plan.md
+++ b/docs/adr/030-lecture-audio-en-arriere-plan.md
@@ -1,0 +1,102 @@
+# ADR 030 — Lecture audio en arrière-plan (audio_service)
+
+**Date** : 2026-08-06
+**Statut** : Accepté
+**Ticket** : [STR-109](https://linear.app/streampulse/issue/STR-109) (US-04-03)
+
+## Contexte
+
+Le lecteur HLS de STR-108 ([ADR 023](023-lecteur-audio-hls-mobile.md)) était volontairement
+**scopé à l'écran** : un `AudioPlayer` just_audio créé/détruit avec `StreamPlayerScreen`. L'ADR 023
+l'annonçait déjà — « le contrôleur devra être **hissé en service** quand STR-109 arrivera ». Deux
+limites en découlaient :
+
+1. quitter l'écran (retour, autre onglet) **détruisait** le player → l'audio s'arrêtait ;
+2. verrouiller le téléphone ou mettre l'app en arrière-plan **coupait** le son (iOS suspend un
+   `AudioPlayer` sans session active ; Android tue la lecture sans service de premier plan).
+
+`audio_service` était déjà une dépendance choisie ([ADR 005](005-architecture-flutter-clean.md)),
+mais **jamais initialisée** : `MainActivity` était un `FlutterActivity` nu et le `<service>` du
+manifeste était mal nommé.
+
+## Décision
+
+**Hisser le lecteur en service partagé, au niveau application.** Un unique `AudioPlayer` est hébergé
+dans un `AudioHandler` `audio_service` (`StreamAudioHandler`), initialisé une fois dans `main()` via
+`AudioService.init(...)` et injecté dans l'arbre. Le lecteur survit ainsi à la navigation et à la
+mise en arrière-plan / au verrouillage, et publie une notification + des contrôles écran verrouillé.
+
+### 1. Frontière : `AudioPlaybackService` (DIP)
+
+Le `AudioPlayerController` dépend d'une abstraction étroite `AudioPlaybackService`
+(`playerStateStream`, `playbackErrors`, `loadUri`, `play`/`pause`/`stop`), **jamais**
+directement de just_audio ni d'audio_service. `StreamAudioHandler` l'implémente côté production ; un
+fake léger la remplace dans les tests. Le contrôleur reste donc testable sans plateforme ni device.
+
+### 2. Répartition des responsabilités
+
+- Le **handler** est « bête » : il mappe les événements du lecteur en `PlaybackState` (notification)
+  et **transmet** les erreurs au contrôleur — il ne décide pas de la reprise.
+- Le **contrôleur** garde tout l'arbitrage STR-118 (reconnexion bornée avec backoff, garde
+  `_disposed`, garde `ended` dans `_onPlayerState`). À l'état terminal (`ended`/`error`), il appelle
+  `stop()` pour retirer la notification.
+- **Ambiguïté du 409** (important) : le manifeste renvoie **409 aussi bien pour un flux terminé que
+  pour un flux live dont le manifeste n'est pas encore prêt** (fenêtre de démarrage ~10 s, segments
+  HLS de 10 s). Le contrôleur lève l'ambiguïté avec un flag `_hasPlayed` : il ne conclut « terminé »
+  immédiatement que si la lecture **avait démarré** (manifeste servi au moins une fois) ; sinon il
+  **reconnecte d'abord** (backoff 1+2+4+8 = 15 s) et ne conclut qu'après épuisement. La sonde
+  (`isManifestUnavailable`) accepte les <500 via `validateStatus` pour ne pas polluer les logs d'un
+  faux « erreur » sur un 404/409 attendu.
+- Les **contrôles système** (play/pause/stop de la notif) appellent le handler, dont l'état de
+  lecture se propage au contrôleur via `playerStateStream` → l'UI reste synchrone.
+
+### 3. Mini-player
+
+« Survivre à la navigation » impose une surface de contrôle in-app : un mini-player persistant est
+posé dans le `MainShell` (entre le contenu de l'onglet et la barre de navigation). Il lit le **même**
+contrôleur partagé (titre + diffuseur, play/pause, croix = `stop`), et se masque à l'état `idle`.
+
+### 4. Configuration native
+
+- **Android** : `MainActivity` étend `AudioServiceActivity` ; le manifeste déclare
+  `com.ryanheise.audioservice.AudioService` (`foregroundServiceType="mediaPlayback"`) + un
+  `MediaButtonReceiver`. Les permissions `FOREGROUND_SERVICE`/`FOREGROUND_SERVICE_MEDIA_PLAYBACK`
+  étaient déjà présentes.
+- **iOS** : `UIBackgroundModes: audio` (déjà présent) suffit avec la session `playback` gérée par
+  audio_service.
+
+### 5. Volume délégué au système (modèle Spotify)
+
+Le **slider de volume in-app** de STR-108 (exigé par STR-117) est **retiré** : comme sur Spotify, le
+volume est piloté par les **boutons matériels / le volume média de l'OS**. Le lecteur reste au volume
+par défaut (1.0) et n'expose plus `setVolume` — supprimé de `PlaybackController`,
+`AudioPlaybackService`, du handler et de l'UI. Cela évite un double contrôle (slider vs boutons) et
+aligne le comportement sur les apps de streaming. *(Supersède la partie « slider volume » de
+l'ADR 023 / STR-117.)*
+
+## Alternatives considérées
+
+- **`just_audio_background`** : plus simple, mais moins de contrôle sur la notification et non
+  retenu comme dépendance — `audio_service` était déjà le choix acté (ADR 005).
+- **Garder le player scopé + seulement une `AudioSession`** : donnerait l'arrière-plan sur iOS mais
+  pas le service de premier plan Android ni les contrôles système, et ne réglerait pas la survie à
+  la navigation. Rejeté.
+- **Déplacer toute la logique STR-118 dans le handler** : rejeté — coupler la reprise/sonde au
+  service isolé compliquerait les tests ; le contrôleur reste le cerveau, le handler le transport.
+
+## Conséquences
+
+- Lecture continue en arrière-plan / écran verrouillé, avec notification et contrôles système, et
+  qui survit à la navigation interne (mini-player).
+- La lecture ne s'arrête plus « toute seule » en quittant l'écran : l'utilisateur l'arrête via la
+  croix du mini-player, la notification, ou en lançant un autre flux.
+- **Non vérifiable sur le web** : l'arrière-plan est une fonctionnalité device (iOS/Android) ; à
+  valider sur téléphone. Les tests unitaires couvrent le contrôleur et le mini-player.
+- `audio_service` est désormais réellement initialisé ; toute future lecture on-demand (playlists)
+  réutilisera ce même handler partagé.
+
+## Références
+
+- [ADR 023](023-lecteur-audio-hls-mobile.md) — lecteur HLS scopé (STR-108), qui annonçait ce passage.
+- [ADR 005](005-architecture-flutter-clean.md) — Clean Architecture Flutter, choix d'`audio_service`.
+- STR-108 (lecteur play/pause/volume) · STR-118 (gestion des erreurs, reprise bornée).

--- a/docs/adr/031-lecture-audio-en-arriere-plan.md
+++ b/docs/adr/031-lecture-audio-en-arriere-plan.md
@@ -1,4 +1,4 @@
-# ADR 030 — Lecture audio en arrière-plan (audio_service)
+# ADR 031 — Lecture audio en arrière-plan (audio_service)
 
 **Date** : 2026-08-06
 **Statut** : Accepté
@@ -60,8 +60,12 @@ contrôleur partagé (titre + diffuseur, play/pause, croix = `stop`), et se masq
 
 - **Android** : `MainActivity` étend `AudioServiceActivity` ; le manifeste déclare
   `com.ryanheise.audioservice.AudioService` (`foregroundServiceType="mediaPlayback"`) + un
-  `MediaButtonReceiver`. Les permissions `FOREGROUND_SERVICE`/`FOREGROUND_SERVICE_MEDIA_PLAYBACK`
-  étaient déjà présentes.
+  `MediaButtonReceiver` ; permissions `FOREGROUND_SERVICE` / `FOREGROUND_SERVICE_MEDIA_PLAYBACK` /
+  `POST_NOTIFICATIONS` (cette dernière requise sur Android 13+ pour afficher la notification média).
+- **Contrainte SDK (important)** : `audio_service` 0.18.18 compile en `compileSdk 35` et n'appelle pas
+  `startForeground()` sous les règles de service de premier plan d'Android 16 (`targetSdk 36`) → ANR +
+  kill en arrière-plan. `targetSdk` est donc **épinglé à 35** (`android/app/build.gradle.kts`) le temps
+  que le plugin supporte le SDK 36. À relever quand ce sera le cas.
 - **iOS** : `UIBackgroundModes: audio` (déjà présent) suffit avec la session `playback` gérée par
   audio_service.
 

--- a/docs/adr/031-lecture-audio-en-arriere-plan.md
+++ b/docs/adr/031-lecture-audio-en-arriere-plan.md
@@ -60,12 +60,16 @@ contrôleur partagé (titre + diffuseur, play/pause, croix = `stop`), et se masq
 
 - **Android** : `MainActivity` étend `AudioServiceActivity` ; le manifeste déclare
   `com.ryanheise.audioservice.AudioService` (`foregroundServiceType="mediaPlayback"`) + un
-  `MediaButtonReceiver` ; permissions `FOREGROUND_SERVICE` / `FOREGROUND_SERVICE_MEDIA_PLAYBACK` /
-  `POST_NOTIFICATIONS` (cette dernière requise sur Android 13+ pour afficher la notification média).
-- **Contrainte SDK (important)** : `audio_service` 0.18.18 compile en `compileSdk 35` et n'appelle pas
-  `startForeground()` sous les règles de service de premier plan d'Android 16 (`targetSdk 36`) → ANR +
-  kill en arrière-plan. `targetSdk` est donc **épinglé à 35** (`android/app/build.gradle.kts`) le temps
-  que le plugin supporte le SDK 36. À relever quand ce sera le cas.
+  `MediaButtonReceiver`.
+- **Permissions Android (pièges vérifiés sur device)** :
+  - `WAKE_LOCK` — **indispensable** : `audio_service` prend un wake lock dans `enterPlayingState()` ;
+    sans cette permission (déclarée ni par le plugin ni implicitement), le check lève une
+    `RemoteException`, `startForeground()` n'est jamais appelé, et le système tue le process en
+    arrière-plan (~20 s). C'était la cause réelle du kill (pas la version de SDK).
+  - `POST_NOTIFICATIONS` (Android 13+) — déclarée **et demandée au runtime**
+    (`ensureNotificationPermission()` à l'ouverture du lecteur, via `permission_handler`) : sans la
+    demande, l'utilisateur ne l'accorde jamais → aucune notification ni contrôle écran verrouillé.
+  - `FOREGROUND_SERVICE` / `FOREGROUND_SERVICE_MEDIA_PLAYBACK` — déjà présentes.
 - **iOS** : `UIBackgroundModes: audio` (déjà présent) suffit avec la session `playback` gérée par
   audio_service.
 

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -25,11 +25,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion
-        // Épinglé à 35 : audio_service 0.18.18 compile en compileSdk 35 et
-        // n'appelle pas startForeground() sous les règles de service de premier
-        // plan d'Android 16 (SDK 36) → ANR + kill en arrière-plan (STR-109).
-        // À relever quand le plugin supportera le SDK 36 (cf. ADR 031).
-        targetSdk = 35
+        targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
     }

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -25,7 +25,11 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion
-        targetSdk = flutter.targetSdkVersion
+        // Épinglé à 35 : audio_service 0.18.18 compile en compileSdk 35 et
+        // n'appelle pas startForeground() sous les règles de service de premier
+        // plan d'Android 16 (SDK 36) → ANR + kill en arrière-plan (STR-109).
+        // À relever quand le plugin supportera le SDK 36 (cf. ADR 031).
+        targetSdk = 35
         versionCode = flutter.versionCode
         versionName = flutter.versionName
     }

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -34,10 +34,21 @@
                 <data android:scheme="streampulse" android:host="app"/>
             </intent-filter>
         </activity>
-        <!-- Service audio_service pour la lecture en arrière-plan -->
-        <service android:name="com.ryanheise.audioservice.AudioServiceFragment"
+        <!-- audio_service : service de premier plan + récepteur des boutons média
+             (casque / écran verrouillé) pour la lecture en arrière-plan (STR-109). -->
+        <service android:name="com.ryanheise.audioservice.AudioService"
             android:foregroundServiceType="mediaPlayback"
-            android:exported="true"/>
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.media.browse.MediaBrowserService"/>
+            </intent-filter>
+        </service>
+        <receiver android:name="com.ryanheise.audioservice.MediaButtonReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MEDIA_BUTTON"/>
+            </intent-filter>
+        </receiver>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,9 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
+    <!-- Android 13+ : requise pour afficher la notification média (contrôles
+         lecture / écran verrouillé) du service de premier plan (STR-109). -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
         android:label="streampulse"

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -3,8 +3,12 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
+    <!-- audio_service prend un wake lock dans enterPlayingState() : sans cette
+         permission, le check lève une RemoteException, startForeground() n'est
+         jamais appelé, et le système tue le process en arrière-plan (STR-109). -->
+    <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <!-- Android 13+ : requise pour afficher la notification média (contrôles
-         lecture / écran verrouillé) du service de premier plan (STR-109). -->
+         lecture / écran verrouillé) du service de premier plan. -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application

--- a/mobile/android/app/src/main/kotlin/fr/streampulse/streampulse/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/fr/streampulse/streampulse/MainActivity.kt
@@ -1,5 +1,7 @@
 package fr.streampulse.streampulse
 
-import io.flutter.embedding.android.FlutterActivity
+import com.ryanheise.audioservice.AudioServiceActivity
 
-class MainActivity : FlutterActivity()
+// audio_service exige que l'Activity hôte étende AudioServiceActivity pour que
+// le service de premier plan de lecture (STR-109) se rattache correctement.
+class MainActivity : AudioServiceActivity()

--- a/mobile/lib/app/app_providers.dart
+++ b/mobile/lib/app/app_providers.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 
+import '../core/audio/audio_playback_service.dart';
 import '../core/network/dio_client.dart';
 import '../core/storage/secure_storage.dart';
 import '../features/auth/data/datasources/auth_remote_data_source.dart';
@@ -21,6 +22,7 @@ import '../features/profile/presentation/providers/profile_controller.dart';
 import '../features/streams/data/datasources/stream_remote_data_source.dart';
 import '../features/streams/data/repositories/stream_repository_impl.dart';
 import '../features/streams/domain/repositories/stream_repository.dart';
+import '../features/streams/presentation/providers/audio_player_controller.dart';
 import '../features/streams/presentation/providers/discover_notifier.dart';
 import '../features/streams/presentation/providers/favorites_controller.dart';
 import '../features/streams/presentation/providers/stream_notifier.dart';
@@ -32,14 +34,22 @@ import '../features/streams/presentation/providers/stream_notifier.dart';
 /// dépendances via `context.read`, ce qui respecte le principe D (inversion
 /// de dépendances) : aucun concret n'est instancié en interne.
 class StreamPulseApp extends StatelessWidget {
-  const StreamPulseApp({super.key, required this.child});
+  const StreamPulseApp({
+    super.key,
+    required this.audioService,
+    required this.child,
+  });
 
+  /// Service de lecture partagé (STR-109), créé au démarrage dans `main()` puis
+  /// injecté ici : durée de vie = celle de l'application.
+  final AudioPlaybackService audioService;
   final Widget child;
 
   @override
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
+        Provider<AudioPlaybackService>.value(value: audioService),
         Provider<SecureStorage>(create: (_) => SecureStorage()),
         Provider<DioClient>(
           create: (ctx) => DioClient(ctx.read<SecureStorage>()),
@@ -104,6 +114,15 @@ class StreamPulseApp extends StatelessWidget {
         ),
         ChangeNotifierProvider<DiscoverNotifier>(
           create: (ctx) => DiscoverNotifier(ctx.read<StreamRepository>()),
+        ),
+        // Lecteur audio partagé (STR-109) : un seul contrôleur app-level pilote
+        // le service de premier plan ; le plein écran et le mini-player le lisent.
+        ChangeNotifierProvider<AudioPlayerController>(
+          create: (ctx) => AudioPlayerController(
+            service: ctx.read<AudioPlaybackService>(),
+            isManifestUnavailable:
+                ctx.read<StreamRepository>().isManifestUnavailable,
+          ),
         ),
       ],
       child: child,

--- a/mobile/lib/app/shell/main_shell.dart
+++ b/mobile/lib/app/shell/main_shell.dart
@@ -20,42 +20,45 @@ class MainShell extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      // Le mini-player (STR-109) se glisse entre le contenu de l'onglet et la
-      // barre de navigation ; masqué (SizedBox.shrink) quand rien ne joue.
-      body: Column(
+      body: navigationShell,
+      // Mini-player (STR-109) + barre de nav dans le `bottomNavigationBar` :
+      // hors du `body`, ils ne sont pas soumis à `resizeToAvoidBottomInset`
+      // (un clavier ne remonte donc pas le mini-player ni ne comprime l'onglet).
+      // Le mini-player est masqué (SizedBox.shrink) quand rien ne joue.
+      bottomNavigationBar: Column(
+        mainAxisSize: MainAxisSize.min,
         children: [
-          Expanded(child: navigationShell),
           const MiniPlayer(),
-        ],
-      ),
-      bottomNavigationBar: NavigationBar(
-        selectedIndex: navigationShell.currentIndex,
-        onDestinationSelected: _onDestinationSelected,
-        destinations: const [
-          NavigationDestination(
-            icon: Icon(Icons.home_outlined),
-            selectedIcon: Icon(Icons.home),
-            label: 'Accueil',
-          ),
-          NavigationDestination(
-            icon: Icon(Icons.library_music_outlined),
-            selectedIcon: Icon(Icons.library_music),
-            label: 'Bibliothèque',
-          ),
-          NavigationDestination(
-            icon: Icon(Icons.explore_outlined),
-            selectedIcon: Icon(Icons.explore),
-            label: 'Découvrir',
-          ),
-          NavigationDestination(
-            icon: Icon(Icons.grid_view_outlined),
-            selectedIcon: Icon(Icons.grid_view),
-            label: 'Tableau',
-          ),
-          NavigationDestination(
-            icon: Icon(Icons.person_outline),
-            selectedIcon: Icon(Icons.person),
-            label: 'Profil',
+          NavigationBar(
+            selectedIndex: navigationShell.currentIndex,
+            onDestinationSelected: _onDestinationSelected,
+            destinations: const [
+              NavigationDestination(
+                icon: Icon(Icons.home_outlined),
+                selectedIcon: Icon(Icons.home),
+                label: 'Accueil',
+              ),
+              NavigationDestination(
+                icon: Icon(Icons.library_music_outlined),
+                selectedIcon: Icon(Icons.library_music),
+                label: 'Bibliothèque',
+              ),
+              NavigationDestination(
+                icon: Icon(Icons.explore_outlined),
+                selectedIcon: Icon(Icons.explore),
+                label: 'Découvrir',
+              ),
+              NavigationDestination(
+                icon: Icon(Icons.grid_view_outlined),
+                selectedIcon: Icon(Icons.grid_view),
+                label: 'Tableau',
+              ),
+              NavigationDestination(
+                icon: Icon(Icons.person_outline),
+                selectedIcon: Icon(Icons.person),
+                label: 'Profil',
+              ),
+            ],
           ),
         ],
       ),

--- a/mobile/lib/app/shell/main_shell.dart
+++ b/mobile/lib/app/shell/main_shell.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../features/streams/presentation/widgets/mini_player.dart';
+
 /// Barre de navigation inférieure + `IndexedStack` des onglets
 /// (`StatefulShellRoute`) ; chaque onglet conserve son état.
 class MainShell extends StatelessWidget {
@@ -18,7 +20,14 @@ class MainShell extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: navigationShell,
+      // Le mini-player (STR-109) se glisse entre le contenu de l'onglet et la
+      // barre de navigation ; masqué (SizedBox.shrink) quand rien ne joue.
+      body: Column(
+        children: [
+          Expanded(child: navigationShell),
+          const MiniPlayer(),
+        ],
+      ),
       bottomNavigationBar: NavigationBar(
         selectedIndex: navigationShell.currentIndex,
         onDestinationSelected: _onDestinationSelected,

--- a/mobile/lib/core/audio/audio_playback_service.dart
+++ b/mobile/lib/core/audio/audio_playback_service.dart
@@ -1,0 +1,42 @@
+import 'package:just_audio/just_audio.dart' show PlayerState;
+
+/// Métadonnées du flux en cours, exposées à l'UI (mini-player, plein écran) et
+/// publiées comme `MediaItem` pour la notification / l'écran verrouillé (STR-109).
+class NowPlaying {
+  const NowPlaying({
+    required this.streamId,
+    required this.title,
+    this.broadcaster,
+  });
+
+  final String streamId;
+  final String title;
+  final String? broadcaster;
+}
+
+/// Service de lecture audio **partagé au niveau application** (DIP) : le
+/// [AudioPlayerController] en dépend, jamais directement de `just_audio` ni
+/// d'`audio_service`. L'implémentation de production ([StreamAudioHandler])
+/// enveloppe un lecteur natif hébergé dans un service de premier plan, ce qui
+/// permet la lecture en arrière-plan / écran verrouillé et les contrôles
+/// système (STR-109). Les tests injectent un fake léger.
+abstract class AudioPlaybackService {
+  /// État natif du lecteur (mappé en état applicatif par le contrôleur).
+  Stream<PlayerState> get playerStateStream;
+
+  /// Erreurs de lecture (perte réseau, flux terminé) — pilotent la reprise
+  /// automatique bornée du contrôleur (STR-118).
+  Stream<Object> get playbackErrors;
+
+  bool get playing;
+
+  /// Charge le manifeste [url] et publie les métadonnées [now] pour la
+  /// notification. Ne démarre pas la lecture (le contrôleur enchaîne).
+  Future<void> loadUri(String url, {required NowPlaying now});
+
+  Future<void> play();
+  Future<void> pause();
+
+  /// Arrête la lecture et retire la notification (fin de direct / fermeture).
+  Future<void> stop();
+}

--- a/mobile/lib/core/audio/stream_audio_handler.dart
+++ b/mobile/lib/core/audio/stream_audio_handler.dart
@@ -1,0 +1,96 @@
+import 'dart:async';
+
+import 'package:audio_service/audio_service.dart';
+import 'package:just_audio/just_audio.dart';
+
+import 'audio_playback_service.dart';
+
+/// Implémentation de [AudioPlaybackService] via `audio_service` + `just_audio`
+/// (STR-109, cf. ADR 030). Enveloppe **un seul** [AudioPlayer] hébergé par le
+/// service de premier plan `audio_service` : la lecture survit à la mise en
+/// arrière-plan / au verrouillage, et les transitions du lecteur alimentent la
+/// notification et les contrôles écran verrouillé (play/pause/stop).
+///
+/// Ce handler reste « bête » sur les erreurs : il les **transmet** au contrôleur
+/// (via [playbackErrors]) sans décider lui-même de la reprise — l'arbitrage
+/// sonde → `ended` versus reconnexion appartient au [AudioPlayerController]
+/// (STR-118), qui pilote ensuite `play`/`stop`.
+class StreamAudioHandler extends BaseAudioHandler
+    implements AudioPlaybackService {
+  StreamAudioHandler({AudioPlayer? player}) : _player = player ?? AudioPlayer() {
+    // Chaque événement du lecteur → un PlaybackState pour la notification. Les
+    // erreurs sont routées vers [playbackErrors] (le contrôleur les gère), et
+    // ne cassent pas le flux de la notification. Le handler vit aussi longtemps
+    // qu'`audio_service` : cet abonnement n'a pas à être annulé.
+    _player.playbackEventStream.listen(
+      (event) => playbackState.add(_transform(event)),
+      onError: (Object e, StackTrace _) => _errors.add(e),
+    );
+  }
+
+  final AudioPlayer _player;
+  final _errors = StreamController<Object>.broadcast();
+
+  @override
+  Stream<PlayerState> get playerStateStream => _player.playerStateStream;
+  @override
+  Stream<Object> get playbackErrors => _errors.stream;
+  @override
+  bool get playing => _player.playing;
+
+  @override
+  Future<void> loadUri(String url, {required NowPlaying now}) async {
+    // Métadonnées de l'écran verrouillé / notification. Un flux live n'a pas de
+    // durée : `isLive` masque la barre de progression côté OS.
+    mediaItem.add(
+      MediaItem(
+        id: now.streamId,
+        title: now.title,
+        artist: now.broadcaster,
+        isLive: true,
+      ),
+    );
+    await _player.setAudioSource(AudioSource.uri(Uri.parse(url)));
+  }
+
+  @override
+  Future<void> play() => _player.play();
+
+  @override
+  Future<void> pause() => _player.pause();
+
+  @override
+  Future<void> stop() async {
+    await _player.stop();
+    mediaItem.add(null); // retire la notification
+    await super.stop();
+  }
+
+  /// Mappe un événement just_audio vers l'état `audio_service` qui pilote la
+  /// notification (contrôles contextuels play/pause + stop).
+  PlaybackState _transform(PlaybackEvent event) {
+    final playing = _player.playing;
+    return PlaybackState(
+      controls: [
+        if (playing) MediaControl.pause else MediaControl.play,
+        MediaControl.stop,
+      ],
+      systemActions: const {
+        MediaAction.play,
+        MediaAction.pause,
+        MediaAction.stop,
+      },
+      androidCompactActionIndices: const [0, 1],
+      processingState: const {
+        ProcessingState.idle: AudioProcessingState.idle,
+        ProcessingState.loading: AudioProcessingState.loading,
+        ProcessingState.buffering: AudioProcessingState.buffering,
+        ProcessingState.ready: AudioProcessingState.ready,
+        ProcessingState.completed: AudioProcessingState.completed,
+      }[_player.processingState]!,
+      playing: playing,
+      updatePosition: _player.position,
+      bufferedPosition: _player.bufferedPosition,
+    );
+  }
+}

--- a/mobile/lib/core/audio/stream_audio_handler.dart
+++ b/mobile/lib/core/audio/stream_audio_handler.dart
@@ -6,7 +6,7 @@ import 'package:just_audio/just_audio.dart';
 import 'audio_playback_service.dart';
 
 /// Implémentation de [AudioPlaybackService] via `audio_service` + `just_audio`
-/// (STR-109, cf. ADR 030). Enveloppe **un seul** [AudioPlayer] hébergé par le
+/// (STR-109, cf. ADR 031). Enveloppe **un seul** [AudioPlayer] hébergé par le
 /// service de premier plan `audio_service` : la lecture survit à la mise en
 /// arrière-plan / au verrouillage, et les transitions du lecteur alimentent la
 /// notification et les contrôles écran verrouillé (play/pause/stop).
@@ -81,13 +81,17 @@ class StreamAudioHandler extends BaseAudioHandler
         MediaAction.stop,
       },
       androidCompactActionIndices: const [0, 1],
+      // `?? idle` : une valeur d'enum ajoutée par une future version de
+      // just_audio ne doit pas lever dans ce listener (ça tuerait le flux de
+      // playbackState → notification figée).
       processingState: const {
         ProcessingState.idle: AudioProcessingState.idle,
         ProcessingState.loading: AudioProcessingState.loading,
         ProcessingState.buffering: AudioProcessingState.buffering,
         ProcessingState.ready: AudioProcessingState.ready,
         ProcessingState.completed: AudioProcessingState.completed,
-      }[_player.processingState]!,
+      }[_player.processingState] ??
+          AudioProcessingState.idle,
       playing: playing,
       updatePosition: _player.position,
       bufferedPosition: _player.bufferedPosition,

--- a/mobile/lib/core/permissions/notification_permission.dart
+++ b/mobile/lib/core/permissions/notification_permission.dart
@@ -1,0 +1,19 @@
+import 'dart:io' show Platform;
+
+import 'package:permission_handler/permission_handler.dart';
+
+/// Demande la permission notifications (Android 13+) pour que la notification
+/// média du service de premier plan (STR-109) — et donc les contrôles écran
+/// verrouillé — soient visibles. Sans demande runtime, l'utilisateur ne
+/// l'accorde jamais et rien ne s'affiche.
+///
+/// No-op hors Android : iOS gère le Now Playing sans cette permission, et
+/// Android < 13 l'accorde implicitement. Le garde `Platform.isAndroid` évite
+/// tout appel de plateforme sur l'hôte de test.
+Future<void> ensureNotificationPermission() async {
+  if (!Platform.isAndroid) return;
+  final status = await Permission.notification.status;
+  if (status.isDenied) {
+    await Permission.notification.request();
+  }
+}

--- a/mobile/lib/features/streams/data/datasources/stream_remote_data_source.dart
+++ b/mobile/lib/features/streams/data/datasources/stream_remote_data_source.dart
@@ -45,17 +45,26 @@ class StreamRemoteDataSource {
     }
   }
 
-  /// Sonde le manifeste HLS **public** du flux pour déterminer s'il est terminé.
-  /// 200 → toujours en direct (`false`) ; 404/409 → le manifeste n'est plus
-  /// servi, le direct est terminé (`true`) ; toute autre issue (réseau, 5xx…) →
-  /// indéterminé (`false`), on laisse la reconnexion réseau opérer (STR-118).
-  Future<bool> isStreamEnded(String streamId) async {
+  /// Sonde le manifeste HLS **public** du flux : `true` si le manifeste n'est
+  /// plus servi (404/409), `false` sinon (200 en direct, ou réseau indéterminé).
+  ///
+  /// ⚠️ Le 409 est **ambigu** côté backend : il couvre aussi bien un flux
+  /// terminé qu'un flux live dont le manifeste n'est **pas encore prêt** (fenêtre
+  /// de démarrage ~10 s). L'appelant ([AudioPlayerController]) lève cette
+  /// ambiguïté en ne concluant « terminé » que si la lecture avait démarré.
+  ///
+  /// `validateStatus` accepte les <500 pour que 404/409 reviennent en réponse
+  /// normale (pas d'exception → pas de log d'erreur parasite ; STR-109).
+  Future<bool> isManifestUnavailable(String streamId) async {
     try {
-      await _api.streamPlaylist(id: streamId);
-      return false;
-    } on DioException catch (e) {
-      final code = e.response?.statusCode;
+      final response = await _api.streamPlaylist(
+        id: streamId,
+        validateStatus: (status) => status != null && status < 500,
+      );
+      final code = response.statusCode;
       return code == 404 || code == 409;
+    } on DioException {
+      return false; // réseau indéterminé → on ne conclut pas
     }
   }
 }

--- a/mobile/lib/features/streams/data/repositories/stream_repository_impl.dart
+++ b/mobile/lib/features/streams/data/repositories/stream_repository_impl.dart
@@ -31,6 +31,6 @@ class StreamRepositoryImpl implements StreamRepository {
       _remote.removeFavorite(streamId);
 
   @override
-  Future<bool> isStreamEnded(String streamId) =>
-      _remote.isStreamEnded(streamId);
+  Future<bool> isManifestUnavailable(String streamId) =>
+      _remote.isManifestUnavailable(streamId);
 }

--- a/mobile/lib/features/streams/domain/repositories/stream_repository.dart
+++ b/mobile/lib/features/streams/domain/repositories/stream_repository.dart
@@ -12,8 +12,9 @@ abstract class StreamRepository {
   /// Retire le flux des favoris (idempotent côté serveur).
   Future<void> removeFavorite(String streamId);
 
-  /// `true` si le direct est terminé (manifeste HLS public 404/409), `false`
-  /// sinon. Sert à distinguer une fin de direct d'une coupure réseau côté
-  /// lecteur (STR-118).
-  Future<bool> isStreamEnded(String streamId);
+  /// `true` si le manifeste HLS public n'est plus servi (404/409), `false` sinon
+  /// (200 en direct, ou réseau indéterminé). Le 409 étant ambigu (fin de direct
+  /// **ou** démarrage pas encore prêt), c'est le lecteur qui lève l'ambiguïté
+  /// (STR-118/109).
+  Future<bool> isManifestUnavailable(String streamId);
 }

--- a/mobile/lib/features/streams/presentation/providers/audio_player_controller.dart
+++ b/mobile/lib/features/streams/presentation/providers/audio_player_controller.dart
@@ -1,9 +1,12 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:just_audio/just_audio.dart';
+import 'package:just_audio/just_audio.dart' show PlayerState, ProcessingState;
 
+import '../../../../core/audio/audio_playback_service.dart';
 import '../../../../core/constants/api_constants.dart';
+
+export '../../../../core/audio/audio_playback_service.dart' show NowPlaying;
 
 /// État applicatif du lecteur, mappé depuis just_audio et exposé à l'UI.
 /// `reconnecting` = une erreur transitoire est en cours de reprise automatique
@@ -19,10 +22,10 @@ enum PlaybackStatus {
   error,
 }
 
-/// Abstraction du lecteur exposée à l'UI (Dependency Inversion) : l'écran dépend
-/// de cette interface, jamais directement de just_audio — ce qui permet de la
-/// remplacer par un fake dans les widget tests. Implémentée par
-/// [AudioPlayerController].
+/// Abstraction du lecteur exposée à l'UI (Dependency Inversion) : les écrans et
+/// le mini-player dépendent de cette interface, jamais directement de
+/// just_audio / audio_service — ce qui permet de la remplacer par un fake dans
+/// les widget tests. Implémentée par [AudioPlayerController].
 abstract class PlaybackController extends ChangeNotifier {
   PlaybackStatus get status;
   bool get isPlaying;
@@ -30,52 +33,63 @@ abstract class PlaybackController extends ChangeNotifier {
   bool get isReconnecting;
   bool get hasError;
   bool get isEnded;
-  double get volume;
 
-  Future<void> load(String streamId);
+  /// Flux en cours (titre + diffuseur), ou `null` si rien ne joue. Alimente le
+  /// mini-player et l'affichage plein écran.
+  NowPlaying? get nowPlaying;
+
+  Future<void> load(NowPlaying now);
   Future<void> togglePlayPause();
-  Future<void> setVolume(double value);
+
+  /// Arrête la lecture et repasse à l'état `idle` (fermeture du mini-player).
+  Future<void> stop();
 }
 
-/// Sonde l'état d'un flux à partir de son manifeste HLS **public** : renvoie
-/// `true` si le direct est terminé (manifeste 404/409), `false` sinon (200 ou
-/// erreur réseau indéterminée). Injectée dans [AudioPlayerController] pour
-/// distinguer « le direct est terminé » d'une simple coupure réseau (STR-118).
-typedef StreamEndedProbe = Future<bool> Function(String streamId);
+/// Sonde le manifeste HLS **public** : `true` s'il n'est plus servi (404/409),
+/// `false` sinon (200 en direct, ou réseau indéterminé). Le 409 étant ambigu
+/// (fin de direct **ou** démarrage pas encore prêt), le contrôleur ne conclut
+/// « terminé » qu'en le combinant à [_hasPlayed] (STR-118/109).
+typedef ManifestUnavailableProbe = Future<bool> Function(String streamId);
 
-/// Contrôleur du lecteur audio HLS (STR-116/118, cf. [ADR 023]). Enveloppe un
-/// [AudioPlayer] just_audio branché sur le manifeste **public** d'un flux et
-/// expose un état simple + play/pause/volume. Gère les erreurs (STR-118) par une
-/// **reconnexion automatique bornée** (perte réseau) puis un état d'erreur clair
-/// (flux indisponible). Scopé à l'écran player : appeler [dispose] à la sortie.
+/// Contrôleur du lecteur audio HLS, **hissé au niveau application** (STR-109,
+/// cf. [ADR 030]). Pilote un [AudioPlaybackService] partagé (service de premier
+/// plan `audio_service`) : la lecture survit à la navigation et à la mise en
+/// arrière-plan. Expose un état applicatif simple + play/pause (le volume est
+/// délégué au système, boutons matériels — pas de contrôle in-app), et gère
+/// les erreurs (STR-118) par une **reconnexion automatique bornée** (perte
+/// réseau) puis un état d'erreur clair (flux indisponible).
 class AudioPlayerController extends PlaybackController {
-  AudioPlayerController({AudioPlayer? player, StreamEndedProbe? isStreamEnded})
-      : _player = player ?? AudioPlayer(),
-        _isStreamEnded = isStreamEnded {
-    _stateSub = _player.playerStateStream.listen(_onPlayerState);
+  AudioPlayerController({
+    required AudioPlaybackService service,
+    ManifestUnavailableProbe? isManifestUnavailable,
+  })  : _service = service,
+        _isManifestUnavailable = isManifestUnavailable {
+    _stateSub = _service.playerStateStream.listen(_onPlayerState);
     // Les erreurs de lecture (perte réseau, flux terminé → manifeste 404/409)
-    // arrivent via le flux d'événements, pas via playerStateStream.
-    _eventSub = _player.playbackEventStream.listen(
-      (_) {},
-      onError: (Object e, StackTrace _) => _fail(e),
-    );
+    // arrivent via un flux dédié, pas via playerStateStream.
+    _errorSub = _service.playbackErrors.listen(_fail);
   }
 
-  /// Nombre de reconnexions automatiques avant d'abandonner (STR-118).
-  static const int _maxAutoRetries = 3;
+  /// Nombre de reconnexions automatiques avant d'abandonner (STR-118). Couvre
+  /// aussi la fenêtre de démarrage du manifeste (~10 s, segments HLS de 10 s) :
+  /// backoff 1+2+4+8 = 15 s avant de conclure sur un flux qui n'a jamais démarré.
+  static const int _maxAutoRetries = 4;
 
-  final AudioPlayer _player;
-  final StreamEndedProbe? _isStreamEnded;
+  final AudioPlaybackService _service;
+  final ManifestUnavailableProbe? _isManifestUnavailable;
   StreamSubscription<PlayerState>? _stateSub;
-  StreamSubscription<PlaybackEvent>? _eventSub;
+  StreamSubscription<Object>? _errorSub;
   Timer? _retryTimer;
 
-  String? _streamId;
+  NowPlaying? _nowPlaying;
   int _retryCount = 0;
   bool _recovering = false;
   bool _disposed = false;
+  // La lecture a-t-elle déjà atteint `ready` sur ce flux ? Sert à lever
+  // l'ambiguïté du 409 : si oui, un manifeste qui disparaît = fin de direct ; si
+  // non, c'est probablement la fenêtre de démarrage (manifeste pas encore prêt).
+  bool _hasPlayed = false;
   PlaybackStatus _status = PlaybackStatus.idle;
-  double _volume = 1;
   Object? _error;
 
   @override
@@ -92,32 +106,32 @@ class AudioPlayerController extends PlaybackController {
   @override
   bool get isEnded => _status == PlaybackStatus.ended;
   @override
-  double get volume => _volume;
+  NowPlaying? get nowPlaying => _nowPlaying;
   Object? get error => _error;
 
-  /// Charge le flux [streamId] et démarre la lecture (autoplay, STR-108).
-  /// Réinitialise le compteur de reconnexions (action utilisateur).
+  /// Charge le flux [now] et démarre la lecture (autoplay, STR-108). Réinitialise
+  /// le compteur de reconnexions (action utilisateur).
   @override
-  Future<void> load(String streamId) async {
-    _streamId = streamId;
+  Future<void> load(NowPlaying now) async {
+    _nowPlaying = now;
     _retryCount = 0;
-    await _start(streamId);
+    _hasPlayed = false;
+    await _start();
   }
 
-  /// (Re)démarre effectivement la lecture du flux — partagé par [load], le
-  /// retry automatique et [retry] (manuel). Ne touche pas au compteur.
-  Future<void> _start(String streamId) async {
+  /// (Re)démarre effectivement la lecture du flux courant — partagé par [load],
+  /// le retry automatique et [retry] (manuel). Ne touche pas au compteur.
+  Future<void> _start() async {
     if (_disposed) return;
+    final now = _nowPlaying;
+    if (now == null) return;
     _retryTimer?.cancel();
     _error = null;
     _setStatus(PlaybackStatus.loading);
     try {
-      await _player.setAudioSource(
-        AudioSource.uri(Uri.parse(ApiConstants.hlsPlaylist(streamId))),
-      );
+      await _service.loadUri(ApiConstants.hlsPlaylist(now.streamId), now: now);
       if (_disposed) return;
-      await _player.setVolume(_volume);
-      await _player.play();
+      await _service.play();
     } catch (e) {
       _fail(e);
     }
@@ -132,27 +146,30 @@ class AudioPlayerController extends PlaybackController {
       return;
     }
     if (isBusy || isReconnecting) return;
-    if (_player.playing) {
-      await _player.pause();
+    if (_service.playing) {
+      await _service.pause();
     } else {
-      await _player.play();
+      await _service.play();
     }
   }
 
   @override
-  Future<void> setVolume(double value) async {
-    _volume = value.clamp(0.0, 1.0).toDouble();
-    await _player.setVolume(_volume);
-    notifyListeners();
+  Future<void> stop() async {
+    _retryTimer?.cancel();
+    _retryCount = 0;
+    _hasPlayed = false;
+    _nowPlaying = null;
+    _error = null;
+    await _service.stop();
+    _setStatus(PlaybackStatus.idle);
   }
 
   /// Relance le flux courant à la demande de l'utilisateur (bouton « réessayer »),
   /// en réarmant les reconnexions automatiques.
   Future<void> retry() async {
-    final id = _streamId;
-    if (id == null) return;
+    if (_nowPlaying == null) return;
     _retryCount = 0;
-    await _start(id);
+    await _start();
   }
 
   void _onPlayerState(PlayerState state) {
@@ -175,6 +192,7 @@ class AudioPlayerController extends PlaybackController {
         _setStatus(PlaybackStatus.buffering);
       case ProcessingState.ready:
         _retryCount = 0; // lecture rétablie : on réarme les reconnexions futures
+        _hasPlayed = true; // le manifeste a été servi au moins une fois
         _setStatus(
           state.playing ? PlaybackStatus.playing : PlaybackStatus.paused,
         );
@@ -193,39 +211,51 @@ class AudioPlayerController extends PlaybackController {
     _recover();
   }
 
-  /// Décide de la suite après un échec : d'abord distinguer une **fin de direct**
-  /// (manifeste 404/409) d'une coupure réseau via la sonde, puis, si le flux est
-  /// toujours là, tenter une **reconnexion automatique bornée** avec backoff
-  /// (perte réseau), sinon basculer en erreur définitive (flux indisponible).
+  /// Décide de la suite après un échec (STR-118/109).
+  ///
+  /// On ne sonde le manifeste que lorsque c'est **décisif** : soit la lecture
+  /// avait démarré (sa disparition = fin de direct → `ended` immédiat), soit les
+  /// reconnexions sont épuisées (verdict final). Pendant la fenêtre de démarrage
+  /// (jamais joué, manifeste pas encore prêt → 409, comme une fin de direct) on
+  /// **reconnecte d'abord** plutôt que de conclure à tort « terminé ».
   Future<void> _recover() async {
     if (_recovering) return; // une seule reprise à la fois (échecs en rafale)
     _recovering = true;
     try {
-      final id = _streamId;
+      final id = _nowPlaying?.streamId;
       if (id == null) {
         _setStatus(PlaybackStatus.error);
         return;
       }
-      // Fin de direct : le manifeste n'est plus servi (404/409) → pas de retry.
-      final probe = _isStreamEnded;
-      if (probe != null && await probe(id)) {
-        if (_disposed) return;
+      final retriesExhausted = _retryCount >= _maxAutoRetries;
+      final probe = _isManifestUnavailable;
+      final manifestGone = probe != null &&
+          (_hasPlayed || retriesExhausted) &&
+          await probe(id);
+      if (_disposed) return;
+
+      // La lecture avait démarré et le manifeste a disparu → fin de direct.
+      if (manifestGone && _hasPlayed) {
         _setStatus(PlaybackStatus.ended);
+        await _service.stop(); // retire la notification (le direct est fini)
         return;
       }
-      if (_disposed) return;
-      // Coupure réseau : reconnexion automatique bornée avec backoff (1, 2, 4 s).
-      if (_retryCount < _maxAutoRetries) {
+      // Reconnexion automatique bornée (coupure réseau, ou manifeste pas encore
+      // prêt au démarrage) avec backoff 1, 2, 4, 8 s.
+      if (!retriesExhausted) {
         _retryCount++;
         _setStatus(PlaybackStatus.reconnecting);
         final delay = Duration(seconds: 1 << (_retryCount - 1));
         _retryTimer?.cancel();
         _retryTimer = Timer(delay, () {
-          if (!_disposed) _start(id);
+          if (!_disposed) _start();
         });
-      } else {
-        _setStatus(PlaybackStatus.error);
+        return;
       }
+      // Tentatives épuisées : manifeste jamais servi = flux terminé / pas live ;
+      // sinon indisponibilité réseau.
+      _setStatus(manifestGone ? PlaybackStatus.ended : PlaybackStatus.error);
+      await _service.stop(); // notification retirée
     } finally {
       _recovering = false;
     }
@@ -239,11 +269,12 @@ class AudioPlayerController extends PlaybackController {
 
   @override
   void dispose() {
+    // Contrôleur app-level : on libère nos abonnements, mais **pas** le service
+    // partagé (sa durée de vie est celle d'`audio_service`, gérée à part).
     _disposed = true;
     _retryTimer?.cancel();
     _stateSub?.cancel();
-    _eventSub?.cancel();
-    _player.dispose();
+    _errorSub?.cancel();
     super.dispose();
   }
 }

--- a/mobile/lib/features/streams/presentation/providers/audio_player_controller.dart
+++ b/mobile/lib/features/streams/presentation/providers/audio_player_controller.dart
@@ -52,7 +52,7 @@ abstract class PlaybackController extends ChangeNotifier {
 typedef ManifestUnavailableProbe = Future<bool> Function(String streamId);
 
 /// Contrôleur du lecteur audio HLS, **hissé au niveau application** (STR-109,
-/// cf. [ADR 030]). Pilote un [AudioPlaybackService] partagé (service de premier
+/// cf. [ADR 031]). Pilote un [AudioPlaybackService] partagé (service de premier
 /// plan `audio_service`) : la lecture survit à la navigation et à la mise en
 /// arrière-plan. Expose un état applicatif simple + play/pause (le volume est
 /// délégué au système, boutons matériels — pas de contrôle in-app), et gère
@@ -232,7 +232,9 @@ class AudioPlayerController extends PlaybackController {
       final manifestGone = probe != null &&
           (_hasPlayed || retriesExhausted) &&
           await probe(id);
-      if (_disposed) return;
+      // La sonde est asynchrone : si entre-temps l'utilisateur a fermé le
+      // lecteur (`stop()`) ou lancé un autre flux, cette reprise est caduque.
+      if (_disposed || _nowPlaying?.streamId != id) return;
 
       // La lecture avait démarré et le manifeste a disparu → fin de direct.
       if (manifestGone && _hasPlayed) {

--- a/mobile/lib/features/streams/presentation/screens/stream_player_screen.dart
+++ b/mobile/lib/features/streams/presentation/screens/stream_player_screen.dart
@@ -4,12 +4,12 @@ import 'package:provider/provider.dart';
 import '../../../../core/errors/exceptions.dart';
 import '../../../auth/presentation/widgets/auth_toasts.dart';
 import '../../domain/entities/live_stream.dart';
-import '../../domain/repositories/stream_repository.dart';
 import '../providers/audio_player_controller.dart';
 import '../providers/favorites_controller.dart';
 
 /// Lecteur audio HLS plein écran (STR-108/117, cf. ADR 023). L'audio est piloté
-/// par un [AudioPlayerController] scopé à cet écran (créé/détruit ici).
+/// par le [AudioPlayerController] **partagé** app-level (STR-109) : la lecture
+/// survit à la navigation et à l'arrière-plan ; l'écran ne le possède pas.
 class StreamPlayerScreen extends StatefulWidget {
   const StreamPlayerScreen({
     super.key,
@@ -21,8 +21,8 @@ class StreamPlayerScreen extends StatefulWidget {
   final String streamId;
   final LiveStream? stream;
 
-  /// Injecté par les widget tests (fake sans just_audio) ; en production, un
-  /// [AudioPlayerController] réel est créé et détruit par l'écran.
+  /// Injecté par les widget tests (fake sans just_audio) ; en production, le
+  /// [AudioPlayerController] **partagé** (app-level, STR-109) est lu du Provider.
   final PlaybackController? controller;
 
   @override
@@ -31,33 +31,28 @@ class StreamPlayerScreen extends StatefulWidget {
 
 class _StreamPlayerScreenState extends State<StreamPlayerScreen> {
   late final PlaybackController _audio;
-  late final bool _ownsController;
 
   @override
   void initState() {
     super.initState();
-    _ownsController = widget.controller == null;
-    // La sonde du manifeste public permet au lecteur de distinguer une fin de
-    // direct (404/409) d'une coupure réseau (STR-118). Injectée via le repo —
-    // uniquement quand l'écran crée le vrai contrôleur (les widget tests en
-    // injectent un fake et ne fournissent pas de StreamRepository).
-    _audio = widget.controller ??
-        AudioPlayerController(
-          isStreamEnded: context.read<StreamRepository>().isStreamEnded,
-        );
-    // Démarre la lecture du flux (autoplay). L'état des favoris est chargé pour
-    // afficher le bon état initial du cœur.
-    _audio.load(widget.streamId);
+    // Contrôleur partagé (le service audio survit à la navigation, STR-109) :
+    // l'écran ne le possède pas et ne le détruit pas.
+    _audio = widget.controller ?? context.read<AudioPlayerController>();
+    // (Re)démarre ce flux uniquement s'il n'est pas déjà en cours : revenir sur
+    // l'écran d'un flux en lecture ne le relance pas (autoplay sinon, STR-108).
+    if (_audio.nowPlaying?.streamId != widget.streamId) {
+      _audio.load(
+        NowPlaying(
+          streamId: widget.streamId,
+          title: widget.stream?.title ?? 'Flux',
+          broadcaster: widget.stream?.broadcasterName,
+        ),
+      );
+    }
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       context.read<FavoritesController>().ensureLoaded();
     });
-  }
-
-  @override
-  void dispose() {
-    if (_ownsController) _audio.dispose();
-    super.dispose();
   }
 
   Future<void> _toggleFavorite() async {
@@ -88,8 +83,11 @@ class _StreamPlayerScreenState extends State<StreamPlayerScreen> {
   Widget build(BuildContext context) {
     final colors = Theme.of(context).colorScheme;
     final text = Theme.of(context).textTheme;
-    final title = widget.stream?.title ?? 'Flux';
-    final subtitle = widget.stream?.broadcasterName; // nom du diffuseur (design)
+    // Métadonnées : celles passées en navigation, sinon celles du flux en cours
+    // dans le contrôleur partagé (ouverture via le mini-player, sans `extra`).
+    final title = widget.stream?.title ?? _audio.nowPlaying?.title ?? 'Flux';
+    final subtitle =
+        widget.stream?.broadcasterName ?? _audio.nowPlaying?.broadcaster;
     final listeners = widget.stream?.listenerCount;
     final isFavorited =
         context.watch<FavoritesController>().isFavorited(widget.streamId);
@@ -131,8 +129,6 @@ class _StreamPlayerScreenState extends State<StreamPlayerScreen> {
                       ],
                       const SizedBox(height: 24),
                       _statusLine(colors, text),
-                      const SizedBox(height: 16),
-                      _volume(colors),
                       const SizedBox(height: 28),
                       _controls(colors, isFavorited),
                       const SizedBox(height: 24),
@@ -284,21 +280,6 @@ class _StreamPlayerScreenState extends State<StreamPlayerScreen> {
         const SizedBox(width: 10),
         Text(label,
             style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant)),
-      ],
-    );
-  }
-
-  Widget _volume(ColorScheme colors) {
-    return Row(
-      children: [
-        Icon(Icons.volume_down, color: colors.onSurfaceVariant),
-        Expanded(
-          child: Slider(
-            value: _audio.volume,
-            onChanged: _audio.setVolume,
-          ),
-        ),
-        Icon(Icons.volume_up, color: colors.onSurfaceVariant),
       ],
     );
   }

--- a/mobile/lib/features/streams/presentation/screens/stream_player_screen.dart
+++ b/mobile/lib/features/streams/presentation/screens/stream_player_screen.dart
@@ -1,7 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../../../../core/errors/exceptions.dart';
+import '../../../../core/permissions/notification_permission.dart';
 import '../../../auth/presentation/widgets/auth_toasts.dart';
 import '../../domain/entities/live_stream.dart';
 import '../providers/audio_player_controller.dart';
@@ -38,6 +41,9 @@ class _StreamPlayerScreenState extends State<StreamPlayerScreen> {
     // Contrôleur partagé (le service audio survit à la navigation, STR-109) :
     // l'écran ne le possède pas et ne le détruit pas.
     _audio = widget.controller ?? context.read<AudioPlayerController>();
+    // Ouvrir le lecteur = intention d'écouter → on demande (Android 13+) la
+    // permission notifications pour que les contrôles média soient visibles.
+    unawaited(ensureNotificationPermission());
     // (Re)démarre ce flux uniquement s'il n'est pas déjà en cours : revenir sur
     // l'écran d'un flux en lecture ne le relance pas (autoplay sinon, STR-108).
     if (_audio.nowPlaying?.streamId != widget.streamId) {

--- a/mobile/lib/features/streams/presentation/widgets/mini_player.dart
+++ b/mobile/lib/features/streams/presentation/widgets/mini_player.dart
@@ -21,6 +21,16 @@ class MiniPlayer extends StatelessWidget {
     final colors = Theme.of(context).colorScheme;
     final text = Theme.of(context).textTheme;
 
+    // Sous-titre contextuel : l'état (terminé / indisponible / reconnexion)
+    // prime sur le nom du diffuseur, sinon le mini-player resterait muet en fin
+    // de direct (icône replay seule).
+    final (String? subtitle, Color subtitleColor) = switch (audio.status) {
+      PlaybackStatus.ended => ('Le direct est terminé', colors.error),
+      PlaybackStatus.error => ('Flux indisponible', colors.error),
+      PlaybackStatus.reconnecting => ('Reconnexion…', colors.onSurfaceVariant),
+      _ => (now.broadcaster, colors.onSurfaceVariant),
+    };
+
     return Material(
       color: colors.surfaceContainerHighest,
       child: InkWell(
@@ -44,13 +54,13 @@ class MiniPlayer extends StatelessWidget {
                       style: text.titleSmall
                           ?.copyWith(fontWeight: FontWeight.w600),
                     ),
-                    if (now.broadcaster != null && now.broadcaster!.isNotEmpty)
+                    if (subtitle != null && subtitle.isNotEmpty)
                       Text(
-                        now.broadcaster!,
+                        subtitle,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
-                        style: text.bodySmall
-                            ?.copyWith(color: colors.onSurfaceVariant),
+                        style:
+                            text.bodySmall?.copyWith(color: subtitleColor),
                       ),
                   ],
                 ),

--- a/mobile/lib/features/streams/presentation/widgets/mini_player.dart
+++ b/mobile/lib/features/streams/presentation/widgets/mini_player.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/audio_player_controller.dart';
+
+/// Mini-player persistant (STR-109) : surface de contrôle in-app du flux en
+/// cours, affichée au-dessus de la barre de navigation quand quelque chose joue.
+/// Tape → plein écran ; play/pause ; croix → arrêt. Masqué à l'état `idle`.
+class MiniPlayer extends StatelessWidget {
+  const MiniPlayer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final audio = context.watch<AudioPlayerController>();
+    final now = audio.nowPlaying;
+    if (now == null || audio.status == PlaybackStatus.idle) {
+      return const SizedBox.shrink();
+    }
+
+    final colors = Theme.of(context).colorScheme;
+    final text = Theme.of(context).textTheme;
+
+    return Material(
+      color: colors.surfaceContainerHighest,
+      child: InkWell(
+        onTap: () => context.push('/stream/${now.streamId}'),
+        child: SizedBox(
+          height: 60,
+          child: Row(
+            children: [
+              const SizedBox(width: 14),
+              Icon(Icons.graphic_eq, color: colors.primary),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      now.title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: text.titleSmall
+                          ?.copyWith(fontWeight: FontWeight.w600),
+                    ),
+                    if (now.broadcaster != null && now.broadcaster!.isNotEmpty)
+                      Text(
+                        now.broadcaster!,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: text.bodySmall
+                            ?.copyWith(color: colors.onSurfaceVariant),
+                      ),
+                  ],
+                ),
+              ),
+              _playPause(audio, colors),
+              IconButton(
+                onPressed: audio.stop,
+                icon: const Icon(Icons.close),
+                tooltip: 'Arrêter',
+              ),
+              const SizedBox(width: 4),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _playPause(AudioPlayerController audio, ColorScheme colors) {
+    if (audio.isBusy || audio.isReconnecting) {
+      return const Padding(
+        padding: EdgeInsets.all(14),
+        child: SizedBox(
+          width: 20,
+          height: 20,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+      );
+    }
+    final IconData icon;
+    if (audio.hasError || audio.isEnded) {
+      icon = Icons.replay;
+    } else if (audio.isPlaying) {
+      icon = Icons.pause;
+    } else {
+      icon = Icons.play_arrow;
+    }
+    return IconButton(
+      onPressed: audio.togglePlayPause,
+      color: colors.primary,
+      iconSize: 30,
+      icon: Icon(icon),
+      tooltip: audio.isPlaying ? 'Pause' : 'Lecture',
+    );
+  }
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,15 +1,32 @@
+import 'package:audio_service/audio_service.dart';
 import 'package:flutter/material.dart';
 
 import 'app/app.dart';
 import 'app/app_providers.dart';
+import 'core/audio/stream_audio_handler.dart';
 
 // StreamPulseApp pose le MultiProvider racine (injection de dépendances)
 // au-dessus de l'arbre de widgets.
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  // Service de lecture partagé, hébergé dans un service de premier plan pour la
+  // lecture en arrière-plan / écran verrouillé (STR-109, ADR 030). Créé une
+  // seule fois au démarrage et injecté dans l'arbre.
+  final audioHandler = await AudioService.init(
+    builder: StreamAudioHandler.new,
+    config: const AudioServiceConfig(
+      androidNotificationChannelId: 'fr.streampulse.streampulse.audio',
+      androidNotificationChannelName: 'Lecture StreamPulse',
+      androidNotificationOngoing: true,
+      androidStopForegroundOnPause: true,
+    ),
+  );
+
   runApp(
-    const StreamPulseApp(
-      child: App(),
+    StreamPulseApp(
+      audioService: audioHandler,
+      child: const App(),
     ),
   );
 }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -11,13 +11,17 @@ Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   // Service de lecture partagé, hébergé dans un service de premier plan pour la
-  // lecture en arrière-plan / écran verrouillé (STR-109, ADR 030). Créé une
+  // lecture en arrière-plan / écran verrouillé (STR-109, ADR 031). Créé une
   // seule fois au démarrage et injecté dans l'arbre.
   final audioHandler = await AudioService.init(
     builder: StreamAudioHandler.new,
     config: const AudioServiceConfig(
       androidNotificationChannelId: 'fr.streampulse.streampulse.audio',
       androidNotificationChannelName: 'Lecture StreamPulse',
+      // `ongoing` impose `stopForegroundOnPause` (assert d'audio_service). On
+      // reste sur le défaut recommandé : à la pause, le service repasse en
+      // arrière-plan (démotable). Sur un live, une reprise rejoint de toute
+      // façon le bord du direct — pas de « position » à perdre.
       androidNotificationOngoing: true,
       androidStopForegroundOnPause: true,
     ),

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -688,6 +688,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0+3"
+  permission_handler:
+    dependency: "direct main"
+    description:
+      name: permission_handler
+      sha256: "59adad729136f01ea9e35a48f5d1395e25cba6cea552249ddbe9cf950f5d7849"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.4.0"
+  permission_handler_android:
+    dependency: transitive
+    description:
+      name: permission_handler_android
+      sha256: d3971dcdd76182a0c198c096b5db2f0884b0d4196723d21a866fc4cdea057ebc
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.1.0"
+  permission_handler_apple:
+    dependency: transitive
+    description:
+      name: permission_handler_apple
+      sha256: "11b7e94a9d2fbee23c27f0cae0105c6266c03fd83b9a2eda6cf09141fc82624b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.5.0"
+  permission_handler_html:
+    dependency: transitive
+    description:
+      name: permission_handler_html
+      sha256: "6ea98b3f17f60d3b527f2647ed2ab4dc0f6bfe25b22cb1c363f5d8f62252f6ac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4+1"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      sha256: a5c8a97ecf5616112a5b16d4b8e9ec0e5ae90ef63ac69c0d7b8ae240be760b23
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.4.0"
+  permission_handler_windows:
+    dependency: transitive
+    description:
+      name: permission_handler_windows
+      sha256: caeae01858a0a7d2df67a445ac98e1ad95e55a0e77c73044f4e9b1c8c2289cbd
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
   platform:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -33,6 +33,9 @@ dependencies:
   just_audio: ^0.9.40
   audio_service: ^0.18.12
 
+  # Permission notifications (Android 13+) pour la notification média (STR-109)
+  permission_handler: ^11.3.1
+
   # WebSocket (chat live)
   web_socket_channel: ^3.0.1
 

--- a/mobile/test/features/profile/presentation/screens/profile_screen_test.dart
+++ b/mobile/test/features/profile/presentation/screens/profile_screen_test.dart
@@ -83,7 +83,7 @@ class _FakeStreamRepository implements StreamRepository {
       const [];
 
   @override
-  Future<bool> isStreamEnded(String streamId) async => false;
+  Future<bool> isManifestUnavailable(String streamId) async => false;
 }
 
 class _FakeProfileRepository implements ProfileRepository {

--- a/mobile/test/features/streams/presentation/providers/audio_player_controller_test.dart
+++ b/mobile/test/features/streams/presentation/providers/audio_player_controller_test.dart
@@ -181,5 +181,30 @@ void main() {
       expect(controller.status, PlaybackStatus.idle);
       expect(controller.nowPlaying, isNull);
     });
+
+    test('stop() pendant la sonde → la reprise caduque ne rebloque pas l\'état',
+        () async {
+      final service = FakeAudioPlaybackService();
+      final probe = Completer<bool>();
+      final controller = AudioPlayerController(
+        service: service,
+        isManifestUnavailable: (_) => probe.future,
+      );
+      addTearDown(controller.dispose);
+
+      await controller.load(_now);
+      _reachPlaying(service);
+      await pumpEventQueue();
+      service.emitError(Exception('x')); // _recover attend la sonde (hasPlayed)
+      await pumpEventQueue();
+
+      await controller.stop(); // l'utilisateur ferme le lecteur pendant la sonde
+      probe.complete(false); // la sonde se résout après coup
+      await pumpEventQueue();
+
+      // La reprise doit avorter (flux courant changé) et laisser l'état à idle,
+      // pas le rebloquer sur « reconnexion ».
+      expect(controller.status, PlaybackStatus.idle);
+    });
   });
 }

--- a/mobile/test/features/streams/presentation/providers/audio_player_controller_test.dart
+++ b/mobile/test/features/streams/presentation/providers/audio_player_controller_test.dart
@@ -2,158 +2,152 @@ import 'dart:async';
 
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:just_audio/just_audio.dart';
+import 'package:just_audio/just_audio.dart' show PlayerState, ProcessingState;
 import 'package:streampulse/features/streams/presentation/providers/audio_player_controller.dart';
 
-/// Fake AudioPlayer just_audio : n'implémente que les membres utilisés par
-/// [AudioPlayerController] (les autres passent par [noSuchMethod], jamais
-/// appelé ici). Permet de piloter les échecs de lecture sans plateforme ni
-/// device — la sonde [StreamEndedProbe] étant injectable, tout le cœur de
-/// STR-118 (`_recover`) devient testable unitairement.
-class _FakeAudioPlayer implements AudioPlayer {
-  final _stateCtrl = StreamController<PlayerState>.broadcast();
-  final _eventCtrl = StreamController<PlaybackEvent>.broadcast();
+import '../../../../support/fake_audio_playback_service.dart';
 
-  /// Si non nul, [setAudioSource] lève cette erreur (simule une source error).
-  Object? setAudioSourceError;
-  int setAudioSourceCalls = 0;
-  bool disposed = false;
-  bool _playing = false;
+const _now = NowPlaying(streamId: 's1', title: 'Flux test', broadcaster: 'DJ');
 
-  void emitState(PlayerState state) {
-    if (!_stateCtrl.isClosed) _stateCtrl.add(state);
-  }
-
-  @override
-  Stream<PlayerState> get playerStateStream => _stateCtrl.stream;
-  @override
-  Stream<PlaybackEvent> get playbackEventStream => _eventCtrl.stream;
-  @override
-  bool get playing => _playing;
-
-  @override
-  Future<Duration?> setAudioSource(
-    AudioSource source, {
-    bool preload = true,
-    int? initialIndex,
-    Duration? initialPosition,
-  }) async {
-    setAudioSourceCalls++;
-    final err = setAudioSourceError;
-    if (err != null) throw err;
-    return null;
-  }
-
-  @override
-  Future<void> setVolume(double volume) async {}
-  @override
-  Future<void> play() async => _playing = true;
-  @override
-  Future<void> pause() async => _playing = false;
-
-  @override
-  Future<void> dispose() async {
-    disposed = true;
-    await _stateCtrl.close();
-    await _eventCtrl.close();
-  }
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      super.noSuchMethod(invocation);
+/// Amène le contrôleur à l'état `playing` (le manifeste a été servi au moins une
+/// fois → `_hasPlayed`).
+void _reachPlaying(FakeAudioPlaybackService service) {
+  service.emitState(PlayerState(true, ProcessingState.ready));
 }
 
 void main() {
-  group('AudioPlayerController._recover (STR-118)', () {
-    test('sonde vraie (fin de direct) → ended, aucun retry armé', () async {
-      final player = _FakeAudioPlayer()..setAudioSourceError = Exception('404');
-      final controller = AudioPlayerController(
-        player: player,
-        isStreamEnded: (_) async => true,
-      );
-      addTearDown(controller.dispose);
-
-      await controller.load('s1');
-      await pumpEventQueue(); // laisse _recover attendre la sonde puis poser l'état
-
-      expect(controller.status, PlaybackStatus.ended);
-      expect(controller.isEnded, isTrue);
-      // Fin de direct : on ne réarme pas de tentative → une seule source posée.
-      expect(player.setAudioSourceCalls, 1);
-    });
-
-    test(
-        'sonde vraie posée, puis état résiduel du player → ended non écrasé',
+  group('AudioPlayerController._recover (STR-118 / STR-109)', () {
+    test('lecture démarrée puis manifeste disparu → ended immédiat, notif retirée',
         () async {
-      final player = _FakeAudioPlayer()..setAudioSourceError = Exception('409');
+      final service = FakeAudioPlaybackService();
       final controller = AudioPlayerController(
-        player: player,
-        isStreamEnded: (_) async => true,
+        service: service,
+        isManifestUnavailable: (_) async => true,
       );
       addTearDown(controller.dispose);
 
-      await controller.load('s1');
+      await controller.load(_now);
+      _reachPlaying(service);
       await pumpEventQueue();
-      expect(controller.status, PlaybackStatus.ended);
+      expect(controller.status, PlaybackStatus.playing);
 
-      // ExoPlayer émet un `idle` résiduel après la source error : ne doit pas
-      // faire régresser « terminé » en « en pause » (garde dans _onPlayerState).
-      player.emitState(PlayerState(false, ProcessingState.idle));
+      // Le diffuseur arrête : le player émet une erreur, le manifeste ne répond
+      // plus. Comme la lecture avait démarré → fin de direct, sans reconnexion.
+      service.emitError(Exception('source error'));
       await pumpEventQueue();
+
       expect(controller.status, PlaybackStatus.ended);
+      expect(service.stopped, isTrue);
+      expect(service.loadCalls, 1);
     });
 
     test(
-        'sonde fausse (coupure réseau) → reconnecting, puis error après 3 tentatives',
-        () {
+        'démarrage jamais joué : manifeste 409 (pas prêt) → reconnexion, pas de faux « terminé »',
+        () async {
+      // Le manifeste répond 409 comme s'il était terminé, mais c'est la fenêtre
+      // de démarrage : `_hasPlayed` étant faux, on ne doit PAS conclure « ended ».
+      final service = FakeAudioPlaybackService()..loadError = Exception('409');
+      final controller = AudioPlayerController(
+        service: service,
+        isManifestUnavailable: (_) async => true,
+      );
+      addTearDown(controller.dispose);
+
+      await controller.load(_now);
+      await pumpEventQueue();
+
+      expect(controller.status, PlaybackStatus.reconnecting);
+      expect(controller.isEnded, isFalse);
+    });
+
+    test('jamais prêt : ended après épuisement des reconnexions', () {
       fakeAsync((async) {
-        final player = _FakeAudioPlayer()
-          ..setAudioSourceError = Exception('network');
+        final service = FakeAudioPlaybackService()..loadError = Exception('409');
         final controller = AudioPlayerController(
-          player: player,
-          isStreamEnded: (_) async => false,
+          service: service,
+          isManifestUnavailable: (_) async => true,
         );
 
-        controller.load('s1');
+        controller.load(_now);
         async.flushMicrotasks();
-        // 1re tentative initiale échouée → reconnexion programmée.
         expect(controller.status, PlaybackStatus.reconnecting);
-        expect(player.setAudioSourceCalls, 1);
+        expect(service.loadCalls, 1);
 
-        // Backoff 1s, 2s, 4s : chaque réveil relance _start (qui échoue encore).
-        async.elapse(const Duration(seconds: 1));
+        // Backoff 1+2+4+8 = 15 s ; à l'épuisement le manifeste répond toujours
+        // 409 → verdict « terminé » (flux jamais réellement servi).
+        async.elapse(const Duration(seconds: 15));
         async.flushMicrotasks();
-        expect(player.setAudioSourceCalls, 2);
-        expect(controller.status, PlaybackStatus.reconnecting);
 
-        async.elapse(const Duration(seconds: 2));
-        async.flushMicrotasks();
-        expect(player.setAudioSourceCalls, 3);
-        expect(controller.status, PlaybackStatus.reconnecting);
-
-        async.elapse(const Duration(seconds: 4));
-        async.flushMicrotasks();
-        // 4e échec : tentatives épuisées → erreur définitive, plus de timer.
-        expect(player.setAudioSourceCalls, 4);
-        expect(controller.status, PlaybackStatus.error);
-
-        async.elapse(const Duration(seconds: 10));
-        async.flushMicrotasks();
-        expect(player.setAudioSourceCalls, 4); // aucun timer résiduel
+        expect(service.loadCalls, 5); // 1 initial + 4 reconnexions
+        expect(controller.status, PlaybackStatus.ended);
+        expect(service.stopped, isTrue);
 
         controller.dispose();
       });
     });
 
-    test(
-        'dispose() pendant l\'attente de la sonde → aucune notification, aucun timer résiduel',
+    test('coupure réseau (sonde false) → error après épuisement', () {
+      fakeAsync((async) {
+        final service = FakeAudioPlaybackService()
+          ..loadError = Exception('network');
+        final controller = AudioPlayerController(
+          service: service,
+          isManifestUnavailable: (_) async => false,
+        );
+
+        controller.load(_now);
+        async.flushMicrotasks();
+        expect(controller.status, PlaybackStatus.reconnecting);
+
+        async.elapse(const Duration(seconds: 15));
+        async.flushMicrotasks();
+
+        expect(service.loadCalls, 5);
+        expect(controller.status, PlaybackStatus.error);
+        expect(service.stopped, isTrue);
+
+        async.elapse(const Duration(seconds: 10));
+        async.flushMicrotasks();
+        expect(service.loadCalls, 5); // aucun timer résiduel
+
+        controller.dispose();
+      });
+    });
+
+    test('état résiduel idle après ended → non écrasé', () async {
+      final service = FakeAudioPlaybackService();
+      final controller = AudioPlayerController(
+        service: service,
+        isManifestUnavailable: (_) async => true,
+      );
+      addTearDown(controller.dispose);
+
+      await controller.load(_now);
+      _reachPlaying(service);
+      await pumpEventQueue();
+      service.emitError(Exception('stop'));
+      await pumpEventQueue();
+      expect(controller.status, PlaybackStatus.ended);
+
+      // `idle` résiduel du player après la source error : ne doit pas faire
+      // régresser « terminé » (garde dans _onPlayerState).
+      service.emitState(PlayerState(false, ProcessingState.idle));
+      await pumpEventQueue();
+      expect(controller.status, PlaybackStatus.ended);
+    });
+
+    test('dispose() pendant l\'attente de la sonde → aucune notification',
         () async {
-      final player = _FakeAudioPlayer()..setAudioSourceError = Exception('x');
+      final service = FakeAudioPlaybackService();
       final probe = Completer<bool>();
       final controller = AudioPlayerController(
-        player: player,
-        isStreamEnded: (_) => probe.future,
+        service: service,
+        isManifestUnavailable: (_) => probe.future,
       );
+
+      await controller.load(_now);
+      _reachPlaying(service);
+      await pumpEventQueue();
 
       var notificationsAfterDispose = 0;
       var disposed = false;
@@ -161,19 +155,31 @@ void main() {
         if (disposed) notificationsAfterDispose++;
       });
 
-      await controller.load('s1');
-      await pumpEventQueue(); // _recover est maintenant bloqué sur la sonde
+      service.emitError(Exception('x')); // → _recover attend la sonde (hasPlayed)
+      await pumpEventQueue();
 
       disposed = true;
       controller.dispose();
 
-      // La sonde se résout après coup : le contrôleur détruit ne doit ni
-      // notifier ni armer de timer (garde _disposed).
       probe.complete(true);
       await pumpEventQueue();
 
       expect(notificationsAfterDispose, 0);
-      expect(player.disposed, isTrue);
+    });
+
+    test('stop() arrête le service et repasse à idle', () async {
+      final service = FakeAudioPlaybackService();
+      final controller = AudioPlayerController(service: service);
+      addTearDown(controller.dispose);
+
+      await controller.load(_now);
+      await pumpEventQueue();
+      expect(controller.nowPlaying, isNotNull);
+
+      await controller.stop();
+      expect(service.stopped, isTrue);
+      expect(controller.status, PlaybackStatus.idle);
+      expect(controller.nowPlaying, isNull);
     });
   });
 }

--- a/mobile/test/features/streams/presentation/providers/favorites_controller_test.dart
+++ b/mobile/test/features/streams/presentation/providers/favorites_controller_test.dart
@@ -38,7 +38,7 @@ class _FakeRepository implements StreamRepository {
       const [];
 
   @override
-  Future<bool> isStreamEnded(String streamId) async => false;
+  Future<bool> isManifestUnavailable(String streamId) async => false;
 }
 
 void main() {

--- a/mobile/test/features/streams/presentation/providers/stream_notifier_test.dart
+++ b/mobile/test/features/streams/presentation/providers/stream_notifier_test.dart
@@ -34,7 +34,7 @@ class _FakeRepository implements StreamRepository {
   Future<void> removeFavorite(String streamId) async {}
 
   @override
-  Future<bool> isStreamEnded(String streamId) async => false;
+  Future<bool> isManifestUnavailable(String streamId) async => false;
 }
 
 class _PagingRepository implements StreamRepository {
@@ -59,7 +59,7 @@ class _PagingRepository implements StreamRepository {
   Future<void> removeFavorite(String streamId) async {}
 
   @override
-  Future<bool> isStreamEnded(String streamId) async => false;
+  Future<bool> isManifestUnavailable(String streamId) async => false;
 }
 
 void main() {

--- a/mobile/test/features/streams/presentation/screens/stream_player_screen_test.dart
+++ b/mobile/test/features/streams/presentation/screens/stream_player_screen_test.dart
@@ -30,13 +30,13 @@ class _FakePlaybackController extends PlaybackController {
   @override
   bool get isEnded => _status == PlaybackStatus.ended;
   @override
-  double get volume => 1;
+  NowPlaying? get nowPlaying => null;
   @override
-  Future<void> load(String streamId) async {}
+  Future<void> load(NowPlaying now) async {}
   @override
   Future<void> togglePlayPause() async {}
   @override
-  Future<void> setVolume(double value) async {}
+  Future<void> stop() async {}
 }
 
 /// Flux « réel » tel que renvoyé par le serveur (métadonnées complètes),
@@ -87,7 +87,7 @@ class _FakeStreamRepository implements StreamRepository {
       const [];
 
   @override
-  Future<bool> isStreamEnded(String streamId) async => false;
+  Future<bool> isManifestUnavailable(String streamId) async => false;
 }
 
 Widget _harness({

--- a/mobile/test/features/streams/presentation/widgets/mini_player_test.dart
+++ b/mobile/test/features/streams/presentation/widgets/mini_player_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:just_audio/just_audio.dart' show PlayerState, ProcessingState;
+import 'package:provider/provider.dart';
+
+import 'package:streampulse/features/streams/presentation/providers/audio_player_controller.dart';
+import 'package:streampulse/features/streams/presentation/widgets/mini_player.dart';
+
+import '../../../../support/fake_audio_playback_service.dart';
+
+Widget _host(AudioPlayerController controller) {
+  return ChangeNotifierProvider<AudioPlayerController>.value(
+    value: controller,
+    child: const MaterialApp(home: Scaffold(body: MiniPlayer())),
+  );
+}
+
+const _now = NowPlaying(streamId: 's1', title: 'Radio Nova', broadcaster: 'DJ Qa');
+
+void main() {
+  testWidgets('masqué quand rien ne joue (idle)', (tester) async {
+    final service = FakeAudioPlaybackService();
+    final controller = AudioPlayerController(service: service);
+    addTearDown(controller.dispose);
+    addTearDown(service.dispose);
+
+    await tester.pumpWidget(_host(controller));
+
+    expect(find.byType(MiniPlayer), findsOneWidget);
+    expect(find.byIcon(Icons.pause), findsNothing);
+    expect(find.byIcon(Icons.play_arrow), findsNothing);
+  });
+
+  testWidgets('affiche titre + diffuseur et le bouton pause en lecture',
+      (tester) async {
+    final service = FakeAudioPlaybackService();
+    final controller = AudioPlayerController(service: service);
+    addTearDown(controller.dispose);
+    addTearDown(service.dispose);
+
+    await controller.load(_now);
+    service.emitState(PlayerState(true, ProcessingState.ready)); // → playing
+    await tester.pumpWidget(_host(controller));
+    await tester.pump();
+
+    expect(find.text('Radio Nova'), findsOneWidget);
+    expect(find.text('DJ Qa'), findsOneWidget);
+    expect(find.byIcon(Icons.pause), findsOneWidget);
+  });
+
+  testWidgets('la croix arrête la lecture et masque le mini-player',
+      (tester) async {
+    final service = FakeAudioPlaybackService();
+    final controller = AudioPlayerController(service: service);
+    addTearDown(controller.dispose);
+    addTearDown(service.dispose);
+
+    await controller.load(_now);
+    service.emitState(PlayerState(true, ProcessingState.ready));
+    await tester.pumpWidget(_host(controller));
+    await tester.pump();
+    expect(find.text('Radio Nova'), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.close));
+    await tester.pump();
+
+    expect(service.stopped, isTrue);
+    expect(find.text('Radio Nova'), findsNothing); // idle → masqué
+  });
+}

--- a/mobile/test/features/streams/presentation/widgets/mini_player_test.dart
+++ b/mobile/test/features/streams/presentation/widgets/mini_player_test.dart
@@ -67,4 +67,27 @@ void main() {
     expect(service.stopped, isTrue);
     expect(find.text('Radio Nova'), findsNothing); // idle → masqué
   });
+
+  testWidgets('flux terminé → affiche « Le direct est terminé » + replay',
+      (tester) async {
+    final service = FakeAudioPlaybackService();
+    final controller = AudioPlayerController(
+      service: service,
+      isManifestUnavailable: (_) async => true,
+    );
+    addTearDown(controller.dispose);
+    addTearDown(service.dispose);
+
+    await controller.load(_now);
+    service.emitState(PlayerState(true, ProcessingState.ready)); // → playing
+    await tester.pumpWidget(_host(controller));
+    await tester.pump();
+
+    service.emitError(Exception('ended')); // manifeste disparu → ended
+    await tester.pumpAndSettle();
+
+    expect(find.text('Le direct est terminé'), findsOneWidget);
+    expect(find.byIcon(Icons.replay), findsOneWidget);
+    expect(find.text('DJ Qa'), findsNothing); // le statut prime sur le diffuseur
+  });
 }

--- a/mobile/test/support/fake_audio_playback_service.dart
+++ b/mobile/test/support/fake_audio_playback_service.dart
@@ -1,0 +1,59 @@
+import 'dart:async';
+
+import 'package:just_audio/just_audio.dart' show PlayerState;
+import 'package:streampulse/core/audio/audio_playback_service.dart';
+
+/// Fake [AudioPlaybackService] pilotable, sans just_audio ni audio_service : les
+/// flux d'état / d'erreur sont poussés manuellement, `loadUri` peut échouer à la
+/// demande. Rend le cœur de STR-118 (`_recover`) et le démarrage app-level
+/// testables unitairement (STR-109).
+class FakeAudioPlaybackService implements AudioPlaybackService {
+  final _stateCtrl = StreamController<PlayerState>.broadcast();
+  final _errorCtrl = StreamController<Object>.broadcast();
+
+  /// Si non nul, [loadUri] lève cette erreur (simule une source error).
+  Object? loadError;
+  int loadCalls = 0;
+  bool stopped = false;
+  NowPlaying? lastNow;
+  bool _playing = false;
+
+  void emitState(PlayerState state) {
+    if (!_stateCtrl.isClosed) _stateCtrl.add(state);
+  }
+
+  void emitError(Object error) {
+    if (!_errorCtrl.isClosed) _errorCtrl.add(error);
+  }
+
+  @override
+  Stream<PlayerState> get playerStateStream => _stateCtrl.stream;
+  @override
+  Stream<Object> get playbackErrors => _errorCtrl.stream;
+  @override
+  bool get playing => _playing;
+
+  @override
+  Future<void> loadUri(String url, {required NowPlaying now}) async {
+    loadCalls++;
+    lastNow = now;
+    final err = loadError;
+    if (err != null) throw err;
+  }
+
+  @override
+  Future<void> play() async => _playing = true;
+  @override
+  Future<void> pause() async => _playing = false;
+
+  @override
+  Future<void> stop() async {
+    stopped = true;
+    _playing = false;
+  }
+
+  Future<void> dispose() async {
+    await _stateCtrl.close();
+    await _errorCtrl.close();
+  }
+}

--- a/mobile/test/widget_test.dart
+++ b/mobile/test/widget_test.dart
@@ -4,10 +4,15 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:streampulse/app/app.dart';
 import 'package:streampulse/app/app_providers.dart';
 
+import 'support/fake_audio_playback_service.dart';
+
 void main() {
   testWidgets('App démarre sans erreur', (WidgetTester tester) async {
+    final audioService = FakeAudioPlaybackService();
+    addTearDown(audioService.dispose);
+
     await tester.pumpWidget(
-      const StreamPulseApp(child: App()),
+      StreamPulseApp(audioService: audioService, child: const App()),
     );
     expect(find.byType(MaterialApp), findsOneWidget);
   });


### PR DESCRIPTION
## Contexte

Implémente **STR-109 (US-04-03)** : la lecture audio continue en **arrière-plan / écran verrouillé** et **survit à la navigation** interne. Le lecteur HLS de STR-108, scopé à l'écran, est **hissé en service partagé** `audio_service` — comme annoncé par l'ADR 023.

Refs: STR-109

## Changements

- **Service audio partagé, app-level** : `StreamAudioHandler` (`audio_service` + just_audio) enveloppe un unique lecteur, initialisé dans `main()` (`AudioService.init`) et injecté via `app_providers`. La lecture survit à l'arrière-plan / au verrouillage (notification + contrôles écran verrouillé) et à la navigation.
- **Refactor `AudioPlayerController`** en contrôleur partagé (DIP via l'abstraction `AudioPlaybackService`, testable avec un fake) ; conserve toute la reprise bornée STR-118 (gardes `_disposed` / `ended`).
- **Mini-player** persistant dans le `MainShell` (titre + diffuseur, play/pause, croix = arrêt), masqué à l'état `idle`.
- **Détection de fin de direct durcie** : le manifeste renvoie **409 aussi bien pour un flux terminé que pour un flux pas encore prêt** (fenêtre de démarrage ~10 s). La sonde `isManifestUnavailable` (`validateStatus` <500 → plus de faux log d'erreur) n'est décisive que combinée au flag `_hasPlayed`, sinon on reconnecte d'abord (backoff 1+2+4+8 s) → **plus de faux « Le direct est terminé » au démarrage**.
- **Volume délégué au système** (modèle Spotify) : slider retiré, `setVolume` supprimé de toute la chaîne — le volume média de l'OS (boutons matériels) pilote le son. *Supersède le slider de STR-117.*
- **Config native** : `MainActivity` → `AudioServiceActivity` ; manifeste Android corrigé (`com.ryanheise.audioservice.AudioService` type `mediaPlayback` + `MediaButtonReceiver`) ; iOS `UIBackgroundModes: audio` déjà présent.
- **Doc & tests** : ADR 030, section mobile de `CLAUDE.md` ; couverture unitaire du contrôleur (fin de direct vs warm-up, backoff, `dispose`, `stop`) et du mini-player sur un fake `AudioPlaybackService`.

## Comment tester

1. `cd mobile && flutter analyze`
2. `cd mobile && flutter test` (333 tests)
3. Diffuseur de test (tonalité, sans micro) — depuis la racine, l'API Docker tournant :
   ```bash
   API=http://localhost:8080
   TOKEN=$(curl -sS -X POST $API/api/auth/login -H 'Content-Type: application/json' -d '{"email":"broadcaster@streampulse.dev","password":"Password123!"}' | grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)
   CREATE=$(curl -sS -X POST $API/api/streams -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d '{"title":"Test arrière-plan","is_public":true}')
   ID=$(echo "$CREATE" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4); KEY=$(echo "$CREATE" | grep -o '"stream_key":"[^"]*"' | cut -d'"' -f4)
   curl -sS -X PATCH $API/api/streams/$ID/start -H "Authorization: Bearer $TOKEN"
   docker compose exec -T api ffmpeg -re -f lavfi -i "sine=frequency=440:sample_rate=44100" -c:a aac -b:a 128k -content_type audio/aac -method POST -f adts "http://localhost:8080/api/streams/ingest/$KEY"
   ```
4. Auditeur (**user1**) sur device → **Accueil/Découvrir** → *Test arrière-plan* → vérifier : verrouillage (contrôles lockscreen), arrière-plan (notification play/pause), autre onglet (mini-player), boutons de volume matériels, et « Le direct est terminé » à l'arrêt du diffuseur.

## Checklist

- [x] Les commits suivent Conventional Commits
- [x] Le titre de la PR suit Conventional Commits
- [x] La branche est à jour avec develop
- [x] Les tests passent localement (333 tests, `flutter analyze` clean)
- [x] Aucun secret / .env committé
- [x] La doc est mise à jour si nécessaire (ADR 030, `CLAUDE.md`)

## QA appareil

Validé sur iPhone : lecture, **continuité en arrière-plan et écran verrouillé** avec contrôles depuis la notification, **mini-player** persistant entre les onglets, **retrait de la barre de volume** (boutons matériels OK), et « **Le direct est terminé** » à l'arrêt du diffuseur. Le warm-up (409 → 200 au démarrage) ne produit plus de faux « terminé ».

🤖 Generated with [Claude Code](https://claude.com/claude-code)
