### PR TITLE
fix(api): corriger les alertes gosec de l'upload de pistes

### DIFF
--- a/backend/internal/track/handler.go
+++ b/backend/internal/track/handler.go
@@ -65,6 +65,8 @@ func (h *Handler) Upload(w http.ResponseWriter, r *http.Request) {
 	// Borne le corps entier avant toute lecture : un upload démesuré est coupé
 	// ici (413) plutôt que bufferisé.
 	r.Body = http.MaxBytesReader(w, r.Body, h.maxUpload+maxFormOverhead)
+	// #nosec G120 -- le corps est déjà borné par MaxBytesReader ci-dessus (pas de
+	// parsing non borné) ; maxMultipartMemory ne fait que limiter la part gardée en RAM.
 	if err := r.ParseMultipartForm(maxMultipartMemory); err != nil {
 		var maxErr *http.MaxBytesError
 		if errors.As(err, &maxErr) {

--- a/backend/internal/track/repository.go
+++ b/backend/internal/track/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -108,7 +109,10 @@ func textValue(t pgtype.Text) *string {
 }
 
 func int4Param(v *int) pgtype.Int4 {
-	if v == nil {
+	// La durée est déjà validée en amont (normalizeDuration : > 0 et ≤ MaxInt32).
+	// Ce garde-fou borne quand même la conversion int -> int32 (colonne int4) pour
+	// écarter tout débordement (gosec G115) : hors plage -> NULL plutôt que wrap.
+	if v == nil || *v < 0 || *v > math.MaxInt32 {
 		return pgtype.Int4{}
 	}
 	return pgtype.Int4{Int32: int32(*v), Valid: true}

--- a/backend/internal/track/service.go
+++ b/backend/internal/track/service.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"math"
 	"net/http"
 	"strings"
 	"unicode/utf8"
@@ -238,13 +239,14 @@ func normalizeArtist(raw *string) (*string, error) {
 	return &a, nil
 }
 
-// normalizeDuration valide la durée fournie par le client : positive si présente
-// (la table impose CHECK duration_s > 0).
+// normalizeDuration valide la durée fournie par le client : positive et tenant
+// dans la colonne int4 si présente (la table impose CHECK duration_s > 0). La
+// borne haute écarte une valeur absurde qui déborderait la conversion int32.
 func normalizeDuration(d *int) (*int, error) {
 	if d == nil {
 		return nil, nil
 	}
-	if *d <= 0 {
+	if *d <= 0 || *d > math.MaxInt32 {
 		return nil, apperror.InvalidArgument("invalid duration")
 	}
 	return d, nil

--- a/backend/internal/track/service_test.go
+++ b/backend/internal/track/service_test.go
@@ -195,11 +195,19 @@ func TestCreate_InvalidDuration(t *testing.T) {
 // Une durée qui déborde int4 (int32) doit être rejetée en amont (400) plutôt que
 // convertie en un int32 wrappé (négatif) qui violerait le CHECK duration_s > 0.
 func TestCreate_DurationTooLarge(t *testing.T) {
+	// Valeur **runtime** (variable, pas une constante) : `math.MaxInt32 + 1`
+	// évalué à la compilation déborderait un `int` 32 bits (GOARCH=386). En
+	// incrémentant une variable, l'addition se fait à l'exécution → compile sur
+	// toutes les archis. Sur 32 bits, int == int32 : l'incrément wrappe en
+	// négatif et on retombe sur la borne `<= 0` — cohérent (rien à déborder).
+	tooLarge := int(math.MaxInt32)
+	tooLarge++
+
 	svc := NewService(&fakeRepo{}, &stubStorage{})
 	_, err := svc.Create(context.Background(), CreateTrackInput{
 		UserID:    testUserID,
 		Title:     "Song",
-		DurationS: ptr(math.MaxInt32 + 1),
+		DurationS: ptr(tooLarge),
 		Size:      int64(len(mp3Header)),
 		Content:   bytes.NewReader(mp3Header),
 	})

--- a/backend/internal/track/service_test.go
+++ b/backend/internal/track/service_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"math"
 	"net/http"
 	"testing"
 
@@ -188,6 +189,22 @@ func TestCreate_InvalidDuration(t *testing.T) {
 	})
 	if !apperror.IsCode(err, apperror.CodeInvalidArgument) {
 		t.Fatalf("expected InvalidArgument for duration<=0, got %v", err)
+	}
+}
+
+// Une durée qui déborde int4 (int32) doit être rejetée en amont (400) plutôt que
+// convertie en un int32 wrappé (négatif) qui violerait le CHECK duration_s > 0.
+func TestCreate_DurationTooLarge(t *testing.T) {
+	svc := NewService(&fakeRepo{}, &stubStorage{})
+	_, err := svc.Create(context.Background(), CreateTrackInput{
+		UserID:    testUserID,
+		Title:     "Song",
+		DurationS: ptr(math.MaxInt32 + 1),
+		Size:      int64(len(mp3Header)),
+		Content:   bytes.NewReader(mp3Header),
+	})
+	if !apperror.IsCode(err, apperror.CodeInvalidArgument) {
+		t.Fatalf("expected InvalidArgument for duration>MaxInt32, got %v", err)
 	}
 }
 

--- a/backend/internal/track/storage.go
+++ b/backend/internal/track/storage.go
@@ -32,7 +32,10 @@ func (s *FileStorage) Save(_ context.Context, id, ext string, r io.Reader) (stri
 	}
 
 	path := filepath.Join(s.root, id+ext)
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o640)
+	// id est un UUID généré côté serveur (jamais le nom client) + extension
+	// canonique : le chemin reste sous root, aucune traversée possible (cf. doc du type).
+	// #nosec G304 -- chemin dérivé d'un UUID serveur, pas d'entrée client.
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
 		return "", fmt.Errorf("track: open file: %w", err)
 	}

--- a/docs/adr/032-domaine-track-upload-audio.md
+++ b/docs/adr/032-domaine-track-upload-audio.md
@@ -69,6 +69,8 @@ sniff pour que l'écriture reparte du début.
 ### 4. La durée est fournie par le client (champ optionnel)
 
 `duration_s` est un champ multipart **optionnel** envoyé par le client, pas extrait côté serveur.
+Étant une entrée client, elle est validée : `> 0` **et** `≤ MaxInt32` (borne de la colonne `int4`), sinon
+400 — sans quoi une valeur absurde déborderait la conversion `int → int32` (gosec G115).
 
 Raison : une extraction serveur (ffprobe) imposerait ffmpeg comme dépendance d'exécution de l'API
 (il n'est présent aujourd'hui que pour le segmenteur HLS et absent du `go run` local), pour une


### PR DESCRIPTION
## Contexte

La CI **Security** (`gosec --exclude-generated ./...`) échouait avec **4 findings** dans le domaine `track` (upload de pistes, US-05-01). Cette PR les corrige : deux par du vrai code, deux par un `#nosec` justifié (faux positif / entrée non-cliente). Pas de ticket Linear dédié — correction de CI.

## Changements

| Finding | Fichier | Correctif |
|---|---|---|
| **G115** — débordement `int → int32` | `repository.go` | garde-fou `*v < 0 \|\| *v > math.MaxInt32` avant la conversion (hors plage → `NULL` plutôt qu'un wrap) **+** borne haute dans `normalizeDuration` (`service.go`) → **400** propre pour une durée absurde |
| **G302** — permissions `0640` | `storage.go` | `0o640` → **`0o600`** (propriétaire seul suffit à l'API) |
| **G304** — inclusion de fichier par variable | `storage.go` | `#nosec G304` justifié : le nom est un **UUID généré serveur** + extension canonique (jamais le nom client) → chemin toujours sous `root`, aucune traversée |
| **G120** — parsing de formulaire non borné | `handler.go` | `#nosec G120` justifié : le corps est **déjà borné** par `http.MaxBytesReader` juste au-dessus (faux positif ; `maxMultipartMemory` ne limite que la part gardée en RAM) |

Les deux `#nosec` sont commentés sur place. Le seul vrai risque (débordement int32) est traité par du code, pas masqué.

## Comment tester

1. `cd backend && gosec --exclude-generated ./...` → **Issues: 0** (Nosec: 4, tous justifiés)
2. `cd backend && go build ./...`
3. `cd backend && go test ./internal/track/...`

## Checklist

- [x] Les commits suivent Conventional Commits
- [x] Le titre de la PR suit Conventional Commits
- [x] La branche est à jour avec develop
- [x] `gosec` passe (Issues: 0), build et tests verts localement
- [x] Aucun secret / .env committé
- [x] Pas de changement de comportement fonctionnel (durcissement + validation de borne)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
