### PR TITLE
feat: lecture d'une playlist avec file d'attente (US-05-04)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -443,8 +443,12 @@ Voir [ADR 033](docs/adr/033-lecture-dune-playlist-avec-file-dattente.md).
 - **Auth du lecteur natif** : le binaire d'une piste est privé, chaque `AudioSource` porte un
   `Authorization`. just_audio ouvrant ses propres connexions HTTP, il ne traverse pas les
   intercepteurs de `DioClient` : `PlaybackAuth` (`core/audio/`) fournit le token, et
-  `DioClient.refreshTokens()` (public) permet **une** reprise après rotation quand la file dure plus
-  que les 15 min d'un access token. Jamais de token en paramètre d'URL.
+  `DioClient.refreshTokens()` (public) alimente la reprise. Jamais de token en paramètre d'URL.
+- **Reprise après échec** : bornée à 3 tentatives, backoff 1/2/4 s, position conservée, et **seule
+  la première** force une rotation de token (une expiration se règle en une rotation). Le compteur
+  ne se réarme qu'à une action utilisateur ou à un changement de piste — pas sur `ready`, sinon un
+  réseau instable relancerait la même piste sans fin. La cause de l'échec n'est pas devinée :
+  just_audio ne remonte pas le statut HTTP (ADR 033 §5).
 - **UI** : bouton « Lire » + appui sur une ligne dans `PlaylistDetailScreen` (démarre à cette
   piste), `QueueMiniPlayer` (précédent/play/suivant/croix), `PlaybackQueueSheet` (file visible,
   appui = saut). La file est une **photo** des pistes au lancement : réordonner la playlist ne

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,9 +283,10 @@ Actions de niveau `user` (`auth.RequireAuth` seul, pas de rôle : l'US vise « d
 |---|---|---|---|
 | POST | `/api/tracks` | `Handler.Upload` | Oui (JWT) — **upload multipart** (`file` + `title` requis, `artist`/`duration_s` optionnels) d'un audio MP3/AAC/OGG ≤ 50 Mo. MIME **sniffé côté serveur** (PDF renommé `.mp3` → 415) ; fichier stocké hors répertoire servi, piste référencée en base (201). 400 (titre/fichier manquant), 403 (quota de stockage/compte dépassé, `MaxUserStorageBytes` = 500 Mo — **403 et non 507** : condition client, hors bucket 5xx/alerte), 409 (titre en doublon `uq_tracks_user_title`), 413 (> 50 Mo), 415 (non-audio, prioritaire sur le quota) |
 | GET | `/api/tracks` | `Handler.ListUserTracks` | Oui (JWT) — bibliothèque de pistes du demandeur, source du sélecteur d'ajout (US-05-03) |
+| GET | `/api/tracks/{id}/stream` | `Handler.StreamTrack` | Oui (JWT) — sert le **binaire audio** d'une piste au lecteur mobile (US-05-04, [ADR 033](docs/adr/033-lecture-dune-playlist-avec-file-dattente.md)). Propriété vérifiée en SQL → piste d'un tiers = **404** (jamais 403 : ne pas révéler son existence) ; `http.ServeContent` honore les requêtes `Range` (206) ; `Content-Type` pris en base (jamais deviné) ; `Cache-Control: private, no-store`. Fichier absent du volume alors que la ligne existe → 404 + log `error` |
 
 - Table `tracks` préexistante (migration `000003`) : `file_path`/`mime_type` (CHECK `audio/mpeg|aac|ogg`)/`file_size`/`duration_s` (CHECK `> 0`) ; contrainte `uq_tracks_user_title (user_id, title)` (`000006`). **Aucune migration** ajoutée par l'US-05-01.
-- Stockage : `track.FileStorage` écrit sous `STORAGE_PATH` (volume Docker `track_storage`, `/data/tracks`), nom = UUID + extension canonique (jamais le nom client → anti-traversal). Interface `track.Storage` (`Save`/`Remove`) pour découpler d'un futur stockage objet.
+- Stockage : `track.FileStorage` écrit sous `STORAGE_PATH` (volume Docker `track_storage`, `/data/tracks`), nom = UUID + extension canonique (jamais le nom client → anti-traversal). Interface `track.Storage` (`Save`/`Open`/`Remove`) pour découpler d'un futur stockage objet ; `Open` renvoie un `StoredFile` (`ReadSeeker` + `Closer` — le `Seek` est ce qui rend les requêtes `Range` possibles).
 - Validation MIME par **sniff de contenu** (`github.com/gabriel-vasile/mimetype`), normalisé vers la valeur canonique du CHECK DB. Durée = champ client optionnel (pas d'extraction ffprobe). Détails [ADR 032](docs/adr/032-domaine-track-upload-audio.md).
 - **Quota** : `MaxUserStorageBytes` (500 Mo) vérifié après `detectAudio` et avant écriture → **403** (`storage_quota_exceeded`, hors bucket 5xx) ; `ParseMultipartForm` borné à 1 Mio en mémoire (débordement disque temporaire) pour éviter l'OOM sous uploads concurrents. Borne de concurrence globale + alerte disque/cap global : tickets séparés.
 - **Nettoyage des fichiers** : la suppression d'un compte (`admin.DeleteUser` **et** `auth.DeleteAccount`) passe par `track.Service.PurgeUserTracks(userID, deleteUser)` (injecté par `SetTrackPurger`, interface `UserTrackPurger`). Il **enrobe** le hard-delete : relève les chemins → exécute `deleteUser` (cascade DB sur `tracks`) → supprime les fichiers du volume **seulement si le delete a réussi** (pas de ligne fantôme). Best-effort. Pas encore de `DELETE /api/tracks/{id}` (hors périmètre US-05-01).
@@ -396,13 +397,18 @@ Créer l'arborescence suivante dans `mobile/lib/features/<nom>/` :
 
 ### Lecture audio auditeur (STR-108/109)
 
-Voir [ADR 023](docs/adr/023-lecteur-audio-hls-mobile.md) (lecteur HLS) et
-[ADR 031](docs/adr/031-lecture-audio-en-arriere-plan.md) (arrière-plan).
+Voir [ADR 023](docs/adr/023-lecteur-audio-hls-mobile.md) (lecteur HLS),
+[ADR 031](docs/adr/031-lecture-audio-en-arriere-plan.md) (arrière-plan) et
+[ADR 033](docs/adr/033-lecture-dune-playlist-avec-file-dattente.md) (file d'attente).
 
 - **Service partagé, app-level** : un unique `AudioPlayer` vit dans `StreamAudioHandler`
   (`core/audio/`, `audio_service` + just_audio), initialisé dans `main()` via `AudioService.init`
   et fourni par `app_providers.dart`. La lecture **survit à la navigation** et à l'arrière-plan /
   verrouillage (notification + contrôles système).
+- **Deux interfaces sur ce lecteur unique** (ISP, ADR 033) : `PlaybackTransport` (play/pause/stop +
+  flux d'état/erreurs) est étendu par `AudioPlaybackService` (`loadUri`, direct) et
+  `QueuePlaybackService` (`loadQueue`/`skipToIndex`/`currentIndexStream`, file d'attente).
+  `StreamAudioHandler` implémente les deux ; `main()` l'injecte sous ses deux rôles.
 - **DIP** : le `AudioPlayerController` (app-level, `ChangeNotifierProvider`) dépend de l'abstraction
   `AudioPlaybackService`, jamais de just_audio/audio_service directement → testable avec un fake
   (`test/support/fake_audio_playback_service.dart`).
@@ -413,12 +419,36 @@ Voir [ADR 023](docs/adr/023-lecteur-audio-hls-mobile.md) (lecteur HLS) et
   **pas encore prêt** (démarrage ~10 s). Le contrôleur ne conclut « terminé » via
   `isManifestUnavailable` que si la lecture avait démarré (`_hasPlayed`) ; sinon il reconnecte
   d'abord. La sonde utilise `validateStatus` (<500) pour ne pas logger de faux « erreur ».
-- **Mini-player** : `MiniPlayer` (dans `MainShell`) lit le même contrôleur (titre/diffuseur,
-  play/pause, croix = `stop`), masqué à l'état `idle`. Le plein écran (`StreamPlayerScreen`) lit
-  aussi ce contrôleur partagé et **ne le détruit pas**.
+- **Mini-player** : `MiniPlayer` (titre/diffuseur, play/pause, croix = `stop`) est masqué à l'état
+  `idle`. Le plein écran (`StreamPlayerScreen`) lit aussi ce contrôleur partagé et **ne le détruit
+  pas**. Dans `MainShell`, c'est `PlayerBar` (`app/shell/`) qui choisit entre ce mini-player et
+  celui de la file d'attente.
 - **Natif** : `MainActivity` étend `AudioServiceActivity` ; le manifeste déclare
   `com.ryanheise.audioservice.AudioService` (`mediaPlayback`) + `MediaButtonReceiver` ; iOS a
   `UIBackgroundModes: audio`. L'arrière-plan ne se teste **que sur device** (pas sur web).
+
+### Lecture d'une playlist avec file d'attente (US-05-04)
+
+Voir [ADR 033](docs/adr/033-lecture-dune-playlist-avec-file-dattente.md).
+
+- **`PlaylistQueueController`** (app-level, `features/playlists/presentation/providers/`) : lance une
+  playlist, expose la file et l'index courant. L'**enchaînement est délégué au lecteur natif**
+  (`ConcatenatingAudioSource`, qui précharge la suivante) ; le contrôleur suit
+  `currentIndexStream` — un saut fait depuis la notification système remonte donc par le même
+  chemin qu'un appui dans l'app, sans seconde source de vérité.
+- **Un lecteur pour deux sources** : démarrer une file appelle `stopLive` (→ `AudioPlayerController
+  .stop`) ; démarrer un direct appelle `onTakeOver` (→ `PlaylistQueueController.clear`, qui vide la
+  file **sans** toucher au lecteur — l'arrêter couperait le direct). Câblage croisé dans
+  `app_providers.dart`, arbitrage d'affichage dans `PlayerBar`.
+- **Auth du lecteur natif** : le binaire d'une piste est privé, chaque `AudioSource` porte un
+  `Authorization`. just_audio ouvrant ses propres connexions HTTP, il ne traverse pas les
+  intercepteurs de `DioClient` : `PlaybackAuth` (`core/audio/`) fournit le token, et
+  `DioClient.refreshTokens()` (public) permet **une** reprise après rotation quand la file dure plus
+  que les 15 min d'un access token. Jamais de token en paramètre d'URL.
+- **UI** : bouton « Lire » + appui sur une ligne dans `PlaylistDetailScreen` (démarre à cette
+  piste), `QueueMiniPlayer` (précédent/play/suivant/croix), `PlaybackQueueSheet` (file visible,
+  appui = saut). La file est une **photo** des pistes au lancement : réordonner la playlist ne
+  change pas ce qui joue tant qu'on ne relance pas.
 
 ### Authentification (mobile)
 
@@ -612,7 +642,7 @@ xcrun simctl openurl booted \
 | `docs/adr/012-openapi-source-de-verite.md` | Décision : OpenAPI source de vérité du contrat HTTP + client Dart/Dio généré |
 
 **Règle :** toute nouvelle décision d'architecture significative → nouvel ADR dans `docs/adr/`
-avec le numéro suivant (prochain : `033-...`). Référencer le ticket Linear correspondant.
+avec le numéro suivant (prochain : `034-...`). Référencer le ticket Linear correspondant.
 
 ## Principes SOLID
 

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -317,6 +317,10 @@ func run() error {
 		http.HandlerFunc(trackHandler.Upload)))
 	mux.Handle("GET /api/tracks", auth.RequireAuth(cfg.JWTSecret,
 		http.HandlerFunc(trackHandler.ListUserTracks)))
+	// Lecture du binaire d'une piste (US-05-04) : réservée à son propriétaire,
+	// requêtes Range honorées pour le lecteur audio de la file d'attente.
+	mux.Handle("GET /api/tracks/{id}/stream", auth.RequireAuth(cfg.JWTSecret,
+		http.HandlerFunc(trackHandler.StreamTrack)))
 	// Événements SSE du direct (STR-85) : notif d'arrêt aux auditeurs authentifiés.
 	mux.Handle("GET /api/streams/{id}/events", auth.RequireAuth(cfg.JWTSecret,
 		http.HandlerFunc(streamingHandler.Events)))

--- a/backend/internal/openapi/openapi.yaml
+++ b/backend/internal/openapi/openapi.yaml
@@ -1661,6 +1661,71 @@ paths:
                       message: seuls les fichiers audio MP3, AAC ou OGG sont acceptés
         "500":
           $ref: "#/components/responses/InternalError"
+  /api/tracks/{id}/stream:
+    get:
+      tags:
+        - Track
+      operationId: streamTrack
+      summary: Stream the audio file of one of the user's tracks.
+      description: >-
+        Serves the raw audio bytes of a track owned by the authenticated user
+        (US-05-04), so the mobile player can play a playlist queue. Range
+        requests are honoured (`Accept-Ranges: bytes`), which lets the player
+        resume or seek within a track without downloading it again. A track that
+        belongs to somebody else is reported as 404, exactly like an unknown one:
+        the status code never reveals that it exists.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Track identifier.
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: The audio file.
+          headers:
+            Accept-Ranges:
+              description: Always `bytes` — the player may request slices.
+              schema:
+                type: string
+          content:
+            audio/mpeg:
+              schema:
+                type: string
+                format: binary
+            audio/aac:
+              schema:
+                type: string
+                format: binary
+            audio/ogg:
+              schema:
+                type: string
+                format: binary
+        "206":
+          description: The requested byte range of the audio file.
+          content:
+            audio/mpeg:
+              schema:
+                type: string
+                format: binary
+            audio/aac:
+              schema:
+                type: string
+                format: binary
+            audio/ogg:
+              schema:
+                type: string
+                format: binary
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalError"
 components:
   securitySchemes:
     bearerAuth:

--- a/backend/internal/track/db/tracks.sql.go
+++ b/backend/internal/track/db/tracks.sql.go
@@ -66,6 +66,35 @@ func (q *Queries) CreateTrack(ctx context.Context, arg CreateTrackParams) (Creat
 	return i, err
 }
 
+const getTrackFileByUser = `-- name: GetTrackFileByUser :one
+SELECT file_path, mime_type, file_size
+FROM tracks
+WHERE id = $1::uuid
+  AND user_id = $2::uuid
+`
+
+type GetTrackFileByUserParams struct {
+	ID     pgtype.UUID
+	UserID pgtype.UUID
+}
+
+type GetTrackFileByUserRow struct {
+	FilePath string
+	MimeType string
+	FileSize int64
+}
+
+// Localise le binaire d'une piste **du demandeur**, pour le servir en lecture
+// (US-05-04). Le filtre porte sur (id, user_id) : la piste d'un tiers ne se
+// distingue pas d'une piste inexistante (0 ligne -> 404), donc l'API ne révèle
+// pas l'existence de la bibliothèque d'autrui.
+func (q *Queries) GetTrackFileByUser(ctx context.Context, arg GetTrackFileByUserParams) (GetTrackFileByUserRow, error) {
+	row := q.db.QueryRow(ctx, getTrackFileByUser, arg.ID, arg.UserID)
+	var i GetTrackFileByUserRow
+	err := row.Scan(&i.FilePath, &i.MimeType, &i.FileSize)
+	return i, err
+}
+
 const listFilePathsByUser = `-- name: ListFilePathsByUser :many
 SELECT file_path
 FROM tracks

--- a/backend/internal/track/db/tracks.sql.go
+++ b/backend/internal/track/db/tracks.sql.go
@@ -67,7 +67,7 @@ func (q *Queries) CreateTrack(ctx context.Context, arg CreateTrackParams) (Creat
 }
 
 const getTrackFileByUser = `-- name: GetTrackFileByUser :one
-SELECT file_path, mime_type, file_size
+SELECT file_path, mime_type
 FROM tracks
 WHERE id = $1::uuid
   AND user_id = $2::uuid
@@ -81,7 +81,6 @@ type GetTrackFileByUserParams struct {
 type GetTrackFileByUserRow struct {
 	FilePath string
 	MimeType string
-	FileSize int64
 }
 
 // Localise le binaire d'une piste **du demandeur**, pour le servir en lecture
@@ -91,7 +90,7 @@ type GetTrackFileByUserRow struct {
 func (q *Queries) GetTrackFileByUser(ctx context.Context, arg GetTrackFileByUserParams) (GetTrackFileByUserRow, error) {
 	row := q.db.QueryRow(ctx, getTrackFileByUser, arg.ID, arg.UserID)
 	var i GetTrackFileByUserRow
-	err := row.Scan(&i.FilePath, &i.MimeType, &i.FileSize)
+	err := row.Scan(&i.FilePath, &i.MimeType)
 	return i, err
 }
 

--- a/backend/internal/track/handler.go
+++ b/backend/internal/track/handler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/rs/zerolog"
 
@@ -29,6 +30,7 @@ const maxMultipartMemory int64 = 1 << 20 // 1 Mio
 type TrackService interface {
 	Create(ctx context.Context, in CreateTrackInput) (Track, error)
 	ListUserTracks(ctx context.Context, requesterID string) ([]Track, error)
+	OpenTrackFile(ctx context.Context, trackID, requesterID string) (OpenedTrackFile, error)
 }
 
 // Handler expose le domaine track en HTTP.
@@ -134,6 +136,43 @@ func (h *Handler) ListUserTracks(w http.ResponseWriter, r *http.Request) {
 	if err := httpjson.Write(w, http.StatusOK, out); err != nil {
 		zerolog.Ctx(r.Context()).Error().Err(err).Msg("track: encode user tracks")
 	}
+}
+
+// StreamTrack gère GET /api/tracks/{id}/stream : sert le binaire audio d'une
+// piste **du demandeur** au lecteur mobile (US-05-04).
+//
+// Le fichier est délégué à http.ServeContent, qui gère les requêtes Range : le
+// lecteur peut reprendre une piste ou y avancer sans retélécharger depuis le
+// début, et enchaîner la piste suivante de la file sans à-coup. Le type MIME
+// vient de la base (figé à l'upload, déjà validé par sniff) : on ne laisse pas
+// ServeContent le deviner depuis un nom de fichier.
+func (h *Handler) StreamTrack(w http.ResponseWriter, r *http.Request) {
+	userID, ok := auth.UserIDFromContext(r.Context())
+	if !ok {
+		httpjson.WriteError(w, r, apperror.Unauthorized("unauthenticated"))
+		return
+	}
+
+	file, err := h.svc.OpenTrackFile(r.Context(), r.PathValue("id"), userID)
+	if err != nil {
+		httpjson.WriteError(w, r, err)
+		return
+	}
+	defer func() {
+		if err := file.Content.Close(); err != nil {
+			zerolog.Ctx(r.Context()).Warn().Err(err).Msg("track: close streamed file")
+		}
+	}()
+
+	w.Header().Set("Content-Type", file.MimeType)
+	// Contenu privé de l'utilisateur : jamais dans un cache partagé, et pas de
+	// recompression par un intermédiaire (elle casserait les octets audio).
+	w.Header().Set("Cache-Control", "private, no-store")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	// modtime nul : le binaire d'une piste est immuable une fois uploadé, il n'y
+	// a pas de revalidation conditionnelle à proposer (ServeContent omet alors
+	// Last-Modified et ignore If-Modified-Since).
+	http.ServeContent(w, r, "", time.Time{}, file.Content)
 }
 
 // tooLargeError construit la réponse 413 commune (dépassement de taille).

--- a/backend/internal/track/handler_test.go
+++ b/backend/internal/track/handler_test.go
@@ -161,7 +161,6 @@ func TestStreamTrack_OK(t *testing.T) {
 	repo := &fakeRepo{fileRet: TrackFile{
 		Path:     "/data/tracks/abc.mp3",
 		MimeType: "audio/mpeg",
-		Size:     int64(len(mp3Header)),
 	}}
 	storage := &stubStorage{openContent: mp3Header}
 	h := NewHandler(NewService(repo, storage))

--- a/backend/internal/track/handler_test.go
+++ b/backend/internal/track/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/LignacAntony/streampulse/internal/auth"
+	"github.com/LignacAntony/streampulse/internal/shared/apperror"
 )
 
 const testSecret = "test-secret-which-is-at-least-32-bytes!!"
@@ -125,6 +126,105 @@ func TestUpload_Unauthenticated(t *testing.T) {
 	h := NewHandler(NewService(&fakeRepo{}, &stubStorage{}))
 
 	rec := upload(t, h, map[string]string{"title": "Demo"}, "demo.mp3", mp3Header, false)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status: got %d, want 401", rec.Code)
+	}
+}
+
+// streamTrack fait passer GET /api/tracks/{id}/stream par la vraie chaîne
+// RequireAuth + ServeMux (le handler lit {id} via PathValue, qui n'est renseigné
+// que par le routeur). rangeHeader vide = requête complète.
+func streamTrack(t *testing.T, h *Handler, trackID, rangeHeader string, withToken bool) *httptest.ResponseRecorder {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.Handle("GET /api/tracks/{id}/stream",
+		auth.RequireAuth(testSecret, http.HandlerFunc(h.StreamTrack)))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tracks/"+trackID+"/stream", nil)
+	if rangeHeader != "" {
+		req.Header.Set("Range", rangeHeader)
+	}
+	if withToken {
+		token, err := auth.GenerateAccessToken(testUserID, "user", testSecret, time.Now().UTC())
+		if err != nil {
+			t.Fatalf("generate token: %v", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestStreamTrack_OK(t *testing.T) {
+	repo := &fakeRepo{fileRet: TrackFile{
+		Path:     "/data/tracks/abc.mp3",
+		MimeType: "audio/mpeg",
+		Size:     int64(len(mp3Header)),
+	}}
+	storage := &stubStorage{openContent: mp3Header}
+	h := NewHandler(NewService(repo, storage))
+
+	rec := streamTrack(t, h, "abc", "", true)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "audio/mpeg" {
+		t.Errorf("content-type must come from the DB, got %q", ct)
+	}
+	if !bytes.Equal(rec.Body.Bytes(), mp3Header) {
+		t.Error("the whole file must be served")
+	}
+	// Sans Accept-Ranges, le lecteur ne peut ni reprendre ni avancer dans la piste.
+	if ar := rec.Header().Get("Accept-Ranges"); ar != "bytes" {
+		t.Errorf("Accept-Ranges: got %q, want bytes", ar)
+	}
+	if cc := rec.Header().Get("Cache-Control"); cc != "private, no-store" {
+		t.Errorf("Cache-Control: got %q, want private, no-store", cc)
+	}
+	if storage.openedFile == nil || !storage.openedFile.closed {
+		t.Error("the served file must be closed (descriptor leak otherwise)")
+	}
+}
+
+// TestStreamTrack_Range : le lecteur audio demande des tranches (reprise, avance).
+func TestStreamTrack_Range(t *testing.T) {
+	repo := &fakeRepo{fileRet: TrackFile{Path: "/p", MimeType: "audio/mpeg"}}
+	h := NewHandler(NewService(repo, &stubStorage{openContent: mp3Header}))
+
+	rec := streamTrack(t, h, "abc", "bytes=4-9", true)
+
+	if rec.Code != http.StatusPartialContent {
+		t.Fatalf("status: got %d, want 206 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.Bytes(); !bytes.Equal(got, mp3Header[4:10]) {
+		t.Errorf("body: got %v, want the requested slice", got)
+	}
+}
+
+// TestStreamTrack_NotOwned : la piste d'un tiers renvoie 404 (jamais 403 : le
+// code ne doit pas révéler qu'elle existe) et rien n'est lu sur le volume.
+func TestStreamTrack_NotOwned(t *testing.T) {
+	repo := &fakeRepo{fileErr: apperror.NotFound("track not found")}
+	storage := &stubStorage{}
+	h := NewHandler(NewService(repo, storage))
+
+	rec := streamTrack(t, h, "abc", "", true)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if storage.openedPath != "" {
+		t.Error("no file must be opened for a track the requester does not own")
+	}
+}
+
+func TestStreamTrack_Unauthenticated(t *testing.T) {
+	h := NewHandler(NewService(&fakeRepo{}, &stubStorage{}))
+
+	rec := streamTrack(t, h, "abc", "", false)
 
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("status: got %d, want 401", rec.Code)

--- a/backend/internal/track/queries/tracks.sql
+++ b/backend/internal/track/queries/tracks.sql
@@ -28,7 +28,7 @@ ORDER BY created_at DESC;
 -- (US-05-04). Le filtre porte sur (id, user_id) : la piste d'un tiers ne se
 -- distingue pas d'une piste inexistante (0 ligne -> 404), donc l'API ne révèle
 -- pas l'existence de la bibliothèque d'autrui.
-SELECT file_path, mime_type, file_size
+SELECT file_path, mime_type
 FROM tracks
 WHERE id = sqlc.arg(id)::uuid
   AND user_id = sqlc.arg(user_id)::uuid;

--- a/backend/internal/track/queries/tracks.sql
+++ b/backend/internal/track/queries/tracks.sql
@@ -23,6 +23,16 @@ FROM tracks
 WHERE user_id = sqlc.arg(user_id)::uuid
 ORDER BY created_at DESC;
 
+-- name: GetTrackFileByUser :one
+-- Localise le binaire d'une piste **du demandeur**, pour le servir en lecture
+-- (US-05-04). Le filtre porte sur (id, user_id) : la piste d'un tiers ne se
+-- distingue pas d'une piste inexistante (0 ligne -> 404), donc l'API ne révèle
+-- pas l'existence de la bibliothèque d'autrui.
+SELECT file_path, mime_type, file_size
+FROM tracks
+WHERE id = sqlc.arg(id)::uuid
+  AND user_id = sqlc.arg(user_id)::uuid;
+
 -- name: SumTrackSizeByUser :one
 -- Taille cumulée des fichiers du demandeur, pour appliquer le quota de stockage
 -- par compte avant un nouvel upload (borne le remplissage du volume).

--- a/backend/internal/track/repository.go
+++ b/backend/internal/track/repository.go
@@ -90,7 +90,6 @@ func (r *pgRepository) GetTrackFileByUser(ctx context.Context, trackID, userID s
 	return TrackFile{
 		Path:     row.FilePath,
 		MimeType: row.MimeType,
-		Size:     row.FileSize,
 	}, nil
 }
 

--- a/backend/internal/track/repository.go
+++ b/backend/internal/track/repository.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -67,6 +68,32 @@ func (r *pgRepository) ListTracksByUser(ctx context.Context, userID string) ([]T
 	return tracks, nil
 }
 
+func (r *pgRepository) GetTrackFileByUser(ctx context.Context, trackID, userID string) (TrackFile, error) {
+	// L'id vient du path : un UUID malformé n'est pas une erreur serveur, c'est
+	// une piste qui n'existe pas.
+	id, ok := parseUUID(trackID)
+	if !ok {
+		return TrackFile{}, apperror.NotFound("track not found")
+	}
+	row, err := r.q.GetTrackFileByUser(ctx, trackdb.GetTrackFileByUserParams{
+		ID:     id,
+		UserID: uuidParam(userID),
+	})
+	if err != nil {
+		// 0 ligne = piste inconnue OU piste d'un tiers : même réponse, l'API ne
+		// divulgue pas l'existence de la bibliothèque d'autrui.
+		if errors.Is(err, pgx.ErrNoRows) {
+			return TrackFile{}, apperror.NotFound("track not found")
+		}
+		return TrackFile{}, fmt.Errorf("repo: get track file: %w", err)
+	}
+	return TrackFile{
+		Path:     row.FilePath,
+		MimeType: row.MimeType,
+		Size:     row.FileSize,
+	}, nil
+}
+
 func (r *pgRepository) SumFileSizeByUser(ctx context.Context, userID string) (int64, error) {
 	total, err := r.q.SumTrackSizeByUser(ctx, uuidParam(userID))
 	if err != nil {
@@ -91,6 +118,15 @@ func uuidParam(s string) pgtype.UUID {
 		panic("track: invalid UUID from internal source: " + s)
 	}
 	return u
+}
+
+// parseUUID convertit un UUID fourni par l'utilisateur (path param) sans paniquer.
+func parseUUID(s string) (pgtype.UUID, bool) {
+	var u pgtype.UUID
+	if err := u.Scan(s); err != nil {
+		return u, false
+	}
+	return u, true
 }
 
 func textParam(s *string) pgtype.Text {

--- a/backend/internal/track/service.go
+++ b/backend/internal/track/service.go
@@ -66,12 +66,12 @@ type CreateTrackInput struct {
 	Content   io.ReadSeeker
 }
 
-// TrackFile localise le binaire d'une piste et décrit ce qu'il faut pour le
-// servir (type MIME et taille, tous deux figés à l'upload).
+// TrackFile localise le binaire d'une piste et porte son type MIME, figé à
+// l'upload. Pas de taille : http.ServeContent la déduit du Seek, la relire en
+// base n'apporterait qu'une source de vérité concurrente du fichier servi.
 type TrackFile struct {
 	Path     string
 	MimeType string
-	Size     int64
 }
 
 // OpenedTrackFile est un binaire de piste prêt à être servi : le contenu est

--- a/backend/internal/track/service.go
+++ b/backend/internal/track/service.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"unicode/utf8"
 
@@ -65,6 +66,22 @@ type CreateTrackInput struct {
 	Content   io.ReadSeeker
 }
 
+// TrackFile localise le binaire d'une piste et décrit ce qu'il faut pour le
+// servir (type MIME et taille, tous deux figés à l'upload).
+type TrackFile struct {
+	Path     string
+	MimeType string
+	Size     int64
+}
+
+// OpenedTrackFile est un binaire de piste prêt à être servi : le contenu est
+// repositionnable (http.ServeContent a besoin de Seek pour honorer les requêtes
+// Range du lecteur audio) et doit être fermé par l'appelant.
+type OpenedTrackFile struct {
+	TrackFile
+	Content StoredFile
+}
+
 // CreateTrackParams est la demande de persistance adressée au Repository (champs
 // validés + chemin/MIME/taille déterminés côté serveur).
 type CreateTrackParams struct {
@@ -81,6 +98,9 @@ type CreateTrackParams struct {
 type Repository interface {
 	CreateTrack(ctx context.Context, p CreateTrackParams) (Track, error)
 	ListTracksByUser(ctx context.Context, userID string) ([]Track, error)
+	// GetTrackFileByUser localise le binaire d'une piste du demandeur. La piste
+	// d'un tiers est traitée comme inexistante (apperror.NotFound).
+	GetTrackFileByUser(ctx context.Context, trackID, userID string) (TrackFile, error)
 	// SumFileSizeByUser retourne la taille cumulée des fichiers du user (quota).
 	SumFileSizeByUser(ctx context.Context, userID string) (int64, error)
 	// ListFilePathsByUser retourne les chemins disque des fichiers du user, pour
@@ -88,10 +108,20 @@ type Repository interface {
 	ListFilePathsByUser(ctx context.Context, userID string) ([]string, error)
 }
 
-// Storage écrit/supprime le binaire audio hors de la base et hors répertoire
+// StoredFile est un binaire ouvert depuis le stockage. Seek est requis :
+// http.ServeContent s'en sert pour honorer les requêtes Range du lecteur audio
+// (reprise, avance dans la piste) sans relire le fichier depuis le début.
+type StoredFile interface {
+	io.ReadSeeker
+	io.Closer
+}
+
+// Storage écrit/lit/supprime le binaire audio hors de la base et hors répertoire
 // servi (implémenté par FileStorage). Save renvoie le chemin persistant.
 type Storage interface {
 	Save(ctx context.Context, id, ext string, r io.Reader) (string, error)
+	// Open ouvre en lecture un fichier écrit par Save (lecture d'une piste).
+	Open(path string) (StoredFile, error)
 	Remove(path string) error
 }
 
@@ -212,6 +242,32 @@ func (s *Service) PurgeUserTracks(ctx context.Context, userID string, deleteUser
 // porte sur le porteur du JWT — aucune piste d'un tiers n'y figure).
 func (s *Service) ListUserTracks(ctx context.Context, requesterID string) ([]Track, error) {
 	return s.repo.ListTracksByUser(ctx, requesterID)
+}
+
+// OpenTrackFile ouvre le binaire d'une piste **du demandeur** pour le servir en
+// lecture (US-05-04). L'appelant DOIT fermer OpenedTrackFile.Content.
+//
+// La propriété est vérifiée en SQL (filtre sur user_id) : la piste d'un tiers
+// renvoie 404, jamais 403 — le code ne doit pas révéler qu'elle existe. Un
+// fichier référencé en base mais absent du volume donne également 404 : la
+// ligne est là, le contenu ne l'est pas, il n'y a rien à servir et rien qu'un
+// réessai résoudrait (c'est une incohérence à journaliser, pas une panne).
+func (s *Service) OpenTrackFile(ctx context.Context, trackID, requesterID string) (OpenedTrackFile, error) {
+	file, err := s.repo.GetTrackFileByUser(ctx, trackID, requesterID)
+	if err != nil {
+		return OpenedTrackFile{}, err
+	}
+
+	content, err := s.storage.Open(file.Path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			zerolog.Ctx(ctx).Error().Str("track_id", trackID).Str("path", file.Path).
+				Msg("track: fichier introuvable sur le volume alors que la piste existe en base")
+			return OpenedTrackFile{}, apperror.NotFound("track not found")
+		}
+		return OpenedTrackFile{}, apperror.Internal("track: open file", err)
+	}
+	return OpenedTrackFile{TrackFile: file, Content: content}, nil
 }
 
 // normalizeTitle trime le titre et valide sa longueur (1-200).

--- a/backend/internal/track/service_test.go
+++ b/backend/internal/track/service_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/LignacAntony/streampulse/internal/shared/apperror"
@@ -32,6 +33,10 @@ type fakeRepo struct {
 	sumErr       error
 	pathsRet     []string
 	pathsErr     error
+	fileRet      TrackFile
+	fileErr      error
+	gotFileTrack string
+	gotFileUser  string
 }
 
 func (f *fakeRepo) CreateTrack(_ context.Context, p CreateTrackParams) (Track, error) {
@@ -50,6 +55,15 @@ func (f *fakeRepo) ListTracksByUser(_ context.Context, _ string) ([]Track, error
 	return f.listRet, nil
 }
 
+func (f *fakeRepo) GetTrackFileByUser(_ context.Context, trackID, userID string) (TrackFile, error) {
+	f.gotFileTrack = trackID
+	f.gotFileUser = userID
+	if f.fileErr != nil {
+		return TrackFile{}, f.fileErr
+	}
+	return f.fileRet, nil
+}
+
 func (f *fakeRepo) SumFileSizeByUser(_ context.Context, _ string) (int64, error) {
 	return f.sumRet, f.sumErr
 }
@@ -66,6 +80,10 @@ type stubStorage struct {
 	savePath     string
 	removeCalled bool
 	removedPath  string
+	openContent  []byte
+	openErr      error
+	openedPath   string
+	openedFile   *stubStoredFile
 }
 
 func (s *stubStorage) Save(_ context.Context, id, ext string, r io.Reader) (string, error) {
@@ -82,9 +100,30 @@ func (s *stubStorage) Save(_ context.Context, id, ext string, r io.Reader) (stri
 	return s.savePath, nil
 }
 
+func (s *stubStorage) Open(path string) (StoredFile, error) {
+	s.openedPath = path
+	if s.openErr != nil {
+		return nil, s.openErr
+	}
+	s.openedFile = &stubStoredFile{Reader: bytes.NewReader(s.openContent)}
+	return s.openedFile, nil
+}
+
 func (s *stubStorage) Remove(path string) error {
 	s.removeCalled = true
 	s.removedPath = path
+	return nil
+}
+
+// stubStoredFile est un binaire en mémoire qui note sa fermeture (le handler
+// doit refermer le fichier servi, sinon les descripteurs fuient).
+type stubStoredFile struct {
+	*bytes.Reader
+	closed bool
+}
+
+func (f *stubStoredFile) Close() error {
+	f.closed = true
 	return nil
 }
 
@@ -323,7 +362,75 @@ func (s *recordingStorage) Save(_ context.Context, _, _ string, _ io.Reader) (st
 	return "", nil
 }
 
+func (s *recordingStorage) Open(_ string) (StoredFile, error) {
+	return nil, os.ErrNotExist
+}
+
 func (s *recordingStorage) Remove(path string) error {
 	s.removed = append(s.removed, path)
 	return nil
+}
+
+// TestOpenTrackFile_OK : le service relaie l'identité du demandeur au repository
+// (c'est lui qui filtre sur user_id) et ouvre le chemin qu'il en reçoit.
+func TestOpenTrackFile_OK(t *testing.T) {
+	repo := &fakeRepo{fileRet: TrackFile{
+		Path:     "/data/tracks/abc.mp3",
+		MimeType: "audio/mpeg",
+		Size:     42,
+	}}
+	storage := &stubStorage{openContent: mp3Header}
+	svc := NewService(repo, storage)
+
+	opened, err := svc.OpenTrackFile(context.Background(), "track-1", testUserID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = opened.Content.Close() }()
+
+	if repo.gotFileUser != testUserID || repo.gotFileTrack != "track-1" {
+		t.Fatalf("repo must be queried with (track, user), got (%q, %q)",
+			repo.gotFileTrack, repo.gotFileUser)
+	}
+	if storage.openedPath != "/data/tracks/abc.mp3" {
+		t.Fatalf("storage must open the path from the DB, got %q", storage.openedPath)
+	}
+	if opened.MimeType != "audio/mpeg" {
+		t.Fatalf("expected the MIME type frozen at upload, got %q", opened.MimeType)
+	}
+	got, err := io.ReadAll(opened.Content)
+	if err != nil {
+		t.Fatalf("unexpected read error: %v", err)
+	}
+	if !bytes.Equal(got, mp3Header) {
+		t.Fatal("the served content must be the stored file")
+	}
+}
+
+// TestOpenTrackFile_NotOwned : la piste d'un tiers (ou inexistante) remonte du
+// repository en 404 — le service ne la transforme pas en 403.
+func TestOpenTrackFile_NotOwned(t *testing.T) {
+	repo := &fakeRepo{fileErr: apperror.NotFound("track not found")}
+	storage := &stubStorage{}
+	svc := NewService(repo, storage)
+
+	_, err := svc.OpenTrackFile(context.Background(), "track-1", testUserID)
+	if !apperror.IsCode(err, apperror.CodeNotFound) {
+		t.Fatalf("expected not found, got %v", err)
+	}
+	if storage.openedPath != "" {
+		t.Fatal("the storage must not be touched when the track is not the requester's")
+	}
+}
+
+// TestOpenTrackFile_MissingBinary : ligne en base mais fichier absent du volume
+// → 404 (il n'y a rien à servir), pas 500.
+func TestOpenTrackFile_MissingBinary(t *testing.T) {
+	repo := &fakeRepo{fileRet: TrackFile{Path: "/data/tracks/gone.mp3", MimeType: "audio/mpeg"}}
+	svc := NewService(repo, &stubStorage{openErr: os.ErrNotExist})
+
+	_, err := svc.OpenTrackFile(context.Background(), "track-1", testUserID)
+	if !apperror.IsCode(err, apperror.CodeNotFound) {
+		t.Fatalf("expected not found for a missing binary, got %v", err)
+	}
 }

--- a/backend/internal/track/service_test.go
+++ b/backend/internal/track/service_test.go
@@ -377,7 +377,6 @@ func TestOpenTrackFile_OK(t *testing.T) {
 	repo := &fakeRepo{fileRet: TrackFile{
 		Path:     "/data/tracks/abc.mp3",
 		MimeType: "audio/mpeg",
-		Size:     42,
 	}}
 	storage := &stubStorage{openContent: mp3Header}
 	svc := NewService(repo, storage)

--- a/backend/internal/track/storage.go
+++ b/backend/internal/track/storage.go
@@ -49,6 +49,19 @@ func (s *FileStorage) Save(_ context.Context, id, ext string, r io.Reader) (stri
 	return path, nil
 }
 
+// Open ouvre en lecture un fichier précédemment écrit, pour le servir à son
+// propriétaire (US-05-04). Le chemin vient toujours de la base (colonne
+// file_path écrite par Save), jamais du client : il n'y a donc rien à assainir
+// ici. Un fichier absent (volume purgé, restauration partielle) remonte tel quel
+// — le service le traduit en 404.
+func (s *FileStorage) Open(path string) (StoredFile, error) {
+	f, err := os.Open(path) // #nosec G304 -- chemin issu de la base, écrit par Save
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
 // Remove supprime un fichier précédemment écrit (best-effort côté service, pour
 // nettoyer un orphelin quand l'INSERT en base échoue après l'écriture disque).
 func (s *FileStorage) Remove(path string) error {

--- a/backend/internal/track/storage_test.go
+++ b/backend/internal/track/storage_test.go
@@ -3,6 +3,8 @@ package track
 import (
 	"bytes"
 	"context"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,6 +34,45 @@ func TestFileStorage_Save(t *testing.T) {
 	}
 	if !bytes.Equal(got, content) {
 		t.Errorf("content mismatch: got %q", got)
+	}
+}
+
+func TestFileStorage_Open(t *testing.T) {
+	root := t.TempDir()
+	s := NewFileStorage(root)
+	content := []byte("fake audio bytes")
+	path, err := s.Save(context.Background(), "readable", ".mp3", bytes.NewReader(content))
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	f, err := s.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	// Seek : http.ServeContent en dépend pour honorer les requêtes Range.
+	if _, err := f.Seek(5, io.SeekStart); err != nil {
+		t.Fatalf("seek: %v", err)
+	}
+	got, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(got, content[5:]) {
+		t.Errorf("content from offset 5: got %q, want %q", got, content[5:])
+	}
+}
+
+// TestFileStorage_OpenMissing : un fichier absent doit remonter os.ErrNotExist,
+// que le service traduit en 404 (et non en 500).
+func TestFileStorage_OpenMissing(t *testing.T) {
+	s := NewFileStorage(t.TempDir())
+
+	_, err := s.Open(filepath.Join(t.TempDir(), "nope.mp3"))
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected os.ErrNotExist, got %v", err)
 	}
 }
 

--- a/docs/adr/033-lecture-dune-playlist-avec-file-dattente.md
+++ b/docs/adr/033-lecture-dune-playlist-avec-file-dattente.md
@@ -1,0 +1,142 @@
+# ADR 033 — Lecture d'une playlist avec file d'attente (queue)
+
+**Date** : 2026-08-09
+**Statut** : Accepté
+**Ticket** : [STR-133](https://linear.app/streampulse/issue/STR-133) (US-05-04)
+
+## Contexte
+
+À l'issue de l'US-05-03 ([ADR 029](029-pistes-dune-playlist-ajout-retrait-reordonnancement.md)) une
+playlist est **ordonnable mais muette** : l'ordre des pistes est persisté, aucune ne peut être
+écoutée. L'US-05-01 ([ADR 032](032-domaine-track-upload-audio.md)) a posé l'upload et le stockage
+des fichiers, délibérément **hors répertoire servi** — il n'existe donc aucune route capable de
+rendre les octets d'une piste.
+
+Côté mobile, l'US-04-03 ([ADR 031](031-lecture-audio-en-arriere-plan.md)) a hissé le lecteur au
+niveau application dans un service de premier plan, mais uniquement pour **un flux live** : une
+source unique, sans durée, sans notion de « suivante ».
+
+L'US-05-04 demande : enchaînement automatique, file d'attente visible, saut à n'importe quelle
+piste, lecture qui continue en arrière-plan.
+
+## Décision
+
+### 1. Backend — `GET /api/tracks/{id}/stream`, propriétaire uniquement
+
+Une route dédiée sert le binaire, plutôt que d'exposer `STORAGE_PATH` en statique :
+
+- **Propriété vérifiée en SQL** (`WHERE id = $1 AND user_id = $2`). Zéro ligne → **404**, jamais
+  403 : la piste d'un tiers doit être indiscernable d'une piste inexistante, sinon le code de statut
+  révèle l'existence de la bibliothèque d'autrui.
+- **`http.ServeContent`** plutôt qu'un `io.Copy` : il gère les requêtes `Range`, dont le lecteur
+  audio a besoin pour reprendre ou avancer dans une piste sans la retélécharger.
+- **Type MIME issu de la base** (figé à l'upload, déjà validé par sniff) : ServeContent ne le devine
+  jamais depuis un nom de fichier, et `X-Content-Type-Options: nosniff` interdit au client d'en
+  faire autant.
+- **`Cache-Control: private, no-store`** : contenu privé, aucun cache partagé.
+- **Fichier absent du volume alors que la ligne existe → 404**, pas 500 : il n'y a rien à servir et
+  aucun réessai ne le changera. L'incohérence est journalisée en `error` pour être vue.
+
+Le domaine gagne `Storage.Open` (interface `StoredFile` = `ReadSeeker` + `Closer`) : le stockage
+reste une abstraction, un futur stockage objet n'aura qu'à l'implémenter.
+
+### 2. Mobile — un seul lecteur, deux interfaces (ISP)
+
+L'application n'héberge **qu'un** `AudioPlayer` (ADR 031). Direct et file d'attente s'excluent donc
+par construction. Plutôt que de gonfler `AudioPlaybackService` de méthodes de file, l'interface est
+scindée :
+
+```
+PlaybackTransport          play/pause/stop, playerStateStream, playbackErrors
+├── AudioPlaybackService   + loadUri            (direct HLS)
+└── QueuePlaybackService   + loadQueue, skipToIndex, currentIndexStream
+```
+
+`StreamAudioHandler` implémente les deux ; `main()` l'injecte sous ses deux rôles. Chaque contrôleur
+ne dépend que de ce qu'il utilise, et un test peut ne simuler qu'un des deux.
+
+### 3. L'enchaînement est délégué au lecteur natif
+
+`ConcatenatingAudioSource` enchaîne et précharge la piste suivante. Le contrôleur applicatif
+**n'ordonnance rien** : il s'abonne à `currentIndexStream` et suit. Conséquence importante : un saut
+déclenché depuis la notification système ou un casque Bluetooth met à jour la file affichée par le
+même chemin qu'un appui dans l'app — une seule source de vérité, donc aucune dérive possible entre
+ce qu'on entend et ce qu'on voit.
+
+`ProcessingState.completed` ne survient qu'à la fin de la **dernière** piste : c'est l'état
+« file terminée ».
+
+### 4. Arbitrage direct ↔ file
+
+Deux contrôleurs app-level se disputent un lecteur unique. Le câblage est croisé dans
+`app_providers` :
+
+- `PlaylistQueueController.play()` appelle `stopLive` (→ `AudioPlayerController.stop`) **avant** de
+  charger sa file ;
+- `AudioPlayerController.load()` appelle `onTakeOver` (→ `PlaylistQueueController.clear`), qui
+  abandonne la file **sans toucher au lecteur** — l'arrêter couperait le direct qui vient de le
+  charger.
+
+L'UI suit cet arbitrage : `PlayerBar` (couche `app`, seule légitime à connaître les deux features)
+affiche le mini-player de la file quand elle est active, celui du direct sinon. Ni l'un ni l'autre
+n'a besoin de savoir que le second existe.
+
+### 5. Authentification du lecteur natif
+
+Contrairement au manifeste HLS (public), le binaire d'une piste est privé : chaque `AudioSource`
+porte un en-tête `Authorization`. Or **just_audio ouvre ses propres connexions HTTP** et ne traverse
+pas les intercepteurs de `DioClient` — personne ne rafraîchit son token.
+
+D'où :
+
+- `DioClient.refreshTokens()` devient public (même verrou sérialisé que l'intercepteur) ;
+- `PlaybackAuth.token({forceRefresh})` fournit l'access token au contrôleur de file ;
+- sur un échec de lecture, le contrôleur retente **une** fois après rotation, à la piste courante.
+  Une file peut durer plus que les 15 min d'un access token : sans cette reprise, elle casserait au
+  milieu. Un second échec devient un état d'erreur explicite — réessayer en boucle ne ferait que le
+  masquer.
+
+Le token voyage en en-tête, jamais en paramètre d'URL (il finirait dans les logs d'accès).
+
+### 6. La file est une photo, pas un lien vivant
+
+`PlaylistQueueController` reçoit une **copie** des pistes au lancement. Réordonner ou retirer une
+piste dans l'écran de détail ne modifie pas ce qui joue tant que la lecture n'est pas relancée. Le
+contrôleur vit au niveau application, l'écran non : le faire suivre imposerait de réconcilier une
+mutation d'ordre avec une position de lecture en cours (que devient « piste 3 » si elle passe en
+tête ?). L'utilisateur relance quand il veut la nouvelle version.
+
+## Alternatives écartées
+
+| Alternative | Pourquoi non |
+|---|---|
+| Servir `STORAGE_PATH` en statique (Caddy/`http.FileServer`) | Aucun contrôle de propriété : le chemin est un UUID, mais quiconque l'obtient lit le fichier. L'ADR 032 a mis ces fichiers hors répertoire servi précisément pour ça. |
+| URL signée à durée de vie courte (token en query) | Le token atterrit dans les logs d'accès et les caches ; il faudrait signer, vérifier et faire tourner un secret de plus. L'en-tête `Authorization` fait le travail sans nouvelle surface. |
+| Une seule interface `AudioPlaybackService` étendue | `loadUri` et `loadQueue` ne concernent jamais le même appelant : le contrôleur de direct hériterait de méthodes de file qu'il n'implémente pas (violation I, et un fake de test devrait les stuber pour rien). |
+| Ordonnancer l'enchaînement côté Dart (charger la piste n+1 à la fin de la n) | Blanc audible entre les pistes (pas de préchargement), et un second ordonnanceur à garder en phase avec les boutons de la notification. |
+| Deux lecteurs natifs (un live, un file) | Deux sources audibles en même temps, deux notifications, deux sessions audio à arbitrer côté OS. |
+| Faire suivre à la file les mutations de l'écran de détail | Impose de définir le comportement de la lecture en cours quand la piste jouée change de place ou disparaît — complexité sans demande dans l'US. |
+
+## Conséquences
+
+**Positives**
+
+- Les pistes uploadées deviennent écoutables ; l'US-05-05 (Shuffle/Repeat, STR-134) n'a plus qu'à
+  s'insérer dans `PlaylistQueueController`.
+- Les requêtes `Range` rendent la reprise et l'avance dans une piste gratuites côté client.
+- Le mode hors ligne (STR-201) pourra remplacer l'URL d'un `QueueItem` par un chemin local sans
+  toucher au contrôleur.
+
+**Négatives / limites assumées**
+
+- La file ne suit pas les mutations de la playlist (cf. §6).
+- Un échec autre qu'un token périmé n'est pas retenté automatiquement (une seule reprise, volontaire).
+- Le serveur lit le fichier depuis le volume local : le passage à un stockage objet demandera une
+  redirection ou un proxy, prévu par l'interface `Storage`.
+- L'arrière-plan ne se teste que sur device (comme l'ADR 031).
+
+## Références
+
+- [ADR 029](029-pistes-dune-playlist-ajout-retrait-reordonnancement.md) — ordre des pistes
+- [ADR 031](031-lecture-audio-en-arriere-plan.md) — lecteur partagé, arrière-plan
+- [ADR 032](032-domaine-track-upload-audio.md) — domaine track, stockage des fichiers

--- a/docs/adr/033-lecture-dune-playlist-avec-file-dattente.md
+++ b/docs/adr/033-lecture-dune-playlist-avec-file-dattente.md
@@ -90,11 +90,22 @@ pas les intercepteurs de `DioClient` — personne ne rafraîchit son token.
 D'où :
 
 - `DioClient.refreshTokens()` devient public (même verrou sérialisé que l'intercepteur) ;
-- `PlaybackAuth.token({forceRefresh})` fournit l'access token au contrôleur de file ;
-- sur un échec de lecture, le contrôleur retente **une** fois après rotation, à la piste courante.
-  Une file peut durer plus que les 15 min d'un access token : sans cette reprise, elle casserait au
-  milieu. Un second échec devient un état d'erreur explicite — réessayer en boucle ne ferait que le
-  masquer.
+- `PlaybackAuth.token({forceRefresh})` fournit l'access token au contrôleur de file.
+
+**La reprise ne suppose pas la cause de l'échec.** On ne peut pas distinguer de façon fiable un 401
+d'une coupure réseau : just_audio remonte un `PlayerException` dont le code est celui du lecteur
+natif, pas le statut HTTP (mesuré sur device : `(0) Source error` pour une API injoignable), et le
+proxy local qui injecte les en-têtes sur Android brouille encore la trace. Le contrôleur applique
+donc une **reprise bornée** valable dans les deux cas, calquée sur celle du direct (STR-118) :
+
+- 3 tentatives au plus, backoff 1/2/4 s, statut `reconnecting` pendant l'attente ;
+- **position conservée** (`QueuePlaybackService.position` → `initialPosition`) : une coupure brève ne
+  fait pas recommencer le morceau ;
+- **seule la première** tentative force une rotation de token — c'est le remède à une expiration en
+  cours de file (15 min), et si une rotation n'a pas suffi, en enchaîner d'autres ne changera rien ;
+- le compteur ne se réarme qu'à une **action utilisateur** ou à un **changement de piste**, jamais
+  sur un simple `ready`. Sans cela, une piste qui s'ouvre puis ré-échoue en boucle (réseau instable)
+  relancerait indéfiniment le même morceau au lieu de rendre une erreur franche.
 
 Le token voyage en en-tête, jamais en paramètre d'URL (il finirait dans les logs d'accès).
 
@@ -130,7 +141,8 @@ tête ?). L'utilisateur relance quand il veut la nouvelle version.
 **Négatives / limites assumées**
 
 - La file ne suit pas les mutations de la playlist (cf. §6).
-- Un échec autre qu'un token périmé n'est pas retenté automatiquement (une seule reprise, volontaire).
+- La reprise est bornée à 3 tentatives : au-delà, l'auditeur relance lui-même. Elle ne cible pas la
+  cause de l'échec (cf. §5), donc une panne durable consomme ses trois essais avant de le dire.
 - Le serveur lit le fichier depuis le volume local : le passage à un stockage objet demandera une
   redirection ou un proxy, prévu par l'interface `Storage`.
 - L'arrière-plan ne se teste que sur device (comme l'ADR 031).

--- a/mobile/lib/app/app_providers.dart
+++ b/mobile/lib/app/app_providers.dart
@@ -2,6 +2,8 @@ import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 
 import '../core/audio/audio_playback_service.dart';
+import '../core/audio/playback_auth.dart';
+import '../core/audio/queue_playback_service.dart';
 import '../core/network/dio_client.dart';
 import '../core/storage/secure_storage.dart';
 import '../features/auth/data/datasources/auth_remote_data_source.dart';
@@ -15,6 +17,7 @@ import '../features/broadcaster/data/datasources/broadcaster_remote_data_source.
 import '../features/broadcaster/data/repositories/broadcaster_repository_impl.dart';
 import '../features/broadcaster/domain/repositories/broadcaster_repository.dart';
 import '../features/broadcaster/presentation/providers/broadcaster_controller.dart';
+import '../features/playlists/presentation/providers/playlist_queue_controller.dart';
 import '../features/profile/data/datasources/profile_remote_data_source.dart';
 import '../features/profile/data/repositories/profile_repository_impl.dart';
 import '../features/profile/domain/repositories/profile_repository.dart';
@@ -37,12 +40,19 @@ class StreamPulseApp extends StatelessWidget {
   const StreamPulseApp({
     super.key,
     required this.audioService,
+    required this.queueService,
     required this.child,
   });
 
   /// Service de lecture partagé (STR-109), créé au démarrage dans `main()` puis
   /// injecté ici : durée de vie = celle de l'application.
+  ///
+  /// [audioService] (direct) et [queueService] (file d'attente) sont deux vues
+  /// du **même** lecteur natif. Deux paramètres plutôt qu'un objet portant les
+  /// deux rôles : chaque contrôleur ne dépend ainsi que de ce qu'il utilise
+  /// (principe I), et un test peut n'en simuler qu'un.
   final AudioPlaybackService audioService;
+  final QueuePlaybackService queueService;
   final Widget child;
 
   @override
@@ -50,9 +60,16 @@ class StreamPulseApp extends StatelessWidget {
     return MultiProvider(
       providers: [
         Provider<AudioPlaybackService>.value(value: audioService),
+        Provider<QueuePlaybackService>.value(value: queueService),
         Provider<SecureStorage>(create: (_) => SecureStorage()),
         Provider<DioClient>(
           create: (ctx) => DioClient(ctx.read<SecureStorage>()),
+        ),
+        // Le lecteur natif ouvre ses propres connexions HTTP : il ne traverse
+        // pas les intercepteurs de DioClient et doit obtenir son token ici.
+        Provider<PlaybackAuth>(
+          create: (ctx) =>
+              PlaybackAuth(ctx.read<SecureStorage>(), ctx.read<DioClient>()),
         ),
         Provider<AuthRemoteDataSource>(
           create: (ctx) => AuthRemoteDataSource(ctx.read<DioClient>().authApi),
@@ -123,6 +140,23 @@ class StreamPulseApp extends StatelessWidget {
             isManifestUnavailable:
                 ctx.read<StreamRepository>().isManifestUnavailable,
           ),
+        ),
+        // File d'attente d'une playlist (US-05-04), app-level pour les mêmes
+        // raisons que le lecteur de direct : la lecture survit à la navigation
+        // et à l'arrière-plan. Les deux se disputent l'unique lecteur natif —
+        // d'où l'aiguillage croisé ci-dessous, qui garantit qu'au plus un des
+        // deux contrôleurs se croit en train de jouer.
+        ChangeNotifierProvider<PlaylistQueueController>(
+          create: (ctx) {
+            final live = ctx.read<AudioPlayerController>();
+            final queue = PlaylistQueueController(
+              service: ctx.read<QueuePlaybackService>(),
+              token: ctx.read<PlaybackAuth>().token,
+              stopLive: live.stop,
+            );
+            live.onTakeOver = queue.clear;
+            return queue;
+          },
         ),
       ],
       child: child,

--- a/mobile/lib/app/shell/main_shell.dart
+++ b/mobile/lib/app/shell/main_shell.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../features/streams/presentation/widgets/mini_player.dart';
+import 'player_bar.dart';
 
 /// Barre de navigation inférieure + `IndexedStack` des onglets
 /// (`StatefulShellRoute`) ; chaque onglet conserve son état.
@@ -21,14 +21,15 @@ class MainShell extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       body: navigationShell,
-      // Mini-player (STR-109) + barre de nav dans le `bottomNavigationBar` :
-      // hors du `body`, ils ne sont pas soumis à `resizeToAvoidBottomInset`
-      // (un clavier ne remonte donc pas le mini-player ni ne comprime l'onglet).
-      // Le mini-player est masqué (SizedBox.shrink) quand rien ne joue.
+      // Barre de lecture (direct STR-109 ou file d'attente US-05-04) + barre de
+      // nav dans le `bottomNavigationBar` : hors du `body`, elles ne sont pas
+      // soumises à `resizeToAvoidBottomInset` (un clavier ne remonte donc pas le
+      // mini-player ni ne comprime l'onglet). La barre est masquée
+      // (SizedBox.shrink) quand rien ne joue.
       bottomNavigationBar: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          const MiniPlayer(),
+          const PlayerBar(),
           NavigationBar(
             selectedIndex: navigationShell.currentIndex,
             onDestinationSelected: _onDestinationSelected,

--- a/mobile/lib/app/shell/player_bar.dart
+++ b/mobile/lib/app/shell/player_bar.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../features/playlists/presentation/providers/playlist_queue_controller.dart';
+import '../../features/playlists/presentation/widgets/queue_mini_player.dart';
+import '../../features/streams/presentation/widgets/mini_player.dart';
+
+/// Barre de lecture persistante, au-dessus de la navigation.
+///
+/// Direct (STR-109) et file d'attente (US-05-04) se partagent un unique lecteur
+/// natif : au plus une des deux surfaces a du sens à un instant donné. Cet
+/// arbitrage vit dans la couche `app`, seule légitime à connaître les deux
+/// features — ni le mini-player du direct ni celui de la file n'a à savoir que
+/// l'autre existe.
+///
+/// La file gagne quand elle est active : c'est elle qui vient d'être lancée (la
+/// démarrer arrête le direct, cf. `PlaylistQueueController.play`).
+class PlayerBar extends StatelessWidget {
+  const PlayerBar({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final hasQueue = context.select<PlaylistQueueController, bool>(
+      (queue) => queue.hasQueue,
+    );
+    return hasQueue ? const QueueMiniPlayer() : const MiniPlayer();
+  }
+}

--- a/mobile/lib/core/audio/audio_playback_service.dart
+++ b/mobile/lib/core/audio/audio_playback_service.dart
@@ -1,4 +1,6 @@
-import 'package:just_audio/just_audio.dart' show PlayerState;
+import 'playback_transport.dart';
+
+export 'playback_transport.dart' show PlaybackStatus, PlaybackTransport;
 
 /// Métadonnées du flux en cours, exposées à l'UI (mini-player, plein écran) et
 /// publiées comme `MediaItem` pour la notification / l'écran verrouillé (STR-109).
@@ -14,29 +16,14 @@ class NowPlaying {
   final String? broadcaster;
 }
 
-/// Service de lecture audio **partagé au niveau application** (DIP) : le
+/// Service de lecture **du direct**, partagé au niveau application (DIP) : le
 /// [AudioPlayerController] en dépend, jamais directement de `just_audio` ni
 /// d'`audio_service`. L'implémentation de production ([StreamAudioHandler])
 /// enveloppe un lecteur natif hébergé dans un service de premier plan, ce qui
 /// permet la lecture en arrière-plan / écran verrouillé et les contrôles
 /// système (STR-109). Les tests injectent un fake léger.
-abstract class AudioPlaybackService {
-  /// État natif du lecteur (mappé en état applicatif par le contrôleur).
-  Stream<PlayerState> get playerStateStream;
-
-  /// Erreurs de lecture (perte réseau, flux terminé) — pilotent la reprise
-  /// automatique bornée du contrôleur (STR-118).
-  Stream<Object> get playbackErrors;
-
-  bool get playing;
-
+abstract class AudioPlaybackService implements PlaybackTransport {
   /// Charge le manifeste [url] et publie les métadonnées [now] pour la
   /// notification. Ne démarre pas la lecture (le contrôleur enchaîne).
   Future<void> loadUri(String url, {required NowPlaying now});
-
-  Future<void> play();
-  Future<void> pause();
-
-  /// Arrête la lecture et retire la notification (fin de direct / fermeture).
-  Future<void> stop();
 }

--- a/mobile/lib/core/audio/playback_auth.dart
+++ b/mobile/lib/core/audio/playback_auth.dart
@@ -1,0 +1,33 @@
+import '../network/dio_client.dart';
+import '../storage/secure_storage.dart';
+
+/// Fournit au lecteur audio l'access token à joindre aux requêtes de pistes.
+///
+/// [forceRefresh] déclenche d'abord une rotation : c'est le recours quand une
+/// lecture a échoué faute d'un token encore valide (une file d'attente peut
+/// durer plus que les 15 min d'un access token). Renvoie `null` si aucun token
+/// n'est disponible — l'appelant laisse alors le serveur répondre 401 plutôt que
+/// d'inventer un état d'erreur local.
+typedef PlaybackTokenProvider = Future<String?> Function({bool forceRefresh});
+
+/// Implémentation branchée sur le stockage sécurisé et le client HTTP.
+///
+/// Existe parce que le lecteur natif (just_audio) ouvre ses propres connexions
+/// et ne traverse pas les intercepteurs de [DioClient] : l'injection du `Bearer`
+/// et le rafraîchissement doivent être faits explicitement pour lui.
+class PlaybackAuth {
+  const PlaybackAuth(this._storage, this._client);
+
+  final SecureStorage _storage;
+  final DioClient _client;
+
+  Future<String?> token({bool forceRefresh = false}) async {
+    if (forceRefresh) {
+      // Échec de la rotation (refresh token expiré/révoqué) : on lit quand même
+      // le token courant. S'il est périmé, le 401 du serveur est la réponse
+      // honnête, et le router renverra vers /login au prochain appel API.
+      await _client.refreshTokens();
+    }
+    return _storage.getAccessToken();
+  }
+}

--- a/mobile/lib/core/audio/playback_transport.dart
+++ b/mobile/lib/core/audio/playback_transport.dart
@@ -1,0 +1,44 @@
+import 'package:just_audio/just_audio.dart' show PlayerState;
+
+/// État applicatif du lecteur, mappé depuis just_audio et exposé à l'UI.
+/// `reconnecting` = une erreur transitoire est en cours de reprise automatique
+/// (STR-118) ; `error` = échec définitif (après épuisement des tentatives).
+///
+/// Partagé par les deux usages du lecteur — le direct HLS (STR-108) et la file
+/// d'attente d'une playlist (US-05-04) — pour que le mini-player n'ait qu'un
+/// seul vocabulaire d'état à comprendre.
+enum PlaybackStatus {
+  idle,
+  loading,
+  buffering,
+  playing,
+  paused,
+  reconnecting,
+  ended,
+  error,
+}
+
+/// Commandes et signaux communs à toute lecture, quelle qu'en soit la source.
+///
+/// L'application n'héberge **qu'un seul** lecteur natif (cf. ADR 031) : direct
+/// et file d'attente s'excluent donc mutuellement, et partagent ce transport.
+/// Ce qui les distingue — charger un manifeste live d'un côté, une file de
+/// pistes de l'autre — vit dans les interfaces dérivées ([AudioPlaybackService],
+/// [QueuePlaybackService]), pour qu'aucun appelant ne dépende de méthodes qui ne
+/// le concernent pas (principe I).
+abstract class PlaybackTransport {
+  /// État natif du lecteur (mappé en état applicatif par les contrôleurs).
+  Stream<PlayerState> get playerStateStream;
+
+  /// Erreurs de lecture (perte réseau, flux terminé, source injoignable) —
+  /// l'arbitrage de la reprise appartient au contrôleur, pas au transport.
+  Stream<Object> get playbackErrors;
+
+  bool get playing;
+
+  Future<void> play();
+  Future<void> pause();
+
+  /// Arrête la lecture et retire la notification.
+  Future<void> stop();
+}

--- a/mobile/lib/core/audio/queue_playback_service.dart
+++ b/mobile/lib/core/audio/queue_playback_service.dart
@@ -1,0 +1,56 @@
+import 'playback_transport.dart';
+
+export 'playback_transport.dart' show PlaybackStatus, PlaybackTransport;
+
+/// Une entrée de la file d'attente, telle que le lecteur natif la consomme :
+/// une URL à jouer et de quoi renseigner la notification / l'écran verrouillé.
+///
+/// Volontairement sans lien avec l'entité `PlaylistTrack` du domaine : le noyau
+/// audio ne connaît pas les playlists, il enchaîne des URLs (une file de pistes
+/// aujourd'hui, autre chose demain).
+class QueueItem {
+  const QueueItem({
+    required this.id,
+    required this.url,
+    required this.title,
+    this.artist,
+    this.duration,
+  });
+
+  final String id;
+  final String url;
+  final String title;
+  final String? artist;
+
+  /// Durée connue de la piste, si le client l'a fournie à l'upload. `null` ne
+  /// bloque rien : le lecteur natif la découvre en ouvrant le fichier, elle sert
+  /// seulement à afficher la barre de progression système sans attendre.
+  final Duration? duration;
+}
+
+/// Service de lecture **d'une file d'attente** (US-05-04), partagé au niveau
+/// application comme [AudioPlaybackService] et servi par le même lecteur natif :
+/// démarrer une file remplace donc le direct en cours, et réciproquement.
+///
+/// L'enchaînement automatique d'une piste à la suivante est assuré par le
+/// lecteur natif (aucune minuterie applicative à surveiller) ; le contrôleur se
+/// contente de suivre [currentIndexStream] pour savoir où en est la file.
+abstract class QueuePlaybackService implements PlaybackTransport {
+  /// Index de la piste en cours dans la file, ou `null` si aucune file n'est
+  /// chargée. Émet à chaque passage automatique comme à chaque saut manuel.
+  Stream<int?> get currentIndexStream;
+
+  /// Charge [items] et positionne la lecture sur [initialIndex]. Ne démarre pas
+  /// la lecture (le contrôleur enchaîne), pour la même raison que `loadUri`.
+  ///
+  /// [headers] est envoyé avec **chaque** requête de piste : les fichiers audio
+  /// d'une bibliothèque sont privés, le lecteur natif doit s'authentifier.
+  Future<void> loadQueue(
+    List<QueueItem> items, {
+    int initialIndex = 0,
+    Map<String, String> headers = const {},
+  });
+
+  /// Saute à la piste [index] de la file et repart de son début.
+  Future<void> skipToIndex(int index);
+}

--- a/mobile/lib/core/audio/queue_playback_service.dart
+++ b/mobile/lib/core/audio/queue_playback_service.dart
@@ -40,14 +40,20 @@ abstract class QueuePlaybackService implements PlaybackTransport {
   /// chargée. Émet à chaque passage automatique comme à chaque saut manuel.
   Stream<int?> get currentIndexStream;
 
-  /// Charge [items] et positionne la lecture sur [initialIndex]. Ne démarre pas
-  /// la lecture (le contrôleur enchaîne), pour la même raison que `loadUri`.
+  /// Position dans la piste en cours. Relevée avant une reprise après erreur
+  /// pour repartir d'où l'auditeur en était, plutôt que du début de la piste.
+  Duration get position;
+
+  /// Charge [items] et positionne la lecture sur [initialIndex], à
+  /// [initialPosition] dans cette piste. Ne démarre pas la lecture (le
+  /// contrôleur enchaîne), pour la même raison que `loadUri`.
   ///
   /// [headers] est envoyé avec **chaque** requête de piste : les fichiers audio
   /// d'une bibliothèque sont privés, le lecteur natif doit s'authentifier.
   Future<void> loadQueue(
     List<QueueItem> items, {
     int initialIndex = 0,
+    Duration initialPosition = Duration.zero,
     Map<String, String> headers = const {},
   });
 

--- a/mobile/lib/core/audio/stream_audio_handler.dart
+++ b/mobile/lib/core/audio/stream_audio_handler.dart
@@ -54,6 +54,8 @@ class StreamAudioHandler extends BaseAudioHandler
   @override
   Stream<int?> get currentIndexStream => _player.currentIndexStream;
   @override
+  Duration get position => _player.position;
+  @override
   bool get playing => _player.playing;
 
   @override
@@ -78,6 +80,7 @@ class StreamAudioHandler extends BaseAudioHandler
   Future<void> loadQueue(
     List<QueueItem> items, {
     int initialIndex = 0,
+    Duration initialPosition = Duration.zero,
     Map<String, String> headers = const {},
   }) async {
     if (items.isEmpty) {
@@ -106,7 +109,7 @@ class StreamAudioHandler extends BaseAudioHandler
         ],
       ),
       initialIndex: start,
-      initialPosition: Duration.zero,
+      initialPosition: initialPosition,
     );
   }
 

--- a/mobile/lib/core/audio/stream_audio_handler.dart
+++ b/mobile/lib/core/audio/stream_audio_handler.dart
@@ -70,6 +70,7 @@ class StreamAudioHandler extends BaseAudioHandler
         isLive: true,
       ),
     );
+    _hasSource = true;
     await _player.setAudioSource(AudioSource.uri(Uri.parse(url)));
   }
 
@@ -90,6 +91,7 @@ class StreamAudioHandler extends BaseAudioHandler
     _queueItems = [for (final item in items) _toMediaItem(item)];
     queue.add(_queueItems);
     mediaItem.add(_queueItems[start]);
+    _hasSource = true;
 
     await _player.setAudioSource(
       // L'enchaînement piste → piste suivante est délégué au lecteur natif :
@@ -110,22 +112,45 @@ class StreamAudioHandler extends BaseAudioHandler
 
   @override
   Future<void> skipToIndex(int index) async {
-    if (index < 0 || index >= _queueItems.length) return;
+    if (!_hasSource || index < 0 || index >= _queueItems.length) return;
     await _player.seek(Duration.zero, index: index);
   }
 
+  /// Refuse les commandes de transport quand plus rien n'est chargé.
+  ///
+  /// Android garde une carte média (« reprise ») après l'arrêt, et son bouton
+  /// lecture rejoue le dernier `MediaItem` : sans ce garde, appuyer dessus
+  /// relancerait la piste alors que l'application a **déjà** vidé sa file et
+  /// masqué son lecteur — l'OS jouerait ce que l'app dit ne pas jouer.
+  bool _hasSource = false;
+
   @override
-  Future<void> play() => _player.play();
+  Future<void> play() async {
+    if (!_hasSource) return;
+    await _player.play();
+  }
 
   @override
   Future<void> pause() => _player.pause();
 
   @override
   Future<void> stop() async {
+    _hasSource = false;
     await _player.stop();
     _queueItems = const [];
     queue.add(const []);
     mediaItem.add(null); // retire la notification
+    // État terminal publié explicitement : le dernier événement du lecteur peut
+    // arriver après coup, et `audio_service` ne retire sa notification qu'en
+    // voyant un état `idle` sans contrôle.
+    playbackState.add(
+      PlaybackState(
+        processingState: AudioProcessingState.idle,
+        playing: false,
+        controls: const [],
+        systemActions: const {},
+      ),
+    );
     await super.stop();
   }
 
@@ -134,16 +159,25 @@ class StreamAudioHandler extends BaseAudioHandler
   /// contrôleur applicatif suit ensuite via `currentIndexStream`, ce qui évite
   /// deux sources de vérité sur la position dans la file.
   @override
-  Future<void> skipToNext() => _player.seekToNext();
+  Future<void> skipToNext() async {
+    if (!_hasSource) return;
+    await _player.seekToNext();
+  }
 
   @override
-  Future<void> skipToPrevious() => _player.seekToPrevious();
+  Future<void> skipToPrevious() async {
+    if (!_hasSource) return;
+    await _player.seekToPrevious();
+  }
 
   @override
   Future<void> skipToQueueItem(int index) => skipToIndex(index);
 
   @override
-  Future<void> seek(Duration position) => _player.seek(position);
+  Future<void> seek(Duration position) async {
+    if (!_hasSource) return;
+    await _player.seek(position);
+  }
 
   MediaItem _toMediaItem(QueueItem item) => MediaItem(
         id: item.id,

--- a/mobile/lib/core/audio/stream_audio_handler.dart
+++ b/mobile/lib/core/audio/stream_audio_handler.dart
@@ -4,37 +4,55 @@ import 'package:audio_service/audio_service.dart';
 import 'package:just_audio/just_audio.dart';
 
 import 'audio_playback_service.dart';
+import 'queue_playback_service.dart';
 
-/// Implémentation de [AudioPlaybackService] via `audio_service` + `just_audio`
-/// (STR-109, cf. ADR 031). Enveloppe **un seul** [AudioPlayer] hébergé par le
-/// service de premier plan `audio_service` : la lecture survit à la mise en
-/// arrière-plan / au verrouillage, et les transitions du lecteur alimentent la
-/// notification et les contrôles écran verrouillé (play/pause/stop).
+/// Implémentation de [AudioPlaybackService] et [QueuePlaybackService] via
+/// `audio_service` + `just_audio` (STR-109/US-05-04, cf. ADR 031 et 033).
+/// Enveloppe **un seul** [AudioPlayer] hébergé par le service de premier plan
+/// `audio_service` : la lecture survit à la mise en arrière-plan / au
+/// verrouillage, et les transitions du lecteur alimentent la notification et les
+/// contrôles écran verrouillé.
+///
+/// Les deux usages — direct HLS et file d'attente d'une playlist — passent par
+/// ce même lecteur : charger l'un remplace l'autre, ce qui est exactement le
+/// comportement attendu (on n'écoute pas deux sources à la fois). Les
+/// contrôleurs applicatifs se chargent d'aligner leur état sur cette bascule.
 ///
 /// Ce handler reste « bête » sur les erreurs : il les **transmet** au contrôleur
 /// (via [playbackErrors]) sans décider lui-même de la reprise — l'arbitrage
 /// sonde → `ended` versus reconnexion appartient au [AudioPlayerController]
 /// (STR-118), qui pilote ensuite `play`/`stop`.
 class StreamAudioHandler extends BaseAudioHandler
-    implements AudioPlaybackService {
+    implements AudioPlaybackService, QueuePlaybackService {
   StreamAudioHandler({AudioPlayer? player}) : _player = player ?? AudioPlayer() {
     // Chaque événement du lecteur → un PlaybackState pour la notification. Les
     // erreurs sont routées vers [playbackErrors] (le contrôleur les gère), et
     // ne cassent pas le flux de la notification. Le handler vit aussi longtemps
-    // qu'`audio_service` : cet abonnement n'a pas à être annulé.
+    // qu'`audio_service` : ces abonnements n'ont pas à être annulés.
     _player.playbackEventStream.listen(
       (event) => playbackState.add(_transform(event)),
       onError: (Object e, StackTrace _) => _errors.add(e),
     );
+    // La piste courante change (enchaînement automatique ou saut) : la
+    // notification doit suivre, sinon l'écran verrouillé annonce encore la
+    // piste précédente.
+    _player.currentIndexStream.listen(_onIndexChanged);
   }
 
   final AudioPlayer _player;
   final _errors = StreamController<Object>.broadcast();
 
+  /// File d'attente courante, vide en lecture de direct. Sert à choisir les
+  /// contrôles de la notification (précédent/suivant n'ont de sens qu'ici) et à
+  /// republier le `MediaItem` à chaque changement de piste.
+  List<MediaItem> _queueItems = const [];
+
   @override
   Stream<PlayerState> get playerStateStream => _player.playerStateStream;
   @override
   Stream<Object> get playbackErrors => _errors.stream;
+  @override
+  Stream<int?> get currentIndexStream => _player.currentIndexStream;
   @override
   bool get playing => _player.playing;
 
@@ -42,6 +60,8 @@ class StreamAudioHandler extends BaseAudioHandler
   Future<void> loadUri(String url, {required NowPlaying now}) async {
     // Métadonnées de l'écran verrouillé / notification. Un flux live n'a pas de
     // durée : `isLive` masque la barre de progression côté OS.
+    _queueItems = const [];
+    queue.add(const []);
     mediaItem.add(
       MediaItem(
         id: now.streamId,
@@ -54,6 +74,47 @@ class StreamAudioHandler extends BaseAudioHandler
   }
 
   @override
+  Future<void> loadQueue(
+    List<QueueItem> items, {
+    int initialIndex = 0,
+    Map<String, String> headers = const {},
+  }) async {
+    if (items.isEmpty) {
+      await stop();
+      return;
+    }
+    // Borne défensive : un index hors file ferait lever setAudioSource et
+    // laisserait la notification décrire une piste qu'on ne joue pas.
+    final start = initialIndex.clamp(0, items.length - 1);
+
+    _queueItems = [for (final item in items) _toMediaItem(item)];
+    queue.add(_queueItems);
+    mediaItem.add(_queueItems[start]);
+
+    await _player.setAudioSource(
+      // L'enchaînement piste → piste suivante est délégué au lecteur natif :
+      // c'est lui qui préchargera la suivante, sans blanc entre les deux.
+      ConcatenatingAudioSource(
+        children: [
+          for (final item in items)
+            AudioSource.uri(
+              Uri.parse(item.url),
+              headers: headers.isEmpty ? null : headers,
+            ),
+        ],
+      ),
+      initialIndex: start,
+      initialPosition: Duration.zero,
+    );
+  }
+
+  @override
+  Future<void> skipToIndex(int index) async {
+    if (index < 0 || index >= _queueItems.length) return;
+    await _player.seek(Duration.zero, index: index);
+  }
+
+  @override
   Future<void> play() => _player.play();
 
   @override
@@ -62,25 +123,71 @@ class StreamAudioHandler extends BaseAudioHandler
   @override
   Future<void> stop() async {
     await _player.stop();
+    _queueItems = const [];
+    queue.add(const []);
     mediaItem.add(null); // retire la notification
     await super.stop();
   }
 
+  /// Contrôles système de la file d'attente (boutons de la notification, casque
+  /// Bluetooth, écran verrouillé). Ils pilotent le lecteur directement : le
+  /// contrôleur applicatif suit ensuite via `currentIndexStream`, ce qui évite
+  /// deux sources de vérité sur la position dans la file.
+  @override
+  Future<void> skipToNext() => _player.seekToNext();
+
+  @override
+  Future<void> skipToPrevious() => _player.seekToPrevious();
+
+  @override
+  Future<void> skipToQueueItem(int index) => skipToIndex(index);
+
+  @override
+  Future<void> seek(Duration position) => _player.seek(position);
+
+  MediaItem _toMediaItem(QueueItem item) => MediaItem(
+        id: item.id,
+        title: item.title,
+        artist: item.artist,
+        duration: item.duration,
+      );
+
+  /// Republie le `MediaItem` de la piste atteinte. Ne fait rien hors file
+  /// d'attente : en direct, l'unique `MediaItem` est posé par [loadUri].
+  void _onIndexChanged(int? index) {
+    if (_queueItems.isEmpty || index == null) return;
+    if (index < 0 || index >= _queueItems.length) return;
+    mediaItem.add(_queueItems[index]);
+  }
+
   /// Mappe un événement just_audio vers l'état `audio_service` qui pilote la
-  /// notification (contrôles contextuels play/pause + stop).
+  /// notification. Les contrôles dépendent de la source : en direct, play/pause
+  /// + stop ; en file d'attente, on ajoute précédent/suivant et l'action `seek`
+  /// (une piste a une durée, contrairement à un live).
   PlaybackState _transform(PlaybackEvent event) {
     final playing = _player.playing;
+    final hasQueue = _queueItems.length > 1;
     return PlaybackState(
       controls: [
+        if (hasQueue) MediaControl.skipToPrevious,
         if (playing) MediaControl.pause else MediaControl.play,
+        if (hasQueue) MediaControl.skipToNext,
         MediaControl.stop,
       ],
-      systemActions: const {
+      systemActions: {
         MediaAction.play,
         MediaAction.pause,
         MediaAction.stop,
+        if (hasQueue) ...{
+          MediaAction.seek,
+          MediaAction.skipToNext,
+          MediaAction.skipToPrevious,
+        },
       },
-      androidCompactActionIndices: const [0, 1],
+      // Les indices compacts pointent les contrôles à garder sur la
+      // notification repliée : précédent/lecture/suivant avec une file, sinon
+      // lecture/stop comme en direct.
+      androidCompactActionIndices: hasQueue ? const [0, 1, 2] : const [0, 1],
       // `?? idle` : une valeur d'enum ajoutée par une future version de
       // just_audio ne doit pas lever dans ce listener (ça tuerait le flux de
       // playbackState → notification figée).
@@ -95,6 +202,7 @@ class StreamAudioHandler extends BaseAudioHandler
       playing: playing,
       updatePosition: _player.position,
       bufferedPosition: _player.bufferedPosition,
+      queueIndex: _player.currentIndex,
     );
   }
 }

--- a/mobile/lib/core/constants/api_constants.dart
+++ b/mobile/lib/core/constants/api_constants.dart
@@ -30,6 +30,12 @@ class ApiConstants {
   // Tracks
   static const String tracks = '/api/tracks';
 
+  /// URL du binaire audio d'une piste de la bibliothèque (US-05-04). Passée au
+  /// player natif via `AudioSource.uri` — contrairement au manifeste HLS
+  /// public, elle exige un en-tête `Authorization` (contenu privé).
+  static String trackStream(String trackId) =>
+      '$baseUrl/api/tracks/$trackId/stream';
+
   // Utilisateur connecté
   static const String me = '/api/users/me';
 }

--- a/mobile/lib/core/network/dio_client.dart
+++ b/mobile/lib/core/network/dio_client.dart
@@ -122,6 +122,16 @@ class DioClient {
         path.endsWith(ApiConstants.register);
   }
 
+  /// Force une rotation des tokens hors de tout cycle de requête Dio.
+  ///
+  /// Nécessaire pour le lecteur audio : il ouvre lui-même ses connexions HTTP
+  /// (just_audio, en natif) et ne traverse donc **pas** `_authInterceptor`. Sans
+  /// ce point d'entrée, une file d'attente plus longue que la durée de vie d'un
+  /// access token (15 min) casserait au changement de piste, sans personne pour
+  /// rafraîchir. Passe par le même verrou que l'intercepteur : un seul refresh
+  /// en vol, quel que soit l'appelant.
+  Future<bool> refreshTokens() => _refreshTokensOnce();
+
   /// Refresh sérialisé : si un refresh est déjà en cours, on attend son résultat.
   /// Renvoie true si la rotation a réussi.
   Future<bool> _refreshTokensOnce() async {

--- a/mobile/lib/core/widgets/mini_player_shell.dart
+++ b/mobile/lib/core/widgets/mini_player_shell.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+
+/// Coquille commune aux mini-players (direct STR-109 et file d'attente
+/// US-05-04) : bandeau de 60 px au-dessus de la navigation, icône, titre et
+/// sous-titre d'état, puis les actions propres à la source.
+///
+/// Les deux surfaces n'ont ni les mêmes contrôles (le direct n'a pas de
+/// précédent/suivant) ni la même destination au tap, mais exactement la même
+/// enveloppe. La partager évite de faire évoluer deux bandeaux en parallèle et
+/// de les laisser diverger visuellement.
+class MiniPlayerShell extends StatelessWidget {
+  const MiniPlayerShell({
+    super.key,
+    required this.icon,
+    required this.title,
+    required this.onTap,
+    required this.actions,
+    this.subtitle,
+    this.subtitleColor,
+  });
+
+  final IconData icon;
+  final String title;
+  final VoidCallback onTap;
+
+  /// Boutons de transport, dans l'ordre d'affichage. Fournis par l'appelant :
+  /// ils dépendent de ce qui joue.
+  final List<Widget> actions;
+
+  /// État en cours (« Reconnexion… », « File d'attente terminée ») ou métadonnée
+  /// (diffuseur, position dans la file). Masqué si vide.
+  final String? subtitle;
+  final Color? subtitleColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    final text = Theme.of(context).textTheme;
+    final line = subtitle;
+
+    return Material(
+      color: colors.surfaceContainerHighest,
+      child: InkWell(
+        onTap: onTap,
+        child: SizedBox(
+          height: 60,
+          child: Row(
+            children: [
+              const SizedBox(width: 14),
+              Icon(icon, color: colors.primary),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style:
+                          text.titleSmall?.copyWith(fontWeight: FontWeight.w600),
+                    ),
+                    if (line != null && line.isNotEmpty)
+                      Text(
+                        line,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: text.bodySmall?.copyWith(
+                          color: subtitleColor ?? colors.onSurfaceVariant,
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+              ...actions,
+              const SizedBox(width: 4),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Bouton lecture/pause des mini-players : jeton d'attente pendant une
+/// transition, flèche de relance sur un état terminal, pause/lecture sinon.
+///
+/// Les trois cas se décidaient à l'identique dans les deux mini-players ; les
+/// séparer laissait la porte ouverte à un état traité d'un côté et pas de
+/// l'autre (c'est arrivé pour « reconnexion »).
+class PlaybackToggleButton extends StatelessWidget {
+  const PlaybackToggleButton({
+    super.key,
+    required this.isBusy,
+    required this.showReplay,
+    required this.isPlaying,
+    required this.onPressed,
+  });
+
+  /// Transition en cours (chargement, mise en mémoire tampon, reconnexion).
+  final bool isBusy;
+
+  /// État terminal (fin de direct, fin de file, erreur) : l'appui relance.
+  final bool showReplay;
+  final bool isPlaying;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    if (isBusy) {
+      return const Padding(
+        padding: EdgeInsets.all(14),
+        child: SizedBox(
+          width: 20,
+          height: 20,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+      );
+    }
+    final IconData icon;
+    if (showReplay) {
+      icon = Icons.replay;
+    } else if (isPlaying) {
+      icon = Icons.pause;
+    } else {
+      icon = Icons.play_arrow;
+    }
+    return IconButton(
+      onPressed: onPressed,
+      color: Theme.of(context).colorScheme.primary,
+      iconSize: 30,
+      icon: Icon(icon),
+      tooltip: isPlaying ? 'Pause' : 'Lecture',
+    );
+  }
+}

--- a/mobile/lib/features/playlists/presentation/providers/playlist_queue_controller.dart
+++ b/mobile/lib/features/playlists/presentation/providers/playlist_queue_controller.dart
@@ -1,0 +1,282 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:just_audio/just_audio.dart' show PlayerState, ProcessingState;
+
+import '../../../../core/audio/playback_auth.dart';
+import '../../../../core/audio/queue_playback_service.dart';
+import '../../../../core/constants/api_constants.dart';
+import '../../domain/entities/playlist_track.dart';
+
+export '../../../../core/audio/queue_playback_service.dart' show PlaybackStatus;
+
+/// Lecture d'une playlist avec file d'attente (US-05-04), hissée au niveau
+/// application comme le lecteur de direct : la file survit à la navigation et à
+/// la mise en arrière-plan (cf. ADR 031/033).
+///
+/// L'enchaînement des pistes n'est **pas** piloté ici : il est délégué au
+/// lecteur natif, qui précharge la piste suivante. Ce contrôleur suit
+/// `currentIndexStream` pour savoir où en est la file — une seule source de
+/// vérité, donc pas de dérive possible entre ce que l'utilisateur entend et ce
+/// que la file d'attente affiche, y compris quand le saut vient des boutons de
+/// la notification.
+class PlaylistQueueController extends ChangeNotifier {
+  PlaylistQueueController({
+    required QueuePlaybackService service,
+    required PlaybackTokenProvider token,
+    Future<void> Function()? stopLive,
+  })  : _service = service,
+        _token = token,
+        _stopLive = stopLive {
+    _stateSub = _service.playerStateStream.listen(_onPlayerState);
+    _indexSub = _service.currentIndexStream.listen(_onIndexChanged);
+    _errorSub = _service.playbackErrors.listen(_onError);
+  }
+
+  final QueuePlaybackService _service;
+  final PlaybackTokenProvider _token;
+
+  /// Arrête le direct avant de prendre le lecteur partagé. Sans ça, le
+  /// mini-player continuerait d'annoncer un flux qui ne joue plus.
+  final Future<void> Function()? _stopLive;
+
+  StreamSubscription<PlayerState>? _stateSub;
+  StreamSubscription<int?>? _indexSub;
+  StreamSubscription<Object>? _errorSub;
+
+  List<PlaylistTrack> _tracks = const [];
+  String? _playlistId;
+  String? _playlistName;
+  int _index = 0;
+  PlaybackStatus _status = PlaybackStatus.idle;
+  bool _disposed = false;
+
+  /// Une reprise après échec a-t-elle déjà été tentée pour cette file ? Borne la
+  /// reprise à **une** tentative : au-delà, l'échec n'est pas une histoire de
+  /// token périmé et réessayer en boucle ne ferait que masquer l'erreur.
+  bool _authRetried = false;
+
+  /// Numéro de la file courante. Un chargement asynchrone dont le numéro n'est
+  /// plus le bon (l'utilisateur a lancé une autre playlist entre-temps) est
+  /// abandonné plutôt que d'écraser l'état de la nouvelle.
+  int _generation = 0;
+
+  List<PlaylistTrack> get tracks => _tracks;
+  String? get playlistId => _playlistId;
+  String? get playlistName => _playlistName;
+  int get currentIndex => _index;
+  PlaybackStatus get status => _status;
+
+  /// La file est-elle active ? Faux à l'arrêt : le mini-player s'efface et rend
+  /// la place au direct.
+  bool get hasQueue =>
+      _tracks.isNotEmpty && _status != PlaybackStatus.idle;
+
+  PlaylistTrack? get currentTrack =>
+      _index >= 0 && _index < _tracks.length ? _tracks[_index] : null;
+
+  bool get isPlaying => _status == PlaybackStatus.playing;
+  bool get isBusy =>
+      _status == PlaybackStatus.loading || _status == PlaybackStatus.buffering;
+  bool get hasError => _status == PlaybackStatus.error;
+  bool get isEnded => _status == PlaybackStatus.ended;
+  bool get hasNext => _index < _tracks.length - 1;
+  bool get hasPrevious => _index > 0;
+
+  /// Lance [tracks] à partir de [startIndex] et démarre la lecture.
+  Future<void> play({
+    required String playlistId,
+    required String playlistName,
+    required List<PlaylistTrack> tracks,
+    int startIndex = 0,
+  }) async {
+    if (tracks.isEmpty) return;
+
+    // Générations : arrêter le direct est asynchrone, et la file peut être
+    // abandonnée entre-temps (clear/stop). Sans ce jeton, une playlist annulée
+    // pendant la bascule se remettrait à jouer.
+    final generation = ++_generation;
+    await _stopLive?.call();
+    if (_disposed || generation != _generation) return;
+
+    _tracks = List.unmodifiable(tracks);
+    _playlistId = playlistId;
+    _playlistName = playlistName;
+    _index = startIndex.clamp(0, tracks.length - 1);
+    _authRetried = false;
+    await _load(fromIndex: _index);
+  }
+
+  /// Saute à la piste [index] de la file (« sauter à n'importe quelle piste »).
+  Future<void> skipTo(int index) async {
+    if (_tracks.isEmpty || index < 0 || index >= _tracks.length) return;
+    // Après la fin de la file (ou un échec), la source native n'est plus
+    // exploitable : on la recharge à la piste demandée plutôt que d'y sauter.
+    if (isEnded || hasError) {
+      _index = index;
+      _authRetried = false;
+      await _load(fromIndex: index);
+      return;
+    }
+    _setIndex(index);
+    await _service.skipToIndex(index);
+    await _service.play();
+  }
+
+  Future<void> next() => hasNext ? skipTo(_index + 1) : Future.value();
+  Future<void> previous() => hasPrevious ? skipTo(_index - 1) : Future.value();
+
+  /// Bascule lecture/pause ; relance la file si elle est terminée ou en erreur.
+  Future<void> togglePlayPause() async {
+    if (_tracks.isEmpty) return;
+    if (isEnded || hasError) {
+      _authRetried = false;
+      await _load(fromIndex: isEnded ? 0 : _index);
+      return;
+    }
+    if (isBusy) return;
+    if (_service.playing) {
+      await _service.pause();
+    } else {
+      await _service.play();
+    }
+  }
+
+  /// Arrête la lecture et vide la file (croix du mini-player).
+  Future<void> stop() async {
+    _reset();
+    await _service.stop();
+  }
+
+  /// Abandonne la file **sans toucher au lecteur** : le direct vient de prendre
+  /// la main sur la source partagée, l'arrêter ici couperait sa lecture.
+  void clear() {
+    if (_tracks.isEmpty && _status == PlaybackStatus.idle) {
+      // Rien à effacer à l'écran, mais un lancement peut être en vol : il doit
+      // être invalidé lui aussi, sinon il prendrait le lecteur au direct.
+      _generation++;
+      return;
+    }
+    _reset();
+  }
+
+  /// (Re)charge la file dans le lecteur à partir de [fromIndex].
+  /// [refreshToken] force une rotation de l'access token (reprise après échec).
+  Future<void> _load({required int fromIndex, bool refreshToken = false}) async {
+    final generation = ++_generation;
+    _setStatus(PlaybackStatus.loading);
+    try {
+      final token = await _token(forceRefresh: refreshToken);
+      if (_disposed || generation != _generation) return;
+
+      await _service.loadQueue(
+        [
+          for (final track in _tracks)
+            QueueItem(
+              id: track.id,
+              url: ApiConstants.trackStream(track.id),
+              title: track.title,
+              artist: track.artist,
+              duration: track.durationS == null
+                  ? null
+                  : Duration(seconds: track.durationS!),
+            ),
+        ],
+        initialIndex: fromIndex,
+        headers: token == null ? const {} : {'Authorization': 'Bearer $token'},
+      );
+      if (_disposed || generation != _generation) return;
+      await _service.play();
+    } catch (e) {
+      if (generation != _generation) return;
+      _onError(e);
+    }
+  }
+
+  void _onPlayerState(PlayerState state) {
+    if (_tracks.isEmpty) return;
+    // `error` est un état terminal décidé par [_onError] : un état résiduel du
+    // lecteur ne doit pas le repeindre en « en pause ».
+    if (_status == PlaybackStatus.error) return;
+    switch (state.processingState) {
+      case ProcessingState.idle:
+        _setStatus(PlaybackStatus.idle);
+      case ProcessingState.loading:
+        _setStatus(PlaybackStatus.loading);
+      case ProcessingState.buffering:
+        _setStatus(PlaybackStatus.buffering);
+      case ProcessingState.ready:
+        // Une piste s'est ouverte : le token était bon, on réarme la reprise
+        // pour un éventuel échec plus loin dans la file.
+        _authRetried = false;
+        _setStatus(
+          state.playing ? PlaybackStatus.playing : PlaybackStatus.paused,
+        );
+      case ProcessingState.completed:
+        // Fin de la **dernière** piste : l'enchaînement intermédiaire ne passe
+        // pas par `completed`.
+        _setStatus(PlaybackStatus.ended);
+    }
+  }
+
+  /// Le lecteur a changé de piste (enchaînement automatique, boutons de la
+  /// notification, ou saut demandé ici) : la file d'attente affichée suit.
+  void _onIndexChanged(int? index) {
+    if (index == null || _tracks.isEmpty) return;
+    if (index < 0 || index >= _tracks.length) return;
+    _setIndex(index);
+  }
+
+  /// Échec de lecture. Le cas de loin le plus probable sur une longue file est
+  /// l'access token expiré en cours de route (15 min) : on retente **une** fois
+  /// après rotation, à la piste courante. Tout autre échec — ou un second —
+  /// devient un état d'erreur que l'utilisateur relance explicitement.
+  void _onError(Object error) {
+    if (_disposed || _tracks.isEmpty) return;
+    if (kDebugMode) {
+      debugPrint('PlaylistQueueController: erreur de lecture: $error');
+    }
+    if (_authRetried) {
+      _setStatus(PlaybackStatus.error);
+      return;
+    }
+    _authRetried = true;
+    unawaited(_load(fromIndex: _index, refreshToken: true));
+  }
+
+  /// Vide la file et repasse à `idle`. Le `_generation++` invalide un chargement
+  /// encore en vol : sans lui, une file arrêtée pourrait se remettre à jouer.
+  void _reset() {
+    _tracks = const [];
+    _playlistId = null;
+    _playlistName = null;
+    _index = 0;
+    _authRetried = false;
+    _generation++;
+    _status = PlaybackStatus.idle;
+    if (!_disposed) notifyListeners();
+  }
+
+  void _setIndex(int index) {
+    if (_disposed || _index == index) return;
+    _index = index;
+    notifyListeners();
+  }
+
+  void _setStatus(PlaybackStatus status) {
+    if (_disposed || _status == status) return;
+    _status = status;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    // Contrôleur app-level : on libère nos abonnements, mais **pas** le service
+    // partagé (sa durée de vie est celle d'`audio_service`, gérée à part).
+    _disposed = true;
+    _stateSub?.cancel();
+    _indexSub?.cancel();
+    _errorSub?.cancel();
+    super.dispose();
+  }
+}

--- a/mobile/lib/features/playlists/presentation/providers/playlist_queue_controller.dart
+++ b/mobile/lib/features/playlists/presentation/providers/playlist_queue_controller.dart
@@ -40,9 +40,14 @@ class PlaylistQueueController extends ChangeNotifier {
   /// mini-player continuerait d'annoncer un flux qui ne joue plus.
   final Future<void> Function()? _stopLive;
 
+  /// Nombre de reprises automatiques avant d'abandonner, avec backoff 1/2/4 s
+  /// (même discipline que le direct, STR-118).
+  static const int _maxAutoRetries = 3;
+
   StreamSubscription<PlayerState>? _stateSub;
   StreamSubscription<int?>? _indexSub;
   StreamSubscription<Object>? _errorSub;
+  Timer? _retryTimer;
 
   List<PlaylistTrack> _tracks = const [];
   String? _playlistId;
@@ -51,10 +56,15 @@ class PlaylistQueueController extends ChangeNotifier {
   PlaybackStatus _status = PlaybackStatus.idle;
   bool _disposed = false;
 
-  /// Une reprise après échec a-t-elle déjà été tentée pour cette file ? Borne la
-  /// reprise à **une** tentative : au-delà, l'échec n'est pas une histoire de
-  /// token périmé et réessayer en boucle ne ferait que masquer l'erreur.
-  bool _authRetried = false;
+  /// Reprises déjà tentées sur la piste courante.
+  ///
+  /// Remis à zéro sur une **action utilisateur** (lancement, saut) et sur un
+  /// **changement de piste** — c'est-à-dire quand la file a réellement avancé.
+  /// Volontairement pas à chaque `ready` : une piste qui s'ouvre puis
+  /// re-échoue en boucle (réseau instable) rearmerait indéfiniment le compteur,
+  /// et l'auditeur verrait la même piste repartir sans fin au lieu d'une erreur
+  /// franche qu'il peut relancer lui-même.
+  int _retryCount = 0;
 
   /// Numéro de la file courante. Un chargement asynchrone dont le numéro n'est
   /// plus le bon (l'utilisateur a lancé une autre playlist entre-temps) est
@@ -80,6 +90,7 @@ class PlaylistQueueController extends ChangeNotifier {
       _status == PlaybackStatus.loading || _status == PlaybackStatus.buffering;
   bool get hasError => _status == PlaybackStatus.error;
   bool get isEnded => _status == PlaybackStatus.ended;
+  bool get isReconnecting => _status == PlaybackStatus.reconnecting;
   bool get hasNext => _index < _tracks.length - 1;
   bool get hasPrevious => _index > 0;
 
@@ -96,6 +107,11 @@ class PlaylistQueueController extends ChangeNotifier {
     // abandonnée entre-temps (clear/stop). Sans ce jeton, une playlist annulée
     // pendant la bascule se remettrait à jouer.
     final generation = ++_generation;
+    // Statut posé **avant** d'arrêter le direct : `stopLive` fait émettre un
+    // `idle` au lecteur partagé alors que la file précédente est encore
+    // affichée. Sans ce `loading`, `hasQueue` passerait à false le temps d'un
+    // battement et le mini-player clignoterait à chaque relancement.
+    _setStatus(PlaybackStatus.loading);
     await _stopLive?.call();
     if (_disposed || generation != _generation) return;
 
@@ -103,7 +119,7 @@ class PlaylistQueueController extends ChangeNotifier {
     _playlistId = playlistId;
     _playlistName = playlistName;
     _index = startIndex.clamp(0, tracks.length - 1);
-    _authRetried = false;
+    _retryCount = 0;
     await _load(fromIndex: _index);
   }
 
@@ -114,10 +130,12 @@ class PlaylistQueueController extends ChangeNotifier {
     // exploitable : on la recharge à la piste demandée plutôt que d'y sauter.
     if (isEnded || hasError) {
       _index = index;
-      _authRetried = false;
+      _retryCount = 0;
       await _load(fromIndex: index);
       return;
     }
+    _retryCount = 0; // action utilisateur : on réarme les reprises
+    _retryTimer?.cancel();
     _setIndex(index);
     await _service.skipToIndex(index);
     await _service.play();
@@ -130,11 +148,11 @@ class PlaylistQueueController extends ChangeNotifier {
   Future<void> togglePlayPause() async {
     if (_tracks.isEmpty) return;
     if (isEnded || hasError) {
-      _authRetried = false;
+      _retryCount = 0;
       await _load(fromIndex: isEnded ? 0 : _index);
       return;
     }
-    if (isBusy) return;
+    if (isBusy || isReconnecting) return;
     if (_service.playing) {
       await _service.pause();
     } else {
@@ -160,9 +178,14 @@ class PlaylistQueueController extends ChangeNotifier {
     _reset();
   }
 
-  /// (Re)charge la file dans le lecteur à partir de [fromIndex].
-  /// [refreshToken] force une rotation de l'access token (reprise après échec).
-  Future<void> _load({required int fromIndex, bool refreshToken = false}) async {
+  /// (Re)charge la file dans le lecteur à partir de [fromIndex], à [position]
+  /// dans cette piste. [refreshToken] force une rotation de l'access token
+  /// (première reprise après échec).
+  Future<void> _load({
+    required int fromIndex,
+    Duration position = Duration.zero,
+    bool refreshToken = false,
+  }) async {
     final generation = ++_generation;
     _setStatus(PlaybackStatus.loading);
     try {
@@ -183,6 +206,7 @@ class PlaylistQueueController extends ChangeNotifier {
             ),
         ],
         initialIndex: fromIndex,
+        initialPosition: position,
         headers: token == null ? const {} : {'Authorization': 'Bearer $token'},
       );
       if (_disposed || generation != _generation) return;
@@ -195,9 +219,23 @@ class PlaylistQueueController extends ChangeNotifier {
 
   void _onPlayerState(PlayerState state) {
     if (_tracks.isEmpty) return;
-    // `error` est un état terminal décidé par [_onError] : un état résiduel du
-    // lecteur ne doit pas le repeindre en « en pause ».
-    if (_status == PlaybackStatus.error) return;
+    // États décidés par le contrôleur, pas par le lecteur : `error` et `ended`
+    // sont terminaux, `reconnecting` est une transition qu'une reprise en cours
+    // pilote. Un événement résiduel du lecteur ne doit repeindre aucun des
+    // trois — sinon un `idle` arrivant juste après `completed` ferait
+    // disparaître le mini-player « File d'attente terminée », et avec lui le
+    // bouton de relance.
+    if (_status == PlaybackStatus.error ||
+        _status == PlaybackStatus.ended ||
+        _status == PlaybackStatus.reconnecting) {
+      return;
+    }
+    // Pendant un (re)chargement, l'`idle` émis par le lecteur en libérant sa
+    // source précédente n'est pas un état à afficher.
+    if (_status == PlaybackStatus.loading &&
+        state.processingState == ProcessingState.idle) {
+      return;
+    }
     switch (state.processingState) {
       case ProcessingState.idle:
         _setStatus(PlaybackStatus.idle);
@@ -206,9 +244,6 @@ class PlaylistQueueController extends ChangeNotifier {
       case ProcessingState.buffering:
         _setStatus(PlaybackStatus.buffering);
       case ProcessingState.ready:
-        // Une piste s'est ouverte : le token était bon, on réarme la reprise
-        // pour un éventuel échec plus loin dans la file.
-        _authRetried = false;
         _setStatus(
           state.playing ? PlaybackStatus.playing : PlaybackStatus.paused,
         );
@@ -224,34 +259,58 @@ class PlaylistQueueController extends ChangeNotifier {
   void _onIndexChanged(int? index) {
     if (index == null || _tracks.isEmpty) return;
     if (index < 0 || index >= _tracks.length) return;
+    // La file a réellement avancé : les reprises consommées sur la piste
+    // précédente ne doivent pas peser sur la suivante.
+    if (index != _index) _retryCount = 0;
     _setIndex(index);
   }
 
-  /// Échec de lecture. Le cas de loin le plus probable sur une longue file est
-  /// l'access token expiré en cours de route (15 min) : on retente **une** fois
-  /// après rotation, à la piste courante. Tout autre échec — ou un second —
-  /// devient un état d'erreur que l'utilisateur relance explicitement.
+  /// Échec de lecture : reprise automatique **bornée**, backoff 1/2/4 s, en
+  /// repartant de la position atteinte dans la piste courante — une coupure
+  /// réseau brève ne doit pas faire recommencer le morceau.
+  ///
+  /// Seule la **première** tentative force une rotation de l'access token :
+  /// c'est le remède à une expiration en cours de file (15 min), et si une
+  /// rotation n'a pas suffi, en enchaîner d'autres ne changera rien. Tentatives
+  /// épuisées → état d'erreur, que l'utilisateur relance explicitement.
   void _onError(Object error) {
     if (_disposed || _tracks.isEmpty) return;
     if (kDebugMode) {
       debugPrint('PlaylistQueueController: erreur de lecture: $error');
     }
-    if (_authRetried) {
+    if (_retryCount >= _maxAutoRetries) {
       _setStatus(PlaybackStatus.error);
       return;
     }
-    _authRetried = true;
-    unawaited(_load(fromIndex: _index, refreshToken: true));
+
+    // Position relevée maintenant : après le délai, le lecteur aura pu être
+    // réinitialisé et l'aurait perdue.
+    final resumeAt = _service.position;
+    final refreshToken = _retryCount == 0;
+    _retryCount++;
+    _setStatus(PlaybackStatus.reconnecting);
+
+    final delay = Duration(seconds: 1 << (_retryCount - 1));
+    _retryTimer?.cancel();
+    _retryTimer = Timer(delay, () {
+      if (_disposed || _tracks.isEmpty) return;
+      unawaited(_load(
+        fromIndex: _index,
+        position: resumeAt,
+        refreshToken: refreshToken,
+      ));
+    });
   }
 
   /// Vide la file et repasse à `idle`. Le `_generation++` invalide un chargement
   /// encore en vol : sans lui, une file arrêtée pourrait se remettre à jouer.
   void _reset() {
+    _retryTimer?.cancel();
     _tracks = const [];
     _playlistId = null;
     _playlistName = null;
     _index = 0;
-    _authRetried = false;
+    _retryCount = 0;
     _generation++;
     _status = PlaybackStatus.idle;
     if (!_disposed) notifyListeners();
@@ -274,6 +333,7 @@ class PlaylistQueueController extends ChangeNotifier {
     // Contrôleur app-level : on libère nos abonnements, mais **pas** le service
     // partagé (sa durée de vie est celle d'`audio_service`, gérée à part).
     _disposed = true;
+    _retryTimer?.cancel();
     _stateSub?.cancel();
     _indexSub?.cancel();
     _errorSub?.cancel();

--- a/mobile/lib/features/playlists/presentation/screens/playlist_detail_screen.dart
+++ b/mobile/lib/features/playlists/presentation/screens/playlist_detail_screen.dart
@@ -9,6 +9,7 @@ import '../../data/repositories/playlist_repository_impl.dart';
 import '../../domain/entities/playlist_track.dart';
 import '../../domain/repositories/playlist_repository.dart';
 import '../providers/playlist_detail_controller.dart';
+import '../providers/playlist_queue_controller.dart';
 import '../track_labels.dart';
 import '../widgets/track_picker_sheet.dart';
 
@@ -112,6 +113,23 @@ class _PlaylistDetailBodyState extends State<_PlaylistDetailBody> {
     }
   }
 
+  /// Lance la playlist à partir de [startIndex] (US-05-04). La file d'attente
+  /// est une **photo** des pistes affichées : le contrôleur de file vit au
+  /// niveau application, il ne peut pas suivre les mutations d'un écran qu'on
+  /// quitte. Réordonner ou retirer une piste ne change donc pas ce qui joue
+  /// tant que l'utilisateur n'a pas relancé la lecture.
+  Future<void> _onPlay({int startIndex = 0}) async {
+    final controller = context.read<PlaylistDetailController>();
+    if (controller.tracks.isEmpty) return;
+
+    await context.read<PlaylistQueueController>().play(
+          playlistId: controller.playlistId,
+          playlistName: widget.title,
+          tracks: controller.tracks,
+          startIndex: startIndex,
+        );
+  }
+
   Future<void> _onReorder(int oldIndex, int newIndex) async {
     final controller = context.read<PlaylistDetailController>();
     try {
@@ -151,6 +169,16 @@ class _PlaylistDetailBodyState extends State<_PlaylistDetailBody> {
           child: _buildBody(controller),
         ),
       ),
+      // Point d'entrée principal de la lecture : sans lui, seul un appui sur une
+      // ligne lancerait la playlist — trouvable seulement par tâtonnement.
+      floatingActionButton: controller.tracks.isEmpty
+          ? null
+          : FloatingActionButton.extended(
+              key: const Key('playlist_play_button'),
+              onPressed: _onPlay,
+              icon: const Icon(Icons.play_arrow),
+              label: const Text('Lire'),
+            ),
     );
   }
 
@@ -190,7 +218,8 @@ class _PlaylistDetailBodyState extends State<_PlaylistDetailBody> {
       // le défilement que la poignée explicite ci-dessous cherche à éviter.
       buildDefaultDragHandles: false,
       physics: const AlwaysScrollableScrollPhysics(),
-      padding: const EdgeInsets.only(bottom: 24),
+      // Assez de marge pour que la dernière ligne ne se cache pas sous le FAB.
+      padding: const EdgeInsets.only(bottom: 88),
       itemCount: controller.tracks.length,
       onReorder: _onReorder,
       itemBuilder: (context, index) {
@@ -201,7 +230,9 @@ class _PlaylistDetailBodyState extends State<_PlaylistDetailBody> {
           key: Key('playlist_track_${track.id}'),
           track: track,
           index: index,
+          playlistId: controller.playlistId,
           onRemove: _onRemove,
+          onPlay: () => _onPlay(startIndex: index),
         );
       },
     );
@@ -242,29 +273,47 @@ class _TrackTile extends StatelessWidget {
     super.key,
     required this.track,
     required this.index,
+    required this.playlistId,
     required this.onRemove,
+    required this.onPlay,
   });
 
   final PlaylistTrack track;
   final int index;
+  final String playlistId;
   final ValueChanged<PlaylistTrack> onRemove;
+  final VoidCallback onPlay;
 
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).colorScheme;
+    // Comparaison par id et non par index : l'ordre local peut différer de
+    // celui figé dans la file (réordonnancement après le lancement).
+    final isCurrent = context.select<PlaylistQueueController, bool>(
+      (queue) =>
+          queue.hasQueue &&
+          queue.playlistId == playlistId &&
+          queue.currentTrack?.id == track.id,
+    );
 
     return ListTile(
-      leading: Text(
-        '${index + 1}',
-        style: Theme.of(context)
-            .textTheme
-            .titleMedium
-            ?.copyWith(color: colors.onSurfaceVariant),
-      ),
+      onTap: onPlay,
+      leading: isCurrent
+          ? Icon(Icons.graphic_eq, color: colors.primary)
+          : Text(
+              '${index + 1}',
+              style: Theme.of(context)
+                  .textTheme
+                  .titleMedium
+                  ?.copyWith(color: colors.onSurfaceVariant),
+            ),
       title: Text(
         track.title,
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
+        style: isCurrent
+            ? TextStyle(color: colors.primary, fontWeight: FontWeight.w600)
+            : null,
       ),
       subtitle: Text(
         trackSubtitle(artist: track.artist, durationS: track.durationS),

--- a/mobile/lib/features/playlists/presentation/screens/playlist_detail_screen.dart
+++ b/mobile/lib/features/playlists/presentation/screens/playlist_detail_screen.dart
@@ -11,6 +11,7 @@ import '../../domain/repositories/playlist_repository.dart';
 import '../providers/playlist_detail_controller.dart';
 import '../providers/playlist_queue_controller.dart';
 import '../track_labels.dart';
+import '../widgets/queue_track_visuals.dart';
 import '../widgets/track_picker_sheet.dart';
 
 /// Écran de détail d'une playlist (US-05-03) : pistes ordonnées, ajout depuis la
@@ -286,7 +287,6 @@ class _TrackTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colors = Theme.of(context).colorScheme;
     // Comparaison par id et non par index : l'ordre local peut différer de
     // celui figé dans la file (réordonnancement après le lancement).
     final isCurrent = context.select<PlaylistQueueController, bool>(
@@ -298,22 +298,12 @@ class _TrackTile extends StatelessWidget {
 
     return ListTile(
       onTap: onPlay,
-      leading: isCurrent
-          ? Icon(Icons.graphic_eq, color: colors.primary)
-          : Text(
-              '${index + 1}',
-              style: Theme.of(context)
-                  .textTheme
-                  .titleMedium
-                  ?.copyWith(color: colors.onSurfaceVariant),
-            ),
+      leading: queueTrackLeading(context, index: index, isCurrent: isCurrent),
       title: Text(
         track.title,
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
-        style: isCurrent
-            ? TextStyle(color: colors.primary, fontWeight: FontWeight.w600)
-            : null,
+        style: queueTrackTitleStyle(context, isCurrent: isCurrent),
       ),
       subtitle: Text(
         trackSubtitle(artist: track.artist, durationS: track.durationS),

--- a/mobile/lib/features/playlists/presentation/widgets/playback_queue_sheet.dart
+++ b/mobile/lib/features/playlists/presentation/widgets/playback_queue_sheet.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../providers/playlist_queue_controller.dart';
 import '../track_labels.dart';
+import 'queue_track_visuals.dart';
 
 /// File d'attente en cours de lecture (US-05-04), en feuille modale.
 ///
@@ -32,7 +33,18 @@ class PlaybackQueueSheet extends StatelessWidget {
     // que d'afficher une liste vide sans explication.
     if (!queue.hasQueue) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (context.mounted) Navigator.of(context).maybePop();
+        if (!context.mounted) return;
+        // On vise **cette** route et pas le sommet de la pile : une autre route
+        // a pu être poussée par-dessus entre-temps, et un `maybePop()` nu la
+        // fermerait à la place de la feuille. Quand la feuille est au sommet on
+        // passe quand même par `maybePop` pour garder l'animation de sortie.
+        final route = ModalRoute.of(context);
+        final navigator = Navigator.of(context);
+        if (route == null || route.isCurrent) {
+          navigator.maybePop();
+        } else {
+          navigator.removeRoute(route);
+        }
       });
       return const SizedBox.shrink();
     }
@@ -66,23 +78,16 @@ class PlaybackQueueSheet extends StatelessWidget {
                 return ListTile(
                   key: Key('queue_item_${track.id}'),
                   selected: isCurrent,
-                  leading: isCurrent
-                      ? Icon(Icons.graphic_eq, color: colors.primary)
-                      : Text(
-                          '${index + 1}',
-                          style: text.titleMedium
-                              ?.copyWith(color: colors.onSurfaceVariant),
-                        ),
+                  leading: queueTrackLeading(
+                    context,
+                    index: index,
+                    isCurrent: isCurrent,
+                  ),
                   title: Text(
                     track.title,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
-                    style: isCurrent
-                        ? text.titleMedium?.copyWith(
-                            color: colors.primary,
-                            fontWeight: FontWeight.w600,
-                          )
-                        : null,
+                    style: queueTrackTitleStyle(context, isCurrent: isCurrent),
                   ),
                   subtitle: Text(
                     trackSubtitle(

--- a/mobile/lib/features/playlists/presentation/widgets/playback_queue_sheet.dart
+++ b/mobile/lib/features/playlists/presentation/widgets/playback_queue_sheet.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/playlist_queue_controller.dart';
+import '../track_labels.dart';
+
+/// File d'attente en cours de lecture (US-05-04), en feuille modale.
+///
+/// Rend visible ce que le mini-player ne peut pas montrer : les pistes à venir,
+/// celles déjà passées, et laquelle joue. Un appui sur n'importe quelle ligne y
+/// saute directement.
+class PlaybackQueueSheet extends StatelessWidget {
+  const PlaybackQueueSheet({super.key});
+
+  static Future<void> show(BuildContext context) {
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      builder: (sheetContext) => const PlaybackQueueSheet(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final queue = context.watch<PlaylistQueueController>();
+    final text = Theme.of(context).textTheme;
+    final colors = Theme.of(context).colorScheme;
+
+    // La file peut se vider pendant que la feuille est ouverte (arrêt depuis la
+    // notification, ou un direct qui reprend le lecteur) : on la referme plutôt
+    // que d'afficher une liste vide sans explication.
+    if (!queue.hasQueue) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (context.mounted) Navigator.of(context).maybePop();
+      });
+      return const SizedBox.shrink();
+    }
+
+    return SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ListTile(
+            leading: const Icon(Icons.queue_music),
+            title: const Text('File d\'attente'),
+            subtitle: Text(
+              queue.playlistName ?? 'Playlist',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+            trailing: Text(
+              '${queue.currentIndex + 1}/${queue.tracks.length}',
+              style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant),
+            ),
+          ),
+          const Divider(height: 1),
+          Flexible(
+            child: ListView.builder(
+              key: const Key('playback_queue_list'),
+              shrinkWrap: true,
+              itemCount: queue.tracks.length,
+              itemBuilder: (context, index) {
+                final track = queue.tracks[index];
+                final isCurrent = index == queue.currentIndex;
+                return ListTile(
+                  key: Key('queue_item_${track.id}'),
+                  selected: isCurrent,
+                  leading: isCurrent
+                      ? Icon(Icons.graphic_eq, color: colors.primary)
+                      : Text(
+                          '${index + 1}',
+                          style: text.titleMedium
+                              ?.copyWith(color: colors.onSurfaceVariant),
+                        ),
+                  title: Text(
+                    track.title,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: isCurrent
+                        ? text.titleMedium?.copyWith(
+                            color: colors.primary,
+                            fontWeight: FontWeight.w600,
+                          )
+                        : null,
+                  ),
+                  subtitle: Text(
+                    trackSubtitle(
+                      artist: track.artist,
+                      durationS: track.durationS,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  onTap: () =>
+                      context.read<PlaylistQueueController>().skipTo(index),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/playlists/presentation/widgets/queue_mini_player.dart
+++ b/mobile/lib/features/playlists/presentation/widgets/queue_mini_player.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/playlist_queue_controller.dart';
+import 'playback_queue_sheet.dart';
+
+/// Mini-player de la file d'attente (US-05-04) : pendant du mini-player du
+/// direct, avec les contrôles que seule une file justifie (précédent/suivant).
+/// Un appui ouvre la file d'attente, la croix l'abandonne.
+class QueueMiniPlayer extends StatelessWidget {
+  const QueueMiniPlayer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final queue = context.watch<PlaylistQueueController>();
+    final track = queue.currentTrack;
+    if (!queue.hasQueue || track == null) return const SizedBox.shrink();
+
+    final colors = Theme.of(context).colorScheme;
+    final text = Theme.of(context).textTheme;
+
+    // L'état prime sur le nom de l'artiste : sinon la fin de file ou une erreur
+    // passeraient inaperçues (seule l'icône changerait).
+    final (String subtitle, Color subtitleColor) = switch (queue.status) {
+      PlaybackStatus.ended => ('File d\'attente terminée', colors.error),
+      PlaybackStatus.error => ('Lecture impossible', colors.error),
+      _ => (
+          '${queue.currentIndex + 1}/${queue.tracks.length} · '
+              '${track.artist ?? 'Artiste inconnu'}',
+          colors.onSurfaceVariant,
+        ),
+    };
+
+    return Material(
+      color: colors.surfaceContainerHighest,
+      child: InkWell(
+        key: const Key('queue_mini_player'),
+        onTap: () => PlaybackQueueSheet.show(context),
+        child: SizedBox(
+          height: 60,
+          child: Row(
+            children: [
+              const SizedBox(width: 14),
+              Icon(Icons.queue_music, color: colors.primary),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      track.title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style:
+                          text.titleSmall?.copyWith(fontWeight: FontWeight.w600),
+                    ),
+                    Text(
+                      subtitle,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: text.bodySmall?.copyWith(color: subtitleColor),
+                    ),
+                  ],
+                ),
+              ),
+              IconButton(
+                key: const Key('queue_mini_previous'),
+                onPressed: queue.hasPrevious ? queue.previous : null,
+                icon: const Icon(Icons.skip_previous),
+                tooltip: 'Piste précédente',
+              ),
+              _playPause(queue, colors),
+              IconButton(
+                key: const Key('queue_mini_next'),
+                onPressed: queue.hasNext ? queue.next : null,
+                icon: const Icon(Icons.skip_next),
+                tooltip: 'Piste suivante',
+              ),
+              IconButton(
+                key: const Key('queue_mini_stop'),
+                onPressed: queue.stop,
+                icon: const Icon(Icons.close),
+                tooltip: 'Arrêter',
+              ),
+              const SizedBox(width: 4),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _playPause(PlaylistQueueController queue, ColorScheme colors) {
+    if (queue.isBusy) {
+      return const Padding(
+        padding: EdgeInsets.all(14),
+        child: SizedBox(
+          width: 20,
+          height: 20,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+      );
+    }
+    final IconData icon;
+    if (queue.hasError || queue.isEnded) {
+      icon = Icons.replay;
+    } else if (queue.isPlaying) {
+      icon = Icons.pause;
+    } else {
+      icon = Icons.play_arrow;
+    }
+    return IconButton(
+      key: const Key('queue_mini_play_pause'),
+      onPressed: queue.togglePlayPause,
+      color: colors.primary,
+      iconSize: 30,
+      icon: Icon(icon),
+      tooltip: queue.isPlaying ? 'Pause' : 'Lecture',
+    );
+  }
+}

--- a/mobile/lib/features/playlists/presentation/widgets/queue_mini_player.dart
+++ b/mobile/lib/features/playlists/presentation/widgets/queue_mini_player.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../../../core/widgets/mini_player_shell.dart';
 import '../providers/playlist_queue_controller.dart';
 import 'playback_queue_sheet.dart';
 
@@ -17,13 +18,13 @@ class QueueMiniPlayer extends StatelessWidget {
     if (!queue.hasQueue || track == null) return const SizedBox.shrink();
 
     final colors = Theme.of(context).colorScheme;
-    final text = Theme.of(context).textTheme;
 
     // L'état prime sur le nom de l'artiste : sinon la fin de file ou une erreur
     // passeraient inaperçues (seule l'icône changerait).
     final (String subtitle, Color subtitleColor) = switch (queue.status) {
       PlaybackStatus.ended => ('File d\'attente terminée', colors.error),
       PlaybackStatus.error => ('Lecture impossible', colors.error),
+      PlaybackStatus.reconnecting => ('Reconnexion…', colors.onSurfaceVariant),
       _ => (
           '${queue.currentIndex + 1}/${queue.tracks.length} · '
               '${track.artist ?? 'Artiste inconnu'}',
@@ -31,92 +32,40 @@ class QueueMiniPlayer extends StatelessWidget {
         ),
     };
 
-    return Material(
-      color: colors.surfaceContainerHighest,
-      child: InkWell(
-        key: const Key('queue_mini_player'),
-        onTap: () => PlaybackQueueSheet.show(context),
-        child: SizedBox(
-          height: 60,
-          child: Row(
-            children: [
-              const SizedBox(width: 14),
-              Icon(Icons.queue_music, color: colors.primary),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      track.title,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style:
-                          text.titleSmall?.copyWith(fontWeight: FontWeight.w600),
-                    ),
-                    Text(
-                      subtitle,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: text.bodySmall?.copyWith(color: subtitleColor),
-                    ),
-                  ],
-                ),
-              ),
-              IconButton(
-                key: const Key('queue_mini_previous'),
-                onPressed: queue.hasPrevious ? queue.previous : null,
-                icon: const Icon(Icons.skip_previous),
-                tooltip: 'Piste précédente',
-              ),
-              _playPause(queue, colors),
-              IconButton(
-                key: const Key('queue_mini_next'),
-                onPressed: queue.hasNext ? queue.next : null,
-                icon: const Icon(Icons.skip_next),
-                tooltip: 'Piste suivante',
-              ),
-              IconButton(
-                key: const Key('queue_mini_stop'),
-                onPressed: queue.stop,
-                icon: const Icon(Icons.close),
-                tooltip: 'Arrêter',
-              ),
-              const SizedBox(width: 4),
-            ],
-          ),
+    return MiniPlayerShell(
+      key: const Key('queue_mini_player'),
+      icon: Icons.queue_music,
+      title: track.title,
+      subtitle: subtitle,
+      subtitleColor: subtitleColor,
+      onTap: () => PlaybackQueueSheet.show(context),
+      actions: [
+        IconButton(
+          key: const Key('queue_mini_previous'),
+          onPressed: queue.hasPrevious ? queue.previous : null,
+          icon: const Icon(Icons.skip_previous),
+          tooltip: 'Piste précédente',
         ),
-      ),
-    );
-  }
-
-  Widget _playPause(PlaylistQueueController queue, ColorScheme colors) {
-    if (queue.isBusy) {
-      return const Padding(
-        padding: EdgeInsets.all(14),
-        child: SizedBox(
-          width: 20,
-          height: 20,
-          child: CircularProgressIndicator(strokeWidth: 2),
+        PlaybackToggleButton(
+          key: const Key('queue_mini_play_pause'),
+          isBusy: queue.isBusy || queue.isReconnecting,
+          showReplay: queue.hasError || queue.isEnded,
+          isPlaying: queue.isPlaying,
+          onPressed: queue.togglePlayPause,
         ),
-      );
-    }
-    final IconData icon;
-    if (queue.hasError || queue.isEnded) {
-      icon = Icons.replay;
-    } else if (queue.isPlaying) {
-      icon = Icons.pause;
-    } else {
-      icon = Icons.play_arrow;
-    }
-    return IconButton(
-      key: const Key('queue_mini_play_pause'),
-      onPressed: queue.togglePlayPause,
-      color: colors.primary,
-      iconSize: 30,
-      icon: Icon(icon),
-      tooltip: queue.isPlaying ? 'Pause' : 'Lecture',
+        IconButton(
+          key: const Key('queue_mini_next'),
+          onPressed: queue.hasNext ? queue.next : null,
+          icon: const Icon(Icons.skip_next),
+          tooltip: 'Piste suivante',
+        ),
+        IconButton(
+          key: const Key('queue_mini_stop'),
+          onPressed: queue.stop,
+          icon: const Icon(Icons.close),
+          tooltip: 'Arrêter',
+        ),
+      ],
     );
   }
 }

--- a/mobile/lib/features/playlists/presentation/widgets/queue_track_visuals.dart
+++ b/mobile/lib/features/playlists/presentation/widgets/queue_track_visuals.dart
@@ -1,0 +1,38 @@
+/// Comment une piste « en cours de lecture » se distingue des autres, partagé
+/// par la feuille de file d'attente et l'écran de détail d'une playlist.
+///
+/// Les deux listes montrent la même file au même moment : si l'une marquait la
+/// piste courante autrement que l'autre, l'utilisateur verrait deux réponses
+/// différentes à « qu'est-ce qui joue ? ».
+library;
+
+import 'package:flutter/material.dart';
+
+/// Numéro de la piste, remplacé par l'égaliseur quand c'est elle qui joue.
+Widget queueTrackLeading(
+  BuildContext context, {
+  required int index,
+  required bool isCurrent,
+}) {
+  final colors = Theme.of(context).colorScheme;
+  if (isCurrent) {
+    return Icon(Icons.graphic_eq, color: colors.primary);
+  }
+  return Text(
+    '${index + 1}',
+    style: Theme.of(context)
+        .textTheme
+        .titleMedium
+        ?.copyWith(color: colors.onSurfaceVariant),
+  );
+}
+
+/// Style du titre : mis en avant pour la piste en cours, par défaut sinon.
+TextStyle? queueTrackTitleStyle(BuildContext context, {required bool isCurrent}) {
+  if (!isCurrent) return null;
+  final theme = Theme.of(context);
+  return theme.textTheme.titleMedium?.copyWith(
+    color: theme.colorScheme.primary,
+    fontWeight: FontWeight.w600,
+  );
+}

--- a/mobile/lib/features/streams/presentation/providers/audio_player_controller.dart
+++ b/mobile/lib/features/streams/presentation/providers/audio_player_controller.dart
@@ -6,21 +6,8 @@ import 'package:just_audio/just_audio.dart' show PlayerState, ProcessingState;
 import '../../../../core/audio/audio_playback_service.dart';
 import '../../../../core/constants/api_constants.dart';
 
-export '../../../../core/audio/audio_playback_service.dart' show NowPlaying;
-
-/// État applicatif du lecteur, mappé depuis just_audio et exposé à l'UI.
-/// `reconnecting` = une erreur transitoire est en cours de reprise automatique
-/// (STR-118) ; `error` = échec définitif (après épuisement des tentatives).
-enum PlaybackStatus {
-  idle,
-  loading,
-  buffering,
-  playing,
-  paused,
-  reconnecting,
-  ended,
-  error,
-}
+export '../../../../core/audio/audio_playback_service.dart'
+    show NowPlaying, PlaybackStatus;
 
 /// Abstraction du lecteur exposée à l'UI (Dependency Inversion) : les écrans et
 /// le mini-player dépendent de cette interface, jamais directement de
@@ -109,10 +96,18 @@ class AudioPlayerController extends PlaybackController {
   NowPlaying? get nowPlaying => _nowPlaying;
   Object? get error => _error;
 
+  /// Appelé **avant** que le direct ne reprenne le lecteur partagé, pour que la
+  /// file d'attente d'une playlist (US-05-04) libère son état : les deux
+  /// sources se partagent un unique lecteur natif, celle qui perd la main doit
+  /// cesser de prétendre jouer. Posé après construction (le contrôleur de file
+  /// est créé plus tard dans l'arbre de providers).
+  void Function()? onTakeOver;
+
   /// Charge le flux [now] et démarre la lecture (autoplay, STR-108). Réinitialise
   /// le compteur de reconnexions (action utilisateur).
   @override
   Future<void> load(NowPlaying now) async {
+    onTakeOver?.call();
     _nowPlaying = now;
     _retryCount = 0;
     _hasPlayed = false;
@@ -173,6 +168,11 @@ class AudioPlayerController extends PlaybackController {
   }
 
   void _onPlayerState(PlayerState state) {
+    // Aucun flux chargé : les états reçus décrivent une **autre** source (la
+    // file d'attente d'une playlist joue sur le même lecteur natif, US-05-04).
+    // Sans ce garde, ce contrôleur se croirait en lecture alors qu'il n'a rien
+    // à jouer.
+    if (_nowPlaying == null) return;
     // États applicatifs terminaux/transitoires : on n'écrase pas avec un état
     // résiduel du player. `ended` en fait partie car _recover() est asynchrone
     // (attente de la sonde HTTP) et le player peut émettre un `idle` juste après
@@ -203,7 +203,9 @@ class AudioPlayerController extends PlaybackController {
 
   /// Échec de lecture : déclenche la reprise (au plus une à la fois). STR-118.
   void _fail(Object e) {
-    if (_disposed) return;
+    // Même raison que dans [_onPlayerState] : sans flux chargé, l'erreur vient
+    // de l'autre source du lecteur partagé et ne nous concerne pas.
+    if (_disposed || _nowPlaying == null) return;
     _error = e;
     if (kDebugMode) {
       debugPrint('AudioPlayerController: erreur de lecture: $e');

--- a/mobile/lib/features/streams/presentation/widgets/mini_player.dart
+++ b/mobile/lib/features/streams/presentation/widgets/mini_player.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 
+import '../../../../core/widgets/mini_player_shell.dart';
 import '../providers/audio_player_controller.dart';
 
 /// Mini-player persistant (STR-109) : surface de contrôle in-app du flux en
@@ -19,7 +20,6 @@ class MiniPlayer extends StatelessWidget {
     }
 
     final colors = Theme.of(context).colorScheme;
-    final text = Theme.of(context).textTheme;
 
     // Sous-titre contextuel : l'état (terminé / indisponible / reconnexion)
     // prime sur le nom du diffuseur, sinon le mini-player resterait muet en fin
@@ -31,79 +31,25 @@ class MiniPlayer extends StatelessWidget {
       _ => (now.broadcaster, colors.onSurfaceVariant),
     };
 
-    return Material(
-      color: colors.surfaceContainerHighest,
-      child: InkWell(
-        onTap: () => context.push('/stream/${now.streamId}'),
-        child: SizedBox(
-          height: 60,
-          child: Row(
-            children: [
-              const SizedBox(width: 14),
-              Icon(Icons.graphic_eq, color: colors.primary),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      now.title,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: text.titleSmall
-                          ?.copyWith(fontWeight: FontWeight.w600),
-                    ),
-                    if (subtitle != null && subtitle.isNotEmpty)
-                      Text(
-                        subtitle,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style:
-                            text.bodySmall?.copyWith(color: subtitleColor),
-                      ),
-                  ],
-                ),
-              ),
-              _playPause(audio, colors),
-              IconButton(
-                onPressed: audio.stop,
-                icon: const Icon(Icons.close),
-                tooltip: 'Arrêter',
-              ),
-              const SizedBox(width: 4),
-            ],
-          ),
+    return MiniPlayerShell(
+      icon: Icons.graphic_eq,
+      title: now.title,
+      subtitle: subtitle,
+      subtitleColor: subtitleColor,
+      onTap: () => context.push('/stream/${now.streamId}'),
+      actions: [
+        PlaybackToggleButton(
+          isBusy: audio.isBusy || audio.isReconnecting,
+          showReplay: audio.hasError || audio.isEnded,
+          isPlaying: audio.isPlaying,
+          onPressed: audio.togglePlayPause,
         ),
-      ),
-    );
-  }
-
-  Widget _playPause(AudioPlayerController audio, ColorScheme colors) {
-    if (audio.isBusy || audio.isReconnecting) {
-      return const Padding(
-        padding: EdgeInsets.all(14),
-        child: SizedBox(
-          width: 20,
-          height: 20,
-          child: CircularProgressIndicator(strokeWidth: 2),
+        IconButton(
+          onPressed: audio.stop,
+          icon: const Icon(Icons.close),
+          tooltip: 'Arrêter',
         ),
-      );
-    }
-    final IconData icon;
-    if (audio.hasError || audio.isEnded) {
-      icon = Icons.replay;
-    } else if (audio.isPlaying) {
-      icon = Icons.pause;
-    } else {
-      icon = Icons.play_arrow;
-    }
-    return IconButton(
-      onPressed: audio.togglePlayPause,
-      color: colors.primary,
-      iconSize: 30,
-      icon: Icon(icon),
-      tooltip: audio.isPlaying ? 'Pause' : 'Lecture',
+      ],
     );
   }
 }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -29,7 +29,10 @@ Future<void> main() async {
 
   runApp(
     StreamPulseApp(
+      // Le même handler sous ses deux rôles : direct (STR-109) et file d'attente
+      // (US-05-04) partagent un unique lecteur natif, donc un unique service.
       audioService: audioHandler,
+      queueService: audioHandler,
       child: const App(),
     ),
   );

--- a/mobile/packages/streampulse_api/README.md
+++ b/mobile/packages/streampulse_api/README.md
@@ -113,6 +113,7 @@ Class | Method | HTTP request | Description
 [*StreamingApi*](doc/StreamingApi.md) | [**streamSegment**](doc/StreamingApi.md#streamsegment) | **GET** /api/streams/{id}/segments/{segment} | Get an HLS media segment (.ts).
 [*StreamingApi*](doc/StreamingApi.md) | [**updateStream**](doc/StreamingApi.md#updatestream) | **PUT** /api/streams/{id} | Update a stream (owner only).
 [*TrackApi*](doc/TrackApi.md) | [**listUserTracks**](doc/TrackApi.md#listusertracks) | **GET** /api/tracks | List the authenticated user&#39;s track library.
+[*TrackApi*](doc/TrackApi.md) | [**streamTrack**](doc/TrackApi.md#streamtrack) | **GET** /api/tracks/{id}/stream | Stream the audio file of one of the user&#39;s tracks.
 [*TrackApi*](doc/TrackApi.md) | [**uploadTrack**](doc/TrackApi.md#uploadtrack) | **POST** /api/tracks | Upload an audio file to the personal library.
 
 

--- a/mobile/packages/streampulse_api/lib/src/api/track_api.dart
+++ b/mobile/packages/streampulse_api/lib/src/api/track_api.dart
@@ -9,6 +9,7 @@ import 'dart:convert';
 import 'package:streampulse_api/src/deserialize.dart';
 import 'package:dio/dio.dart';
 
+import 'dart:typed_data';
 import 'package:streampulse_api/src/model/error_response.dart';
 import 'package:streampulse_api/src/model/track_response.dart';
 
@@ -81,6 +82,83 @@ class TrackApi {
     }
 
     return Response<List<TrackResponse>>(
+      data: _responseData,
+      headers: _response.headers,
+      isRedirect: _response.isRedirect,
+      requestOptions: _response.requestOptions,
+      redirects: _response.redirects,
+      statusCode: _response.statusCode,
+      statusMessage: _response.statusMessage,
+      extra: _response.extra,
+    );
+  }
+
+  /// Stream the audio file of one of the user&#39;s tracks.
+  /// Serves the raw audio bytes of a track owned by the authenticated user (US-05-04), so the mobile player can play a playlist queue. Range requests are honoured (&#x60;Accept-Ranges: bytes&#x60;), which lets the player resume or seek within a track without downloading it again. A track that belongs to somebody else is reported as 404, exactly like an unknown one: the status code never reveals that it exists.
+  ///
+  /// Parameters:
+  /// * [id] - Track identifier.
+  /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
+  /// * [headers] - Can be used to add additional headers to the request
+  /// * [extras] - Can be used to add flags to the request
+  /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
+  /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
+  /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
+  ///
+  /// Returns a [Future] containing a [Response] with a [Uint8List] as data
+  /// Throws [DioException] if API call or serialization fails
+  Future<Response<Uint8List>> streamTrack({
+    required String id,
+    CancelToken? cancelToken,
+    Map<String, dynamic>? headers,
+    Map<String, dynamic>? extra,
+    ValidateStatus? validateStatus,
+    ProgressCallback? onSendProgress,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    final _path = r'/api/tracks/{id}/stream'.replaceAll(
+      '{'
+      r'id'
+      '}',
+      id.toString(),
+    );
+    final _options = Options(
+      method: r'GET',
+      responseType: ResponseType.bytes,
+      headers: <String, dynamic>{...?headers},
+      extra: <String, dynamic>{
+        'secure': <Map<String, String>>[
+          {'type': 'http', 'scheme': 'bearer', 'name': 'bearerAuth'},
+        ],
+        ...?extra,
+      },
+      validateStatus: validateStatus,
+    );
+
+    final _response = await _dio.request<Object>(
+      _path,
+      options: _options,
+      cancelToken: cancelToken,
+      onSendProgress: onSendProgress,
+      onReceiveProgress: onReceiveProgress,
+    );
+
+    Uint8List? _responseData;
+
+    try {
+      final rawData = _response.data;
+      _responseData = rawData == null ? null : rawData as Uint8List;
+    } catch (error, stackTrace) {
+      throw DioException(
+        requestOptions: _response.requestOptions,
+        response: _response,
+        type: DioExceptionType.unknown,
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+
+    return Response<Uint8List>(
       data: _responseData,
       headers: _response.headers,
       isRedirect: _response.isRedirect,

--- a/mobile/test/app/shell/player_bar_test.dart
+++ b/mobile/test/app/shell/player_bar_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:streampulse/app/shell/player_bar.dart';
+import 'package:streampulse/features/playlists/domain/entities/playlist_track.dart';
+import 'package:streampulse/features/playlists/presentation/providers/playlist_queue_controller.dart';
+import 'package:streampulse/features/playlists/presentation/widgets/queue_mini_player.dart';
+import 'package:streampulse/features/streams/presentation/providers/audio_player_controller.dart';
+import 'package:streampulse/features/streams/presentation/widgets/mini_player.dart';
+
+import '../../support/fake_audio_playback_service.dart';
+import '../../support/fake_queue_playback_service.dart';
+
+const _now = NowPlaying(streamId: 's1', title: 'Radio Nova', broadcaster: 'DJ');
+
+const _tracks = [
+  PlaylistTrack(
+    id: 't1',
+    title: 'Midnight Drive',
+    artist: 'Neon Lights',
+    durationS: 214,
+    position: 0,
+  ),
+];
+
+/// Reproduit le câblage croisé d'`app_providers` : démarrer une file arrête le
+/// direct, et démarrer un direct abandonne la file.
+({
+  AudioPlayerController live,
+  PlaylistQueueController queue,
+}) _controllers(
+  FakeAudioPlaybackService liveService,
+  FakeQueuePlaybackService queueService,
+) {
+  final live = AudioPlayerController(service: liveService);
+  final queue = PlaylistQueueController(
+    service: queueService,
+    token: ({bool forceRefresh = false}) async => 'jwt',
+    stopLive: live.stop,
+  );
+  live.onTakeOver = queue.clear;
+  addTearDown(live.dispose);
+  addTearDown(queue.dispose);
+  return (live: live, queue: queue);
+}
+
+Widget _host(AudioPlayerController live, PlaylistQueueController queue) {
+  return MultiProvider(
+    providers: [
+      ChangeNotifierProvider<AudioPlayerController>.value(value: live),
+      ChangeNotifierProvider<PlaylistQueueController>.value(value: queue),
+    ],
+    child: const MaterialApp(home: Scaffold(body: PlayerBar())),
+  );
+}
+
+void main() {
+  group('PlayerBar — un seul lecteur pour deux sources (US-05-04)', () {
+    testWidgets('sans file active, la barre est celle du direct',
+        (tester) async {
+      final liveService = FakeAudioPlaybackService();
+      final queueService = FakeQueuePlaybackService();
+      addTearDown(liveService.dispose);
+      addTearDown(queueService.dispose);
+      final c = _controllers(liveService, queueService);
+
+      await tester.pumpWidget(_host(c.live, c.queue));
+
+      expect(find.byType(MiniPlayer), findsOneWidget);
+      expect(find.byType(QueueMiniPlayer), findsNothing);
+    });
+
+    testWidgets('lancer une playlist arrête le direct et bascule la barre',
+        (tester) async {
+      final liveService = FakeAudioPlaybackService();
+      final queueService = FakeQueuePlaybackService();
+      addTearDown(liveService.dispose);
+      addTearDown(queueService.dispose);
+      final c = _controllers(liveService, queueService);
+
+      await c.live.load(_now);
+      await c.queue.play(
+        playlistId: 'p-1',
+        playlistName: 'My Favorites',
+        tracks: _tracks,
+      );
+      await tester.pumpWidget(_host(c.live, c.queue));
+
+      expect(find.byType(QueueMiniPlayer), findsOneWidget);
+      expect(find.byType(MiniPlayer), findsNothing);
+      expect(c.live.status, PlaybackStatus.idle);
+    });
+
+    testWidgets('reprendre un direct abandonne la file et rend la barre',
+        (tester) async {
+      final liveService = FakeAudioPlaybackService();
+      final queueService = FakeQueuePlaybackService();
+      addTearDown(liveService.dispose);
+      addTearDown(queueService.dispose);
+      final c = _controllers(liveService, queueService);
+
+      await c.queue.play(
+        playlistId: 'p-1',
+        playlistName: 'My Favorites',
+        tracks: _tracks,
+      );
+      await c.live.load(_now);
+      await tester.pumpWidget(_host(c.live, c.queue));
+
+      expect(find.byType(MiniPlayer), findsOneWidget);
+      expect(find.byType(QueueMiniPlayer), findsNothing);
+      expect(c.queue.hasQueue, isFalse);
+      // Le direct vient de charger la source partagée : la file l'abandonne
+      // sans arrêter le lecteur, sinon elle couperait ce direct.
+      expect(queueService.stopped, isFalse);
+    });
+  });
+}

--- a/mobile/test/features/playlists/presentation/playlist_queue_controller_test.dart
+++ b/mobile/test/features/playlists/presentation/playlist_queue_controller_test.dart
@@ -1,0 +1,272 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:just_audio/just_audio.dart' show PlayerState, ProcessingState;
+import 'package:streampulse/core/constants/api_constants.dart';
+import 'package:streampulse/features/playlists/domain/entities/playlist_track.dart';
+import 'package:streampulse/features/playlists/presentation/providers/playlist_queue_controller.dart';
+
+import '../../../support/fake_queue_playback_service.dart';
+
+PlaylistTrack _track(String id, String title, int position) => PlaylistTrack(
+      id: id,
+      title: title,
+      artist: 'Neon Lights',
+      durationS: 214,
+      position: position,
+    );
+
+final _tracks = [
+  _track('t1', 'Midnight Drive', 0),
+  _track('t2', 'Sunrise', 1),
+  _track('t3', 'Afterglow', 2),
+];
+
+/// Contrôleur sous test + fake associé. [tokens] permet d'observer les demandes
+/// de rotation d'access token.
+({PlaylistQueueController controller, FakeQueuePlaybackService service})
+    _build({
+  List<bool>? tokens,
+  Future<void> Function()? stopLive,
+}) {
+  final service = FakeQueuePlaybackService();
+  final controller = PlaylistQueueController(
+    service: service,
+    token: ({bool forceRefresh = false}) async {
+      tokens?.add(forceRefresh);
+      return 'jwt-access';
+    },
+    stopLive: stopLive,
+  );
+  addTearDown(controller.dispose);
+  addTearDown(service.dispose);
+  return (controller: controller, service: service);
+}
+
+Future<void> _play(
+  PlaylistQueueController controller, {
+  int startIndex = 0,
+  List<PlaylistTrack>? tracks,
+}) {
+  return controller.play(
+    playlistId: 'p-1',
+    playlistName: 'My Favorites',
+    tracks: tracks ?? _tracks,
+    startIndex: startIndex,
+  );
+}
+
+void main() {
+  group('PlaylistQueueController — lancement (US-05-04)', () {
+    test('charge la file entière, authentifiée, et démarre la lecture',
+        () async {
+      final t = _build();
+
+      await _play(t.controller);
+
+      expect(t.service.loadCalls, 1);
+      expect(t.service.playCalls, 1);
+      expect(
+        t.service.lastItems.map((i) => i.id).toList(),
+        ['t1', 't2', 't3'],
+      );
+      // Les fichiers d'une bibliothèque sont privés : sans en-tête, le serveur
+      // répondrait 401 et rien ne jouerait.
+      expect(t.service.lastHeaders['Authorization'], 'Bearer jwt-access');
+      expect(t.service.lastItems.first.url, ApiConstants.trackStream('t1'));
+      expect(t.service.lastItems.first.duration, const Duration(seconds: 214));
+      expect(t.controller.hasQueue, isTrue);
+      expect(t.controller.playlistName, 'My Favorites');
+    });
+
+    test('démarre à la piste demandée (appui sur une ligne de la playlist)',
+        () async {
+      final t = _build();
+
+      await _play(t.controller, startIndex: 2);
+
+      expect(t.service.lastInitialIndex, 2);
+      expect(t.controller.currentIndex, 2);
+      expect(t.controller.currentTrack?.id, 't3');
+    });
+
+    test('arrête le direct avant de prendre le lecteur partagé', () async {
+      var liveStopped = false;
+      final t = _build(stopLive: () async => liveStopped = true);
+
+      await _play(t.controller);
+
+      expect(liveStopped, isTrue);
+    });
+
+    test('une playlist vide ne lance rien', () async {
+      final t = _build();
+
+      await _play(t.controller, tracks: const []);
+
+      expect(t.service.loadCalls, 0);
+      expect(t.controller.hasQueue, isFalse);
+    });
+  });
+
+  group('PlaylistQueueController — file d\'attente', () {
+    test('l\'enchaînement automatique fait suivre la piste courante', () async {
+      final t = _build();
+      await _play(t.controller);
+
+      // C'est le lecteur natif qui enchaîne : le contrôleur l'apprend par
+      // currentIndexStream, pas en décidant lui-même.
+      t.service.emitIndex(1);
+      await pumpEventQueue();
+
+      expect(t.controller.currentIndex, 1);
+      expect(t.controller.currentTrack?.title, 'Sunrise');
+      // Aucun rechargement : la file était déjà dans le lecteur.
+      expect(t.service.loadCalls, 1);
+    });
+
+    test('sauter à une piste la demande au lecteur et relance', () async {
+      final t = _build();
+      await _play(t.controller);
+      t.service.emitState(PlayerState(true, ProcessingState.ready));
+      await pumpEventQueue();
+
+      await t.controller.skipTo(2);
+
+      expect(t.service.skips, [2]);
+      expect(t.controller.currentIndex, 2);
+    });
+
+    test('un index hors file est ignoré', () async {
+      final t = _build();
+      await _play(t.controller);
+
+      await t.controller.skipTo(9);
+
+      expect(t.service.skips, isEmpty);
+      expect(t.controller.currentIndex, 0);
+    });
+
+    test('la fin de la dernière piste termine la file', () async {
+      final t = _build();
+      await _play(t.controller);
+
+      t.service.emitState(PlayerState(false, ProcessingState.completed));
+      await pumpEventQueue();
+
+      expect(t.controller.status, PlaybackStatus.ended);
+      // La file reste affichée : l'utilisateur peut la relancer ou y sauter.
+      expect(t.controller.hasQueue, isTrue);
+    });
+
+    test('sauter à une piste après la fin recharge la file', () async {
+      final t = _build();
+      await _play(t.controller);
+      t.service.emitState(PlayerState(false, ProcessingState.completed));
+      await pumpEventQueue();
+
+      await t.controller.skipTo(1);
+
+      // La source native est épuisée : un simple seek ne relancerait rien.
+      expect(t.service.loadCalls, 2);
+      expect(t.service.lastInitialIndex, 1);
+    });
+
+    test('hasNext / hasPrevious bornent la navigation', () async {
+      final t = _build();
+      await _play(t.controller);
+
+      expect(t.controller.hasPrevious, isFalse);
+      expect(t.controller.hasNext, isTrue);
+
+      t.service.emitIndex(2);
+      await pumpEventQueue();
+
+      expect(t.controller.hasPrevious, isTrue);
+      expect(t.controller.hasNext, isFalse);
+    });
+  });
+
+  group('PlaylistQueueController — erreurs', () {
+    test('un échec relance une fois après rotation du token', () async {
+      final tokens = <bool>[];
+      final t = _build(tokens: tokens);
+      await _play(t.controller);
+      expect(tokens, [false]);
+
+      // Cas typique : l'access token (15 min) a expiré au milieu de la file.
+      t.service.emitError(Exception('401'));
+      await pumpEventQueue();
+
+      expect(t.service.loadCalls, 2);
+      expect(tokens, [false, true], reason: 'la reprise force un refresh');
+      expect(t.controller.hasError, isFalse);
+    });
+
+    test('un second échec devient un état d\'erreur', () async {
+      final t = _build();
+      await _play(t.controller);
+
+      t.service.emitError(Exception('401'));
+      await pumpEventQueue();
+      t.service.emitError(Exception('toujours KO'));
+      await pumpEventQueue();
+
+      expect(t.controller.hasError, isTrue);
+      // Pas de troisième tentative : réessayer en boucle masquerait l'erreur.
+      expect(t.service.loadCalls, 2);
+    });
+
+    test('une piste qui s\'ouvre réarme la reprise pour la suite de la file',
+        () async {
+      final t = _build();
+      await _play(t.controller);
+
+      t.service.emitError(Exception('401'));
+      await pumpEventQueue();
+      t.service.emitState(PlayerState(true, ProcessingState.ready));
+      await pumpEventQueue();
+      t.service.emitError(Exception('401 plus loin'));
+      await pumpEventQueue();
+
+      expect(t.service.loadCalls, 3);
+      expect(t.controller.hasError, isFalse);
+    });
+  });
+
+  group('PlaylistQueueController — arrêt', () {
+    test('stop vide la file et arrête le lecteur', () async {
+      final t = _build();
+      await _play(t.controller);
+
+      await t.controller.stop();
+
+      expect(t.service.stopped, isTrue);
+      expect(t.controller.hasQueue, isFalse);
+      expect(t.controller.status, PlaybackStatus.idle);
+      expect(t.controller.tracks, isEmpty);
+    });
+
+    test('clear abandonne la file sans toucher au lecteur (le direct reprend)',
+        () async {
+      final t = _build();
+      await _play(t.controller);
+
+      t.controller.clear();
+
+      expect(t.controller.hasQueue, isFalse);
+      // Arrêter le lecteur ici couperait le direct qui vient de le charger.
+      expect(t.service.stopped, isFalse);
+    });
+
+    test('un chargement encore en vol ne ressuscite pas une file arrêtée',
+        () async {
+      final t = _build();
+      final pending = _play(t.controller);
+      t.controller.clear();
+      await pending;
+      await pumpEventQueue();
+
+      expect(t.controller.hasQueue, isFalse);
+      expect(t.controller.status, PlaybackStatus.idle);
+    });
+  });
+}

--- a/mobile/test/features/playlists/presentation/playlist_queue_controller_test.dart
+++ b/mobile/test/features/playlists/presentation/playlist_queue_controller_test.dart
@@ -1,3 +1,4 @@
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:just_audio/just_audio.dart' show PlayerState, ProcessingState;
 import 'package:streampulse/core/constants/api_constants.dart';
@@ -145,6 +146,53 @@ void main() {
       expect(t.controller.currentIndex, 0);
     });
 
+    test('un état résiduel du lecteur n\'efface pas la fin de file', () async {
+      final t = _build();
+      await _play(t.controller);
+      t.service.emitState(PlayerState(false, ProcessingState.completed));
+      await pumpEventQueue();
+      expect(t.controller.isEnded, isTrue);
+
+      // `idle` émis juste après `completed` (libération de la source) : sans
+      // garde, le mini-player « terminée » et son bouton de relance
+      // disparaîtraient.
+      t.service.emitState(PlayerState(false, ProcessingState.idle));
+      await pumpEventQueue();
+
+      expect(t.controller.isEnded, isTrue);
+      expect(t.controller.hasQueue, isTrue);
+    });
+
+    test('relancer une file déjà en cours ne fait pas clignoter le lecteur',
+        () async {
+      // Le direct qu'on arrête émet un `idle` alors que la file précédente est
+      // encore affichée : `hasQueue` doit rester vrai sur toute la bascule,
+      // sinon PlayerBar retire puis remet le mini-player.
+      final service = FakeQueuePlaybackService();
+      final controller = PlaylistQueueController(
+        service: service,
+        token: ({bool forceRefresh = false}) async => 'jwt-access',
+        stopLive: () async =>
+            service.emitState(PlayerState(false, ProcessingState.idle)),
+      );
+      addTearDown(controller.dispose);
+      addTearDown(service.dispose);
+      final t = (controller: controller, service: service);
+
+      await _play(t.controller);
+      t.service.emitState(PlayerState(true, ProcessingState.ready));
+      await pumpEventQueue();
+
+      final seen = <bool>[];
+      t.controller.addListener(() => seen.add(t.controller.hasQueue));
+      await _play(t.controller);
+      await pumpEventQueue();
+
+      expect(seen, isNotEmpty);
+      expect(seen.contains(false), isFalse,
+          reason: 'la file ne doit jamais paraître inactive pendant la bascule');
+    });
+
     test('la fin de la dernière piste termine la file', () async {
       final t = _build();
       await _play(t.controller);
@@ -185,50 +233,124 @@ void main() {
     });
   });
 
-  group('PlaylistQueueController — erreurs', () {
-    test('un échec relance une fois après rotation du token', () async {
-      final tokens = <bool>[];
-      final t = _build(tokens: tokens);
-      await _play(t.controller);
-      expect(tokens, [false]);
+  group('PlaylistQueueController — reprise après erreur', () {
+    /// Laisse filer le backoff (1/2/4 s) sans attendre en temps réel.
+    Future<void> elapse(FakeAsync async, {int seconds = 10}) async {
+      async.elapse(Duration(seconds: seconds));
+      async.flushMicrotasks();
+    }
 
-      // Cas typique : l'access token (15 min) a expiré au milieu de la file.
-      t.service.emitError(Exception('401'));
-      await pumpEventQueue();
+    test('la reprise attend le backoff, force UN refresh et garde la position',
+        () {
+      fakeAsync((async) {
+        final tokens = <bool>[];
+        final t = _build(tokens: tokens);
+        _play(t.controller);
+        async.flushMicrotasks();
+        expect(tokens, [false]);
 
-      expect(t.service.loadCalls, 2);
-      expect(tokens, [false, true], reason: 'la reprise force un refresh');
-      expect(t.controller.hasError, isFalse);
+        // L'auditeur était à 30 s de la piste quand le réseau a lâché.
+        t.service.position = const Duration(seconds: 30);
+        t.service.emitError(Exception('coupure'));
+        async.flushMicrotasks();
+
+        // Rechargement différé : pendant le backoff, l'état est « reconnexion ».
+        expect(t.controller.status, PlaybackStatus.reconnecting);
+        expect(t.service.loadCalls, 1, reason: 'pas de rechargement immédiat');
+
+        elapse(async);
+        expect(t.service.loadCalls, 2);
+        expect(t.service.lastInitialPosition, const Duration(seconds: 30),
+            reason: 'une coupure brève ne doit pas faire recommencer la piste');
+        expect(tokens, [false, true],
+            reason: 'la première reprise seule force une rotation de token');
+      });
     });
 
-    test('un second échec devient un état d\'erreur', () async {
-      final t = _build();
-      await _play(t.controller);
+    test('les reprises suivantes ne redemandent pas de rotation de token', () {
+      fakeAsync((async) {
+        final tokens = <bool>[];
+        final t = _build(tokens: tokens);
+        _play(t.controller);
+        async.flushMicrotasks();
 
-      t.service.emitError(Exception('401'));
-      await pumpEventQueue();
-      t.service.emitError(Exception('toujours KO'));
-      await pumpEventQueue();
+        for (var i = 0; i < 2; i++) {
+          t.service.emitError(Exception('encore KO'));
+          async.flushMicrotasks();
+          elapse(async);
+        }
 
-      expect(t.controller.hasError, isTrue);
-      // Pas de troisième tentative : réessayer en boucle masquerait l'erreur.
-      expect(t.service.loadCalls, 2);
+        // Une rotation n'ayant pas résolu l'échec, en enchaîner d'autres non plus.
+        expect(tokens, [false, true, false]);
+      });
     });
 
-    test('une piste qui s\'ouvre réarme la reprise pour la suite de la file',
-        () async {
-      final t = _build();
-      await _play(t.controller);
+    test('les reprises sont bornées : au-delà, état d\'erreur', () {
+      fakeAsync((async) {
+        final t = _build();
+        _play(t.controller);
+        async.flushMicrotasks();
 
-      t.service.emitError(Exception('401'));
-      await pumpEventQueue();
-      t.service.emitState(PlayerState(true, ProcessingState.ready));
-      await pumpEventQueue();
-      t.service.emitError(Exception('401 plus loin'));
-      await pumpEventQueue();
+        for (var i = 0; i < 4; i++) {
+          t.service.emitError(Exception('KO'));
+          async.flushMicrotasks();
+          elapse(async);
+        }
 
-      expect(t.service.loadCalls, 3);
-      expect(t.controller.hasError, isFalse);
+        expect(t.controller.hasError, isTrue);
+        // 1 chargement initial + 3 reprises, pas une de plus.
+        expect(t.service.loadCalls, 4);
+      });
+    });
+
+    test(
+        'une piste qui rejoue puis re-échoue ne boucle pas indéfiniment '
+        '(réseau instable)', () {
+      fakeAsync((async) {
+        final tokens = <bool>[];
+        final t = _build(tokens: tokens);
+        _play(t.controller);
+        async.flushMicrotasks();
+
+        // Le cycle ready → erreur se répète : sans compteur persistant, chaque
+        // `ready` réarmerait la reprise et la piste repartirait sans fin.
+        for (var i = 0; i < 5; i++) {
+          t.service.emitState(PlayerState(true, ProcessingState.ready));
+          async.flushMicrotasks();
+          t.service.emitError(Exception('flap'));
+          async.flushMicrotasks();
+          elapse(async);
+        }
+
+        expect(t.controller.hasError, isTrue);
+        expect(t.service.loadCalls, 4, reason: 'bornées malgré les ready');
+        expect(tokens.where((forced) => forced).length, 1,
+            reason: 'une seule rotation de token sur toute la séquence');
+      });
+    });
+
+    test('avancer dans la file réarme les reprises', () {
+      fakeAsync((async) {
+        final t = _build();
+        _play(t.controller);
+        async.flushMicrotasks();
+
+        t.service.emitError(Exception('KO sur la piste 1'));
+        async.flushMicrotasks();
+        elapse(async);
+
+        // La file avance : la piste suivante repart avec son quota complet.
+        t.service.emitIndex(1);
+        async.flushMicrotasks();
+        for (var i = 0; i < 3; i++) {
+          t.service.emitError(Exception('KO sur la piste 2'));
+          async.flushMicrotasks();
+          elapse(async);
+        }
+
+        expect(t.controller.hasError, isFalse,
+            reason: '3 reprises restaient disponibles sur la nouvelle piste');
+      });
     });
   });
 

--- a/mobile/test/features/playlists/presentation/screens/playlist_detail_screen_test.dart
+++ b/mobile/test/features/playlists/presentation/screens/playlist_detail_screen_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
 import 'package:toastification/toastification.dart';
 
 import 'package:streampulse/core/errors/exceptions.dart';
@@ -7,7 +8,10 @@ import 'package:streampulse/features/playlists/domain/entities/playlist.dart';
 import 'package:streampulse/features/playlists/domain/entities/playlist_track.dart';
 import 'package:streampulse/features/playlists/domain/entities/track.dart';
 import 'package:streampulse/features/playlists/domain/repositories/playlist_repository.dart';
+import 'package:streampulse/features/playlists/presentation/providers/playlist_queue_controller.dart';
 import 'package:streampulse/features/playlists/presentation/screens/playlist_detail_screen.dart';
+
+import '../../../../support/fake_queue_playback_service.dart';
 
 PlaylistTrack _track(String id, String title, int position) => PlaylistTrack(
       id: id,
@@ -88,17 +92,35 @@ class _FakePlaylistRepository implements PlaylistRepository {
   Future<void> delete(String id) => throw UnimplementedError();
 }
 
-Widget _harness(PlaylistRepository repository, {TargetPlatform? platform}) {
-  return ToastificationWrapper(
-    child: MaterialApp(
-      // `ReorderableListView` choisit ses poignées par défaut d'après
-      // `Theme.of(context).platform` : le forcer permet de tester le rendu
-      // desktop.
-      theme: platform == null ? null : ThemeData(platform: platform),
-      home: PlaylistDetailScreen(
-        playlistId: 'p-1',
-        playlistName: 'My Favorites',
-        repository: repository,
+/// Contrôleur de file d'attente pour les tests d'écran : le service est un fake,
+/// le token une constante (l'écran ne fait que déclencher la lecture).
+PlaylistQueueController _queueController(FakeQueuePlaybackService service) {
+  return PlaylistQueueController(
+    service: service,
+    token: ({bool forceRefresh = false}) async => 'jwt',
+  );
+}
+
+Widget _harness(
+  PlaylistRepository repository, {
+  TargetPlatform? platform,
+  PlaylistQueueController? queue,
+}) {
+  // L'écran lit la file d'attente app-level (US-05-04) pour lancer la lecture et
+  // souligner la piste en cours : elle doit exister au-dessus de lui.
+  return ChangeNotifierProvider<PlaylistQueueController>.value(
+    value: queue ?? _queueController(FakeQueuePlaybackService()),
+    child: ToastificationWrapper(
+      child: MaterialApp(
+        // `ReorderableListView` choisit ses poignées par défaut d'après
+        // `Theme.of(context).platform` : le forcer permet de tester le rendu
+        // desktop.
+        theme: platform == null ? null : ThemeData(platform: platform),
+        home: PlaylistDetailScreen(
+          playlistId: 'p-1',
+          playlistName: 'My Favorites',
+          repository: repository,
+        ),
       ),
     ),
   );
@@ -140,6 +162,57 @@ void main() {
       expect(find.text('1'), findsOneWidget);
       expect(find.text('2'), findsOneWidget);
       expect(find.byKey(const Key('playlist_tracks_list')), findsOneWidget);
+    });
+
+    testWidgets('le bouton Lire lance la playlist depuis le début (US-05-04)',
+        (tester) async {
+      final repo = _FakePlaylistRepository(
+        initial: [_track('t1', 'Midnight Drive', 0), _track('t2', 'Sunrise', 1)],
+      );
+      final service = FakeQueuePlaybackService();
+      final queue = _queueController(service);
+      addTearDown(queue.dispose);
+      addTearDown(service.dispose);
+
+      await tester.pumpWidget(_harness(repo, queue: queue));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('playlist_play_button')));
+      await tester.pumpAndSettle();
+
+      expect(service.lastItems.map((i) => i.id).toList(), ['t1', 't2']);
+      expect(service.lastInitialIndex, 0);
+      expect(queue.playlistName, 'My Favorites');
+      // La ligne en cours est repérable : son numéro cède la place à l'icône.
+      expect(find.byIcon(Icons.graphic_eq), findsOneWidget);
+    });
+
+    testWidgets('un appui sur une piste démarre la file à cette piste',
+        (tester) async {
+      final repo = _FakePlaylistRepository(
+        initial: [_track('t1', 'Midnight Drive', 0), _track('t2', 'Sunrise', 1)],
+      );
+      final service = FakeQueuePlaybackService();
+      final queue = _queueController(service);
+      addTearDown(queue.dispose);
+      addTearDown(service.dispose);
+
+      await tester.pumpWidget(_harness(repo, queue: queue));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Sunrise'));
+      await tester.pumpAndSettle();
+
+      // Toute la playlist est chargée — on démarre juste plus loin dedans.
+      expect(service.lastItems.map((i) => i.id).toList(), ['t1', 't2']);
+      expect(service.lastInitialIndex, 1);
+      expect(queue.currentIndex, 1);
+    });
+
+    testWidgets('playlist vide : ni bouton Lire, ni file lancée',
+        (tester) async {
+      await tester.pumpWidget(_harness(_FakePlaylistRepository()));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('playlist_play_button')), findsNothing);
     });
 
     testWidgets('playlist vide : message dédié + appel à l\'action',

--- a/mobile/test/features/playlists/presentation/widgets/queue_ui_test.dart
+++ b/mobile/test/features/playlists/presentation/widgets/queue_ui_test.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:just_audio/just_audio.dart' show PlayerState, ProcessingState;
+import 'package:provider/provider.dart';
+
+import 'package:streampulse/features/playlists/domain/entities/playlist_track.dart';
+import 'package:streampulse/features/playlists/presentation/providers/playlist_queue_controller.dart';
+import 'package:streampulse/features/playlists/presentation/widgets/queue_mini_player.dart';
+
+import '../../../../support/fake_queue_playback_service.dart';
+
+PlaylistTrack _track(String id, String title, int position) => PlaylistTrack(
+      id: id,
+      title: title,
+      artist: 'Neon Lights',
+      durationS: 214,
+      position: position,
+    );
+
+final _tracks = [
+  _track('t1', 'Midnight Drive', 0),
+  _track('t2', 'Sunrise', 1),
+  _track('t3', 'Afterglow', 2),
+];
+
+Widget _host(PlaylistQueueController controller, Widget child) {
+  return ChangeNotifierProvider<PlaylistQueueController>.value(
+    value: controller,
+    child: MaterialApp(home: Scaffold(body: child)),
+  );
+}
+
+/// Monte [child] au-dessus d'une file en cours de lecture.
+///
+/// L'ordre compte : le widget est monté **avant** l'émission de l'état du
+/// lecteur, car sous `testWidgets` seule une `pump` fait avancer la boucle
+/// d'événements (le temps y est simulé).
+Future<
+    ({
+      PlaylistQueueController controller,
+      FakeQueuePlaybackService service,
+    })> _pumpPlaying(
+  WidgetTester tester,
+  Widget child, {
+  int startIndex = 0,
+}) async {
+  final service = FakeQueuePlaybackService();
+  final controller = PlaylistQueueController(
+    service: service,
+    token: ({bool forceRefresh = false}) async => 'jwt',
+  );
+  addTearDown(controller.dispose);
+  addTearDown(service.dispose);
+
+  await controller.play(
+    playlistId: 'p-1',
+    playlistName: 'My Favorites',
+    tracks: _tracks,
+    startIndex: startIndex,
+  );
+  await tester.pumpWidget(_host(controller, child));
+  service.emitState(PlayerState(true, ProcessingState.ready));
+  await tester.pump();
+  return (controller: controller, service: service);
+}
+
+/// Ouvre la file d'attente depuis le mini-player.
+Future<void> _openQueueSheet(WidgetTester tester) async {
+  await tester.tap(find.byKey(const Key('queue_mini_player')));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('QueueMiniPlayer (US-05-04)', () {
+    testWidgets('masqué quand aucune file n\'est active', (tester) async {
+      final service = FakeQueuePlaybackService();
+      final controller = PlaylistQueueController(
+        service: service,
+        token: ({bool forceRefresh = false}) async => 'jwt',
+      );
+      addTearDown(controller.dispose);
+      addTearDown(service.dispose);
+
+      await tester.pumpWidget(_host(controller, const QueueMiniPlayer()));
+
+      expect(find.byKey(const Key('queue_mini_player')), findsNothing);
+    });
+
+    testWidgets('affiche la piste en cours et sa position dans la file',
+        (tester) async {
+      await _pumpPlaying(tester, const QueueMiniPlayer());
+
+      expect(find.text('Midnight Drive'), findsOneWidget);
+      expect(find.text('1/3 · Neon Lights'), findsOneWidget);
+      expect(find.byIcon(Icons.pause), findsOneWidget);
+    });
+
+    testWidgets('suivant / précédent naviguent dans la file', (tester) async {
+      final t = await _pumpPlaying(tester, const QueueMiniPlayer());
+
+      // Sur la première piste, « précédent » n'a rien à faire.
+      final previous = tester.widget<IconButton>(
+        find.byKey(const Key('queue_mini_previous')),
+      );
+      expect(previous.onPressed, isNull);
+
+      await tester.tap(find.byKey(const Key('queue_mini_next')));
+      await tester.pump();
+
+      expect(t.service.skips, [1]);
+      expect(find.text('Sunrise'), findsOneWidget);
+    });
+
+    testWidgets('la fin de file est annoncée et relançable', (tester) async {
+      final t = await _pumpPlaying(tester, const QueueMiniPlayer());
+
+      t.service.emitState(PlayerState(false, ProcessingState.completed));
+      await tester.pump();
+
+      expect(find.text('File d\'attente terminée'), findsOneWidget);
+      expect(find.byIcon(Icons.replay), findsOneWidget);
+    });
+
+    testWidgets('la croix arrête la lecture et masque la barre',
+        (tester) async {
+      final t = await _pumpPlaying(tester, const QueueMiniPlayer());
+
+      await tester.tap(find.byKey(const Key('queue_mini_stop')));
+      await tester.pump();
+
+      expect(t.service.stopped, isTrue);
+      expect(find.byKey(const Key('queue_mini_player')), findsNothing);
+    });
+  });
+
+  group('PlaybackQueueSheet (US-05-04)', () {
+    testWidgets('liste la file entière et marque la piste en cours',
+        (tester) async {
+      await _pumpPlaying(tester, const QueueMiniPlayer(), startIndex: 1);
+      await _openQueueSheet(tester);
+
+      expect(find.byKey(const Key('playback_queue_list')), findsOneWidget);
+      expect(find.text('2/3'), findsOneWidget);
+      for (final track in _tracks) {
+        expect(find.byKey(Key('queue_item_${track.id}')), findsOneWidget);
+      }
+      // La piste en cours porte l'icône d'équaliseur au lieu de son numéro.
+      expect(find.byIcon(Icons.graphic_eq), findsOneWidget);
+    });
+
+    testWidgets('un appui sur une piste y saute', (tester) async {
+      final t = await _pumpPlaying(tester, const QueueMiniPlayer());
+      await _openQueueSheet(tester);
+
+      await tester.tap(find.byKey(const Key('queue_item_t3')));
+      await tester.pumpAndSettle();
+
+      expect(t.service.skips, [2]);
+      expect(t.controller.currentIndex, 2);
+    });
+
+    testWidgets('la feuille se referme si la file s\'arrête pendant', (
+      tester,
+    ) async {
+      final t = await _pumpPlaying(tester, const QueueMiniPlayer());
+      await _openQueueSheet(tester);
+      expect(find.byKey(const Key('playback_queue_list')), findsOneWidget);
+
+      // Arrêt depuis la notification système, ou direct qui reprend le lecteur.
+      await t.controller.stop();
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('playback_queue_list')), findsNothing);
+    });
+  });
+}

--- a/mobile/test/support/fake_queue_playback_service.dart
+++ b/mobile/test/support/fake_queue_playback_service.dart
@@ -1,0 +1,86 @@
+import 'dart:async';
+
+import 'package:just_audio/just_audio.dart' show PlayerState;
+import 'package:streampulse/core/audio/queue_playback_service.dart';
+
+/// Fake [QueuePlaybackService] pilotable, sans just_audio ni audio_service : les
+/// flux d'état / d'index / d'erreur sont poussés manuellement et `loadQueue`
+/// peut échouer à la demande. Rend testable le cœur de l'US-05-04 (enchaînement
+/// suivi via `currentIndexStream`, saut de piste, reprise après token expiré).
+class FakeQueuePlaybackService implements QueuePlaybackService {
+  final _stateCtrl = StreamController<PlayerState>.broadcast();
+  final _indexCtrl = StreamController<int?>.broadcast();
+  final _errorCtrl = StreamController<Object>.broadcast();
+
+  /// Si non nul, [loadQueue] lève cette erreur (simule une source injoignable,
+  /// typiquement un 401 sur un access token périmé).
+  Object? loadError;
+
+  int loadCalls = 0;
+  int playCalls = 0;
+  bool stopped = false;
+  List<QueueItem> lastItems = const [];
+  int? lastInitialIndex;
+  Map<String, String> lastHeaders = const {};
+  final List<int> skips = [];
+  bool _playing = false;
+
+  void emitState(PlayerState state) {
+    if (!_stateCtrl.isClosed) _stateCtrl.add(state);
+  }
+
+  void emitIndex(int? index) {
+    if (!_indexCtrl.isClosed) _indexCtrl.add(index);
+  }
+
+  void emitError(Object error) {
+    if (!_errorCtrl.isClosed) _errorCtrl.add(error);
+  }
+
+  @override
+  Stream<PlayerState> get playerStateStream => _stateCtrl.stream;
+  @override
+  Stream<int?> get currentIndexStream => _indexCtrl.stream;
+  @override
+  Stream<Object> get playbackErrors => _errorCtrl.stream;
+  @override
+  bool get playing => _playing;
+
+  @override
+  Future<void> loadQueue(
+    List<QueueItem> items, {
+    int initialIndex = 0,
+    Map<String, String> headers = const {},
+  }) async {
+    loadCalls++;
+    lastItems = items;
+    lastInitialIndex = initialIndex;
+    lastHeaders = headers;
+    final err = loadError;
+    if (err != null) throw err;
+  }
+
+  @override
+  Future<void> skipToIndex(int index) async => skips.add(index);
+
+  @override
+  Future<void> play() async {
+    playCalls++;
+    _playing = true;
+  }
+
+  @override
+  Future<void> pause() async => _playing = false;
+
+  @override
+  Future<void> stop() async {
+    stopped = true;
+    _playing = false;
+  }
+
+  Future<void> dispose() async {
+    await _stateCtrl.close();
+    await _indexCtrl.close();
+    await _errorCtrl.close();
+  }
+}

--- a/mobile/test/support/fake_queue_playback_service.dart
+++ b/mobile/test/support/fake_queue_playback_service.dart
@@ -21,6 +21,11 @@ class FakeQueuePlaybackService implements QueuePlaybackService {
   bool stopped = false;
   List<QueueItem> lastItems = const [];
   int? lastInitialIndex;
+  Duration? lastInitialPosition;
+
+  /// Position simulée du lecteur, relevée par le contrôleur avant une reprise.
+  @override
+  Duration position = Duration.zero;
   Map<String, String> lastHeaders = const {};
   final List<int> skips = [];
   bool _playing = false;
@@ -50,11 +55,13 @@ class FakeQueuePlaybackService implements QueuePlaybackService {
   Future<void> loadQueue(
     List<QueueItem> items, {
     int initialIndex = 0,
+    Duration initialPosition = Duration.zero,
     Map<String, String> headers = const {},
   }) async {
     loadCalls++;
     lastItems = items;
     lastInitialIndex = initialIndex;
+    lastInitialPosition = initialPosition;
     lastHeaders = headers;
     final err = loadError;
     if (err != null) throw err;

--- a/mobile/test/widget_test.dart
+++ b/mobile/test/widget_test.dart
@@ -5,14 +5,21 @@ import 'package:streampulse/app/app.dart';
 import 'package:streampulse/app/app_providers.dart';
 
 import 'support/fake_audio_playback_service.dart';
+import 'support/fake_queue_playback_service.dart';
 
 void main() {
   testWidgets('App démarre sans erreur', (WidgetTester tester) async {
     final audioService = FakeAudioPlaybackService();
+    final queueService = FakeQueuePlaybackService();
     addTearDown(audioService.dispose);
+    addTearDown(queueService.dispose);
 
     await tester.pumpWidget(
-      StreamPulseApp(audioService: audioService, child: const App()),
+      StreamPulseApp(
+        audioService: audioService,
+        queueService: queueService,
+        child: const App(),
+      ),
     );
     expect(find.byType(MaterialApp), findsOneWidget);
   });


### PR DESCRIPTION
Closes STR-133.

En tant qu'utilisateur, je veux lire ma playlist avec passage automatique à la
piste suivante afin de profiter d'une écoute continue sans intervention.

## Backend — `GET /api/tracks/{id}/stream`

Les fichiers uploadés en US-05-01 sont stockés hors répertoire servi : aucune
route ne pouvait jusqu'ici en rendre les octets. La nouvelle route sert le
binaire d'une piste **à son propriétaire** :

- propriété filtrée en SQL (`WHERE id = $1 AND user_id = $2`) → une piste d'un
  tiers renvoie **404**, jamais 403 : le code de statut ne doit pas révéler
  qu'elle existe ;
- `http.ServeContent` plutôt qu'un `io.Copy` : les requêtes `Range` sont
  honorées, ce dont le lecteur a besoin pour reprendre ou avancer dans une piste ;
- type MIME lu en base (figé à l'upload, déjà validé par sniff) + `nosniff` ;
- `Cache-Control: private, no-store` ;
- fichier absent du volume alors que la ligne existe → 404 + log `error`, pas 500.

`Storage` gagne `Open` (`StoredFile` = `ReadSeeker` + `Closer`) pour rester une
abstraction utilisable par un futur stockage objet.

## Mobile — file d'attente

L'**enchaînement est délégué au lecteur natif** (`ConcatenatingAudioSource`, qui
précharge la piste suivante). `PlaylistQueueController` ne l'ordonnance pas : il
suit `currentIndexStream`. Un saut déclenché depuis la notification système
remonte donc par le même chemin qu'un appui dans l'app — une seule source de
vérité, aucune dérive possible entre ce qu'on entend et ce qu'on voit.

L'interface du lecteur est scindée (`PlaybackTransport` étendu par
`AudioPlaybackService` et `QueuePlaybackService`) : direct et file partagent un
unique `AudioPlayer`, mais chaque contrôleur ne dépend que de ce qu'il utilise.
Le câblage croisé de `app_providers` garantit qu'au plus une des deux sources se
croit en lecture ; `PlayerBar` choisit le mini-player correspondant.

just_audio ouvrant ses propres connexions HTTP, il ne traverse pas les
intercepteurs de `DioClient` : `PlaybackAuth` lui fournit l'access token, et une
reprise unique après rotation évite qu'une file plus longue que 15 min casse au
changement de piste. Jamais de token en paramètre d'URL.

UI : bouton « Lire » et appui sur une ligne (démarre à cette piste),
`QueueMiniPlayer` (précédent/play/suivant/croix), `PlaybackQueueSheet` (file
visible, appui = saut).

## Décision documentée

[ADR 033](docs/adr/033-lecture-dune-playlist-avec-file-dattente.md) — dont le
choix d'une file **photographiée au lancement** : réordonner la playlist ne
change pas ce qui joue tant qu'on ne relance pas.

## Tests

- Backend : `go test ./...` (518), `golangci-lint` 0 issue. Handler testé à
  travers le vrai `ServeMux` + `RequireAuth` + `ServeContent`, dont un 206 sur
  `Range`.
- Mobile : `flutter analyze` 0 issue, `flutter test` vert (+27 tests : contrôleur
  de file, UI de la file, arbitrage `PlayerBar`, écran de détail).

## QA sur device (Samsung SM-G988B)

Enchaînement automatique mesuré via `dumpsys media_session` : 12 s par piste,
item 0 → 1 → 2. File visible, saut de piste OK (y compris après fin de file),
lecture qui continue en arrière-plan et franchit une limite de piste, contrôles
précédent/suivant de la notification suivis par l'UI.

Un bug y a été trouvé et corrigé : après la croix du mini-player, Android gardait
une carte média dont le bouton lecture relançait la dernière piste alors que
l'application avait déjà vidé sa file — l'OS jouait ce que l'app disait ne pas
jouer. Le handler refuse désormais les commandes de transport tant que rien n'est
chargé et publie explicitement un état `idle` sans contrôle à l'arrêt.

Non couvert par la QA device : l'arbitrage direct ↔ file (demande un flux en
direct, donc rôle diffuseur + push ffmpeg) et l'expiration du token au-delà de
15 min — les deux restent couverts par les tests unitaires.
