### PR TITLE
feat(mobile): modes shuffle et repeat de la file d'attente (US-05-05)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -471,6 +471,10 @@ Voir [ADR 035](docs/adr/035-modes-shuffle-et-repeat.md).
   l'application règle le mode et **lit** l'ordre obtenu (`effectiveIndices`). `shuffle()` est appelé
   avant l'activation (il garde la piste courante en tête → la lecture n'est pas coupée) et après
   chaque `loadQueue` (une source neuve arrive avec un ordre naturel).
+- ⚠️ **Un ordre n'est tiré que sur demande de l'auditeur** (`play`). Un rechargement **subi**
+  (reprise après erreur, relance d'une file terminée) passe l'ordre courant à `loadQueue`, que le
+  handler réapplique via `_FixedShuffleOrder` : sans ça, l'expiration d'access token (15 min,
+  ADR 034 §5) réécrirait la suite de la file à ce rythme.
 - **`PlaybackOrder`** (`core/audio/playback_order.dart`) : objet **pur** (comme `InterruptionPolicy`)
   portant `positionOf` et `relative(current, ±1, wrap:)`. Utilisé par le contrôleur **et** par
   `StreamAudioHandler._skipRelative` (boutons de la notification) → une seule règle.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -399,8 +399,9 @@ Créer l'arborescence suivante dans `mobile/lib/features/<nom>/` :
 
 Voir [ADR 023](docs/adr/023-lecteur-audio-hls-mobile.md) (lecteur HLS),
 [ADR 031](docs/adr/031-lecture-audio-en-arriere-plan.md) (arrière-plan) et
-[ADR 033](docs/adr/033-gestion-des-interruptions-audio.md) (interruptions) et
-[ADR 034](docs/adr/034-lecture-dune-playlist-avec-file-dattente.md) (file d'attente).
+[ADR 033](docs/adr/033-gestion-des-interruptions-audio.md) (interruptions),
+[ADR 034](docs/adr/034-lecture-dune-playlist-avec-file-dattente.md) (file d'attente) et
+[ADR 035](docs/adr/035-modes-shuffle-et-repeat.md) (shuffle/repeat).
 
 - **Service partagé, app-level** : un unique `AudioPlayer` vit dans `StreamAudioHandler`
   (`core/audio/`, `audio_service` + just_audio), initialisé dans `main()` via `AudioService.init`
@@ -461,6 +462,29 @@ Voir [ADR 034](docs/adr/034-lecture-dune-playlist-avec-file-dattente.md).
   piste), `QueueMiniPlayer` (précédent/play/suivant/croix), `PlaybackQueueSheet` (file visible,
   appui = saut). La file est une **photo** des pistes au lancement : réordonner la playlist ne
   change pas ce qui joue tant qu'on ne relance pas.
+
+### Modes shuffle et repeat (US-05-05)
+
+Voir [ADR 035](docs/adr/035-modes-shuffle-et-repeat.md).
+
+- **Mélange tiré par le lecteur natif** (`setShuffleModeEnabled` + `shuffle()`), jamais côté Dart :
+  l'application règle le mode et **lit** l'ordre obtenu (`effectiveIndices`). `shuffle()` est appelé
+  avant l'activation (il garde la piste courante en tête → la lecture n'est pas coupée) et après
+  chaque `loadQueue` (une source neuve arrive avec un ordre naturel).
+- **`PlaybackOrder`** (`core/audio/playback_order.dart`) : objet **pur** (comme `InterruptionPolicy`)
+  portant `positionOf` et `relative(current, ±1, wrap:)`. Utilisé par le contrôleur **et** par
+  `StreamAudioHandler._skipRelative` (boutons de la notification) → une seule règle.
+- ⚠️ **`repeat one` ne gouverne que l'enchaînement automatique** : un saut manuel avance quand même.
+  D'où le remplacement de `seekToNext()`/`seekToPrevious()`, qui sous `LoopMode.one` rejouent la
+  piste courante.
+- Énumération applicative `QueueRepeatMode` (`off`/`one`/`all`), traduite en `LoopMode` par le seul
+  handler. **Préfixée `Queue`** : `material.dart` exporte déjà un `RepeatMode` (animations).
+- **Les modes appartiennent au contrôleur**, pas au lecteur (que le direct remet à zéro en prenant
+  la main) : réappliqués avant chaque chargement, conservés après `stop()`, perdus au redémarrage
+  (pas de persistance). Non exposés aux commandes système (l'état ne serait pas relu → dérive).
+- **UI** : toggles « Aléatoire » / répétition (3 états) dans `PlaybackQueueSheet` ; action
+  « Lire en aléatoire » dans l'AppBar de `PlaylistDetailScreen`, avec **piste de départ tirée au
+  sort**. La file affichée et le « n/total » suivent l'**ordre de lecture**, pas celui de la playlist.
 
 ### Authentification (mobile)
 
@@ -654,7 +678,7 @@ xcrun simctl openurl booted \
 | `docs/adr/012-openapi-source-de-verite.md` | Décision : OpenAPI source de vérité du contrat HTTP + client Dart/Dio généré |
 
 **Règle :** toute nouvelle décision d'architecture significative → nouvel ADR dans `docs/adr/`
-avec le numéro suivant (prochain : `035-...`). Référencer le ticket Linear correspondant.
+avec le numéro suivant (prochain : `036-...`). Référencer le ticket Linear correspondant.
 
 ## Principes SOLID
 

--- a/docs/adr/035-modes-shuffle-et-repeat.md
+++ b/docs/adr/035-modes-shuffle-et-repeat.md
@@ -35,6 +35,16 @@ introduit un second ordre à garder en phase avec celui que le lecteur applique 
 - après chaque chargement, parce qu'une source neuve arrive avec un ordre de mélange neuf, c'est-à-
   dire naturel : sans ce tirage, relancer une playlist en mode aléatoire la rejouerait dans l'ordre.
 
+**Sauf sur un rechargement subi.** Le lecteur ne tire un ordre que lorsque l'auditeur a demandé
+quelque chose : `play()`. Une reprise après erreur ou la relance d'une file terminée rechargent la
+source sans que personne ne l'ait demandé, et `loadQueue` reçoit alors l'ordre courant à réappliquer
+(`_FixedShuffleOrder`, une `ShuffleOrder` qui rend la permutation qu'on lui donne et ignore les
+demandes de mélange). Ce n'est pas un détail de confort : l'access token embarqué dans les
+`AudioSource` expire au bout de 15 minutes (ADR 034 §5), donc sans cette conservation la suite
+annoncée serait réécrite à ce rythme sur toute écoute un peu longue. Le handler vérifie que l'ordre
+reçu est une permutation exacte de la file avant de l'appliquer — à un élément près, il laisserait
+des pistes injouables.
+
 ### 2. `PlaybackOrder` — un objet pur pour la règle du saut
 
 Un désaccord existe entre just_audio et l'attente d'un auditeur : sous `LoopMode.one`,
@@ -119,8 +129,9 @@ affichée sous les toggles qui rend leur effet lisible.
 **Négatives / limites assumées**
 
 - Les modes sont perdus au redémarrage de l'application (§3).
-- Une reprise après erreur recharge la source, donc tire un nouvel ordre : la suite annoncée avant
-  la coupure n'est pas celle qui reprendra (la piste courante, elle, est conservée).
+- L'ordre conservé lors d'un rechargement subi (§1) suppose que la file rechargée est bien la même :
+  le handler le vérifie (permutation exacte) et retombe sur un tirage neuf sinon, plutôt que de
+  jouer un ordre qui ne correspond plus.
 - L'ordre de lecture n'est pas exposé aux commandes système : le tableau de bord d'une voiture
   affichera « lecture normale » même en aléatoire.
 - Comme en US-05-04, la file reste une **photo** des pistes au lancement : réordonner la playlist ne

--- a/docs/adr/035-modes-shuffle-et-repeat.md
+++ b/docs/adr/035-modes-shuffle-et-repeat.md
@@ -1,0 +1,133 @@
+# ADR 035 — Modes shuffle et repeat de la file d'attente
+
+**Date** : 2026-08-12
+**Statut** : Accepté
+**Ticket** : [STR-134](https://linear.app/streampulse/issue/STR-134) (US-05-05)
+
+## Contexte
+
+L'US-05-04 ([ADR 034](034-lecture-dune-playlist-avec-file-dattente.md)) a posé une file d'attente
+qui se joue **une fois, dans l'ordre** : `PlaylistQueueController` suit `currentIndexStream`, et
+l'enchaînement appartient au lecteur natif (`ConcatenatingAudioSource`, qui précharge la piste
+suivante).
+
+L'US-05-05 demande deux variations sur cet enchaînement : lecture aléatoire, et répétition — d'une
+piste ou de toute la file. Toutes deux touchent la même question : **quelle piste vient après
+celle-ci**, à laquelle deux acteurs répondent déjà (le lecteur natif pour l'enchaînement
+automatique, le contrôleur pour les boutons précédent/suivant et la file affichée).
+
+## Décision
+
+### 1. Le mélange est tiré par le lecteur natif, pas par l'application
+
+just_audio sait mélanger (`setShuffleModeEnabled` + `shuffle()`) et répéter (`LoopMode`). Le
+choix de l'ADR 034 — l'ordonnancement appartient au lecteur — est reconduit : l'application règle
+les modes et **lit** l'ordre obtenu (`effectiveIndices`), elle ne tire aucune permutation.
+
+Conséquence directe : un enchaînement automatique, un appui dans l'application et un appui sur la
+notification système donnent forcément la même piste. Une permutation calculée côté Dart aurait
+introduit un second ordre à garder en phase avec celui que le lecteur applique réellement.
+
+`shuffle()` est appelé **avant** l'activation du mode et **après** chaque `loadQueue` :
+
+- avant l'activation, parce qu'il place la piste courante en tête de l'ordre tiré — basculer en
+  aléatoire ne coupe donc jamais ce qu'on écoute ;
+- après chaque chargement, parce qu'une source neuve arrive avec un ordre de mélange neuf, c'est-à-
+  dire naturel : sans ce tirage, relancer une playlist en mode aléatoire la rejouerait dans l'ordre.
+
+### 2. `PlaybackOrder` — un objet pur pour la règle du saut
+
+Un désaccord existe entre just_audio et l'attente d'un auditeur : sous `LoopMode.one`,
+`seekToNext()` renvoie la **piste courante**. Le bouton « suivant » ne changerait donc pas de piste
+tant que la répétition d'une piste est active — comportement qui se lit comme une panne.
+
+La règle retenue est celle des lecteurs grand public : **`repeat one` ne gouverne que
+l'enchaînement automatique**, jamais les sauts manuels. Elle vit dans `PlaybackOrder`
+(`core/audio/playback_order.dart`), objet pur et testable comme `InterruptionPolicy`
+([ADR 033](033-gestion-des-interruptions-audio.md)) :
+
+```
+PlaybackOrder(indices)                     // ordre effectif, index de la file d'origine
+  .positionOf(index)                       // rang affiché (« 2/12 »)
+  .relative(current, ±1, wrap: repeat all) // piste du saut manuel, ou null
+```
+
+Les deux surfaces qui sautent l'utilisent : les boutons de l'application via le contrôleur, ceux de
+la notification via `StreamAudioHandler._skipRelative`. Une seule implémentation, donc aucune
+divergence possible entre les deux — et une règle testable sans lecteur natif ni plugin.
+
+L'énumération applicative est `QueueRepeatMode` (`off`/`one`/`all`), traduite en `LoopMode` par le
+seul handler. Le préfixe `Queue` évite la collision avec le `RepeatMode` que `material.dart`
+exporte déjà (animations), qui obligerait sinon chaque widget affichant le mode à renommer un
+import.
+
+### 3. Les modes appartiennent au contrôleur, pas au lecteur
+
+Le lecteur natif est partagé avec le direct, qui remet shuffle et loop à zéro en prenant la main
+(un live n'a ni file ni fin, et `LoopMode.one` y rejouerait un segment). Si les modes n'étaient
+tenus que par le lecteur, écouter un direct puis revenir à une playlist les perdrait sans que rien
+ne l'annonce.
+
+`PlaylistQueueController` les porte donc comme état propre et les **réapplique avant chaque
+chargement**. Ils survivent aussi à `stop()` : ce sont des préférences d'écoute, pas l'état d'une
+file. Ils ne survivent en revanche pas au redémarrage de l'application (aucune persistance —
+l'US ne la demande pas, et la préférence est à un tap).
+
+### 4. La file affichée montre l'ordre de lecture
+
+`PlaybackQueueSheet` liste les pistes dans l'ordre où elles seront jouées, et le « n/total » du
+mini-player compte le rang dans cet ordre. Afficher l'ordre de la playlist pendant une lecture
+aléatoire annoncerait une suite qui n'arrivera pas.
+
+Le contrôleur photographie cet ordre (`_refreshOrder`) après chaque chargement et chaque bascule,
+plutôt que de le relire à la volée : l'UI le parcourt à chaque frame, et un ordre qui changerait
+sans `notifyListeners` afficherait une file désynchronisée du son.
+
+### 5. Points d'entrée
+
+- **Dans la file** (`PlaybackQueueSheet`) : deux boutons libellés — « Aléatoire » et un bouton de
+  répétition qui fait défiler *aucune → toute la file → la piste*. Un seul bouton pour trois états
+  exclusifs, convention des lecteurs audio. Ils sont libellés et pas seulement colorés : « répéter
+  la piste » et « répéter la file » ne se distinguent pas d'une icône.
+- **Avant la lecture** (`PlaylistDetailScreen`) : une action « Lire en aléatoire » dans l'AppBar,
+  qui démarre sur une piste **tirée au sort** — le lecteur gardant la piste de départ en tête,
+  partir systématiquement de la première rendrait un aléatoire qui commence toujours pareil.
+
+Le mini-player ne porte pas ces réglages : 60 px de haut et quatre boutons déjà, et c'est la file
+affichée sous les toggles qui rend leur effet lisible.
+
+## Alternatives écartées
+
+| Alternative | Pourquoi non |
+|---|---|
+| Mélanger la liste côté Dart et charger la file dans cet ordre | Deux ordres à garder en phase (celui affiché, celui du lecteur), et désactiver l'aléatoire imposerait de recharger la source pour revenir à l'ordre naturel — donc une coupure audible. |
+| Suivre just_audio jusqu'au bout (`seekToNext`) sous `repeat one` | Le bouton « suivant » rejouerait la piste courante. La notification et l'application partageraient le défaut, ce qui ne le rend pas moins déroutant. |
+| Deux boutons de répétition (piste / file) | Trois états exclusifs sur deux interrupteurs : il faut interdire la combinaison des deux, pour un gain de clarté nul. |
+| Tenir les modes dans le lecteur uniquement | Le direct les remet à zéro en prenant le lecteur partagé ; la préférence disparaîtrait sans raison visible. |
+| Exposer shuffle/repeat aux commandes système (Android Auto, casque) | `audio_service` sait les publier, mais un basculement venu du système ne remonterait pas au contrôleur, qui tient l'état : l'application afficherait un mode et le lecteur en appliquerait un autre. Écarté tant que l'état n'est pas relu depuis le lecteur. |
+| Persister les modes entre deux lancements | Hors US ; une préférence à un tap ne justifie pas encore un stockage. |
+
+## Conséquences
+
+**Positives**
+
+- L'enchaînement reste piloté par un seul acteur : ce qu'on entend, ce que la file affiche et ce que
+  la notification propose ne peuvent pas diverger.
+- La règle du saut manuel est une fonction pure, couverte par des tests sans plugin ni device.
+- Activer l'aléatoire ne coupe pas la lecture en cours (piste courante gardée en tête).
+
+**Négatives / limites assumées**
+
+- Les modes sont perdus au redémarrage de l'application (§3).
+- Une reprise après erreur recharge la source, donc tire un nouvel ordre : la suite annoncée avant
+  la coupure n'est pas celle qui reprendra (la piste courante, elle, est conservée).
+- L'ordre de lecture n'est pas exposé aux commandes système : le tableau de bord d'une voiture
+  affichera « lecture normale » même en aléatoire.
+- Comme en US-05-04, la file reste une **photo** des pistes au lancement : réordonner la playlist ne
+  change pas ce qui joue tant qu'on ne relance pas.
+
+## Références
+
+- [ADR 031](031-lecture-audio-en-arriere-plan.md) — lecteur partagé, arrière-plan
+- [ADR 033](033-gestion-des-interruptions-audio.md) — politique pure et testable
+- [ADR 034](034-lecture-dune-playlist-avec-file-dattente.md) — file d'attente, ordonnancement délégué

--- a/mobile/lib/core/audio/playback_order.dart
+++ b/mobile/lib/core/audio/playback_order.dart
@@ -1,0 +1,74 @@
+/// Mode de répétition d'une file d'attente (US-05-05).
+///
+/// Vocabulaire applicatif volontairement distinct du `LoopMode` de just_audio :
+/// seul le handler traduit l'un vers l'autre, le reste de l'application (et ses
+/// tests) n'a pas à dépendre du lecteur natif.
+///
+/// Préfixé `Queue` parce que `material.dart` exporte déjà un `RepeatMode`
+/// (animations) : sans ça, tout widget qui affiche le mode devrait renommer
+/// l'un des deux à l'import.
+enum QueueRepeatMode {
+  /// La file s'arrête après la dernière piste.
+  off,
+
+  /// La piste courante se répète indéfiniment.
+  one,
+
+  /// La file reboucle sur sa première piste après la dernière.
+  all,
+}
+
+/// Ordre de lecture effectif d'une file : la liste des index de la file
+/// d'origine, dans l'ordre où le lecteur les enchaînera. Identité en lecture
+/// normale, permutation en lecture aléatoire.
+///
+/// Objet **pur et testable** (même parti pris qu'`InterruptionPolicy`,
+/// ADR 033) : c'est ici que vit la règle du saut manuel, et elle est appliquée
+/// aux deux surfaces qui sautent — les boutons de l'application via le
+/// contrôleur, et ceux de la notification via `StreamAudioHandler`. Une seule
+/// implémentation, donc aucune divergence possible entre les deux.
+class PlaybackOrder {
+  const PlaybackOrder(this.indices);
+
+  /// Ordre de lecture vide : aucun saut possible.
+  static const PlaybackOrder empty = PlaybackOrder([]);
+
+  /// Ordre naturel de `length` éléments (aucun mélange).
+  factory PlaybackOrder.natural(int length) =>
+      PlaybackOrder(List.generate(length, (i) => i));
+
+  /// Index de la file d'origine, dans l'ordre de lecture.
+  final List<int> indices;
+
+  bool get isEmpty => indices.isEmpty;
+
+  /// Rang de [index] dans l'ordre de lecture (« piste 3 sur 12 » compte les
+  /// pistes telles qu'elles seront jouées, pas telles qu'elles sont rangées).
+  /// `-1` si la piste n'appartient pas à cet ordre.
+  int positionOf(int index) => indices.indexOf(index);
+
+  /// Index de la file à jouer [offset] rangs après [current] dans l'ordre de
+  /// lecture, ou `null` s'il n'y en a pas.
+  ///
+  /// [wrap] (mode `all`) fait reboucler aux deux extrémités.
+  ///
+  /// **`QueueRepeatMode.one` n'intervient pas ici** : il ne gouverne que
+  /// l'enchaînement automatique, pas les boutons précédent/suivant. C'est le
+  /// seul écart assumé avec just_audio, dont `seekToNext` rejoue la piste
+  /// courante quand `LoopMode.one` est actif — un bouton « suivant » qui ne
+  /// change pas de piste passerait pour une panne.
+  int? relative(int current, int offset, {required bool wrap}) {
+    if (indices.isEmpty) return null;
+    final position = positionOf(current);
+    if (position < 0) return null;
+
+    var target = position + offset;
+    if (target < 0 || target >= indices.length) {
+      if (!wrap) return null;
+      // L'opérateur `%` de Dart rend toujours un reste positif : -1 sur une
+      // file de 3 donne bien 2 (la dernière piste), sans cas particulier.
+      target %= indices.length;
+    }
+    return indices[target];
+  }
+}

--- a/mobile/lib/core/audio/queue_playback_service.dart
+++ b/mobile/lib/core/audio/queue_playback_service.dart
@@ -1,5 +1,7 @@
+import 'playback_order.dart';
 import 'playback_transport.dart';
 
+export 'playback_order.dart' show PlaybackOrder, QueueRepeatMode;
 export 'playback_transport.dart' show PlaybackStatus, PlaybackTransport;
 
 /// Une entrée de la file d'attente, telle que le lecteur natif la consomme :
@@ -43,6 +45,26 @@ abstract class QueuePlaybackService implements PlaybackTransport {
   /// Position dans la piste en cours. Relevée avant une reprise après erreur
   /// pour repartir d'où l'auditeur en était, plutôt que du début de la piste.
   Duration get position;
+
+  /// Ordre dans lequel le lecteur enchaînera la file chargée (US-05-05) :
+  /// identité en lecture normale, permutation en lecture aléatoire.
+  ///
+  /// Lu **après** [loadQueue] / [setShuffleEnabled], jamais deviné : c'est le
+  /// lecteur natif qui tire le mélange, et l'afficher depuis une autre source
+  /// mentirait sur ce qui va réellement jouer.
+  PlaybackOrder get playbackOrder;
+
+  /// Active ou coupe la lecture aléatoire. À l'activation, un nouvel ordre est
+  /// tiré en **gardant la piste courante en tête** : basculer en aléatoire ne
+  /// coupe jamais ce qu'on est en train d'écouter.
+  Future<void> setShuffleEnabled(bool enabled);
+
+  /// Règle la répétition. Elle gouverne l'**enchaînement automatique** ; les
+  /// sauts manuels suivent [PlaybackOrder.relative] (cf. `QueueRepeatMode.one`).
+  ///
+  /// `setRepeat` et non `setRepeatMode` : ce dernier nom est déjà celui de la
+  /// commande système d'`audio_service`, que l'implémentation hérite.
+  Future<void> setRepeat(QueueRepeatMode mode);
 
   /// Charge [items] et positionne la lecture sur [initialIndex], à
   /// [initialPosition] dans cette piste. Ne démarre pas la lecture (le

--- a/mobile/lib/core/audio/queue_playback_service.dart
+++ b/mobile/lib/core/audio/queue_playback_service.dart
@@ -72,11 +72,17 @@ abstract class QueuePlaybackService implements PlaybackTransport {
   ///
   /// [headers] est envoyé avec **chaque** requête de piste : les fichiers audio
   /// d'une bibliothèque sont privés, le lecteur natif doit s'authentifier.
+  ///
+  /// [order] réapplique un ordre de lecture existant au lieu d'en faire tirer un
+  /// neuf. Sert aux rechargements **subis** (reprise après erreur) : sans lui,
+  /// une coupure réseau réécrirait la suite de la file alors que l'auditeur n'a
+  /// rien demandé. `null` = nouveau tirage si l'aléatoire est actif.
   Future<void> loadQueue(
     List<QueueItem> items, {
     int initialIndex = 0,
     Duration initialPosition = Duration.zero,
     Map<String, String> headers = const {},
+    PlaybackOrder? order,
   });
 
   /// Saute à la piste [index] de la file et repart de son début.

--- a/mobile/lib/core/audio/stream_audio_handler.dart
+++ b/mobile/lib/core/audio/stream_audio_handler.dart
@@ -139,6 +139,7 @@ class StreamAudioHandler extends BaseAudioHandler
     int initialIndex = 0,
     Duration initialPosition = Duration.zero,
     Map<String, String> headers = const {},
+    PlaybackOrder? order,
   }) async {
     if (items.isEmpty) {
       await stop();
@@ -153,6 +154,13 @@ class StreamAudioHandler extends BaseAudioHandler
     mediaItem.add(_queueItems[start]);
     _hasSource = true;
 
+    // Ordre imposé (rechargement subi) : le lecteur le reçoit tel quel et ne
+    // tire rien. Le vérifier ici plutôt que de faire confiance à l'appelant —
+    // un ordre qui ne couvre pas exactement la file désordonnerait la lecture.
+    final keep = order != null && _coversQueue(order, items.length)
+        ? _FixedShuffleOrder(order.indices)
+        : null;
+
     await _player.setAudioSource(
       // L'enchaînement piste → piste suivante est délégué au lecteur natif :
       // c'est lui qui préchargera la suivante, sans blanc entre les deux.
@@ -164,6 +172,7 @@ class StreamAudioHandler extends BaseAudioHandler
               headers: headers.isEmpty ? null : headers,
             ),
         ],
+        shuffleOrder: keep,
       ),
       initialIndex: start,
       initialPosition: initialPosition,
@@ -171,8 +180,22 @@ class StreamAudioHandler extends BaseAudioHandler
 
     // Chaque source neuve arrive avec un ordre de mélange neuf, donc naturel :
     // sans ce tirage, relancer une playlist en mode aléatoire la rejouerait
-    // dans l'ordre. `shuffle()` garde la piste de départ en tête.
-    if (_player.shuffleModeEnabled) await _player.shuffle();
+    // dans l'ordre. `shuffle()` garde la piste de départ en tête. Sauté quand un
+    // ordre est imposé, sinon il l'écraserait aussitôt.
+    if (_player.shuffleModeEnabled && keep == null) await _player.shuffle();
+  }
+
+  /// Un ordre n'est réutilisable que s'il est une permutation exacte de la file
+  /// à charger : à un élément près, il laisserait des pistes injouables ou
+  /// pointerait hors de la file.
+  static bool _coversQueue(PlaybackOrder order, int length) {
+    if (order.indices.length != length) return false;
+    final seen = List.filled(length, false);
+    for (final index in order.indices) {
+      if (index < 0 || index >= length || seen[index]) return false;
+      seen[index] = true;
+    }
+    return true;
   }
 
   @override
@@ -374,4 +397,52 @@ class StreamAudioHandler extends BaseAudioHandler
       queueIndex: _player.currentIndex,
     );
   }
+}
+
+/// Ordre de lecture **imposé** : rend la permutation qu'on lui donne et ignore
+/// les demandes de mélange.
+///
+/// Sert aux rechargements subis (reprise après erreur) : le lecteur repart d'une
+/// source neuve, mais la suite annoncée à l'auditeur ne doit pas changer parce
+/// que le réseau a hoqueté.
+///
+/// `ConcatenatingAudioSource` appelle `insert(0, n)` depuis son constructeur
+/// pour déclarer ses enfants : c'est là qu'on pose la permutation. Les autres
+/// mutations n'arrivent pas dans cette application (une file n'est jamais
+/// modifiée en place, elle est rechargée entière) ; elles sont quand même
+/// traitées, en ordre naturel, plutôt que de laisser des index incohérents.
+class _FixedShuffleOrder extends ShuffleOrder {
+  _FixedShuffleOrder(this._fixed);
+
+  final List<int> _fixed;
+
+  @override
+  final indices = <int>[];
+
+  @override
+  void shuffle({int? initialIndex}) {}
+
+  @override
+  void insert(int index, int count) {
+    if (index == 0 && indices.isEmpty && count == _fixed.length) {
+      indices.addAll(_fixed);
+      return;
+    }
+    for (var i = 0; i < indices.length; i++) {
+      if (indices[i] >= index) indices[i] += count;
+    }
+    indices.insertAll(index, List.generate(count, (i) => index + i));
+  }
+
+  @override
+  void removeRange(int start, int end) {
+    final count = end - start;
+    indices.removeWhere((i) => i >= start && i < end);
+    for (var i = 0; i < indices.length; i++) {
+      if (indices[i] >= end) indices[i] -= count;
+    }
+  }
+
+  @override
+  void clear() => indices.clear();
 }

--- a/mobile/lib/core/audio/stream_audio_handler.dart
+++ b/mobile/lib/core/audio/stream_audio_handler.dart
@@ -76,8 +76,47 @@ class StreamAudioHandler extends BaseAudioHandler
   @override
   bool get playing => _player.playing;
 
+  /// Ordre de lecture effectif tel que le lecteur natif le tient (US-05-05).
+  /// `effectiveIndices` vaut `null` tant qu'aucune source n'est chargée : on
+  /// rend alors l'ordre naturel plutôt que rien, pour que l'appelant n'ait pas
+  /// de cas nul à traiter avant le premier chargement.
+  @override
+  PlaybackOrder get playbackOrder {
+    final indices = _player.effectiveIndices;
+    if (indices == null) return PlaybackOrder.natural(_queueItems.length);
+    return PlaybackOrder(List.unmodifiable(indices));
+  }
+
+  @override
+  Future<void> setShuffleEnabled(bool enabled) async {
+    // `shuffle()` **avant** l'activation : il tire l'ordre à partir de la piste
+    // courante et la place en tête, si bien qu'activer l'aléatoire ne coupe pas
+    // ce qui joue. Sans source chargée il n'y a rien à mélanger — le prochain
+    // `loadQueue` s'en chargera.
+    if (enabled && _hasSource) await _player.shuffle();
+    await _player.setShuffleModeEnabled(enabled);
+  }
+
+  /// Applique le mode de répétition au lecteur natif.
+  ///
+  /// Nommée `setRepeat` et non `setRepeatMode` : `BaseAudioHandler` réserve
+  /// déjà ce nom pour la commande système (`AudioServiceRepeatMode`), qui n'est
+  /// pas le même vocabulaire.
+  @override
+  Future<void> setRepeat(QueueRepeatMode mode) => _player.setLoopMode(
+        const {
+          QueueRepeatMode.off: LoopMode.off,
+          QueueRepeatMode.one: LoopMode.one,
+          QueueRepeatMode.all: LoopMode.all,
+        }[mode]!,
+      );
+
   @override
   Future<void> loadUri(String url, {required NowPlaying now}) async {
+    // Un direct n'a ni file ni fin : les modes hérités d'une écoute de playlist
+    // n'ont plus de sens ici (et `LoopMode.one` rejouerait un segment).
+    await _player.setShuffleModeEnabled(false);
+    await _player.setLoopMode(LoopMode.off);
     // Métadonnées de l'écran verrouillé / notification. Un flux live n'a pas de
     // durée : `isLive` masque la barre de progression côté OS.
     _queueItems = const [];
@@ -129,6 +168,11 @@ class StreamAudioHandler extends BaseAudioHandler
       initialIndex: start,
       initialPosition: initialPosition,
     );
+
+    // Chaque source neuve arrive avec un ordre de mélange neuf, donc naturel :
+    // sans ce tirage, relancer une playlist en mode aléatoire la rejouerait
+    // dans l'ordre. `shuffle()` garde la piste de départ en tête.
+    if (_player.shuffleModeEnabled) await _player.shuffle();
   }
 
   @override
@@ -180,15 +224,29 @@ class StreamAudioHandler extends BaseAudioHandler
   /// contrôleur applicatif suit ensuite via `currentIndexStream`, ce qui évite
   /// deux sources de vérité sur la position dans la file.
   @override
-  Future<void> skipToNext() async {
-    if (!_hasSource) return;
-    await _player.seekToNext();
-  }
+  Future<void> skipToNext() => _skipRelative(1);
 
   @override
-  Future<void> skipToPrevious() async {
+  Future<void> skipToPrevious() => _skipRelative(-1);
+
+  /// Saut manuel d'un rang dans l'**ordre de lecture** (mélangé ou non).
+  ///
+  /// Volontairement pas `_player.seekToNext()` : sous `LoopMode.one`, just_audio
+  /// y renvoie la piste courante, et le bouton « suivant » de la notification
+  /// ne ferait que la redémarrer. La répétition d'une piste ne concerne que
+  /// l'enchaînement automatique — d'où le passage par [PlaybackOrder], partagé
+  /// avec les boutons de l'application.
+  Future<void> _skipRelative(int offset) async {
     if (!_hasSource) return;
-    await _player.seekToPrevious();
+    final current = _player.currentIndex;
+    if (current == null) return;
+    final target = playbackOrder.relative(
+      current,
+      offset,
+      wrap: _player.loopMode == LoopMode.all,
+    );
+    if (target == null) return;
+    await _player.seek(Duration.zero, index: target);
   }
 
   @override

--- a/mobile/lib/features/playlists/presentation/providers/playlist_queue_controller.dart
+++ b/mobile/lib/features/playlists/presentation/providers/playlist_queue_controller.dart
@@ -8,7 +8,8 @@ import '../../../../core/audio/queue_playback_service.dart';
 import '../../../../core/constants/api_constants.dart';
 import '../../domain/entities/playlist_track.dart';
 
-export '../../../../core/audio/queue_playback_service.dart' show PlaybackStatus;
+export '../../../../core/audio/queue_playback_service.dart'
+    show PlaybackStatus, QueueRepeatMode;
 
 /// Lecture d'une playlist avec file d'attente (US-05-04), hissée au niveau
 /// application comme le lecteur de direct : la file survit à la navigation et à
@@ -56,6 +57,19 @@ class PlaylistQueueController extends ChangeNotifier {
   PlaybackStatus _status = PlaybackStatus.idle;
   bool _disposed = false;
 
+  /// Modes de lecture (US-05-05). Ils appartiennent au contrôleur et non au
+  /// lecteur : celui-ci est partagé avec le direct, qui les remet à zéro en
+  /// prenant la main. Les réappliquer à chaque chargement les rend insensibles
+  /// à cette bascule.
+  bool _shuffleEnabled = false;
+  QueueRepeatMode _repeatMode = QueueRepeatMode.off;
+
+  /// Ordre de lecture effectif, relevé auprès du lecteur après chaque
+  /// chargement ou changement de mode. Photographié plutôt que lu à la volée :
+  /// l'UI le parcourt à chaque frame, et un ordre qui changerait sans
+  /// `notifyListeners` afficherait une file désynchronisée du son.
+  PlaybackOrder _order = PlaybackOrder.empty;
+
   /// Reprises déjà tentées sur la piste courante.
   ///
   /// Remis à zéro sur une **action utilisateur** (lancement, saut) et sur un
@@ -76,6 +90,20 @@ class PlaylistQueueController extends ChangeNotifier {
   String? get playlistName => _playlistName;
   int get currentIndex => _index;
   PlaybackStatus get status => _status;
+  bool get shuffleEnabled => _shuffleEnabled;
+  QueueRepeatMode get repeatMode => _repeatMode;
+
+  /// Index de [tracks] dans l'ordre où ils seront joués (US-05-05). C'est cet
+  /// ordre que la file d'attente affiche : montrer l'ordre de la playlist
+  /// pendant une lecture aléatoire annoncerait une suite qui n'arrivera pas.
+  List<int> get playbackOrder => _order.indices;
+
+  /// Rang de la piste courante dans l'ordre de lecture (base 0), pour l'affichage
+  /// « n/total ». Retombe sur l'index brut si l'ordre n'est pas encore connu.
+  int get positionInOrder {
+    final position = _order.positionOf(_index);
+    return position < 0 ? _index : position;
+  }
 
   /// La file est-elle active ? Faux à l'arrêt : le mini-player s'efface et rend
   /// la place au direct.
@@ -91,15 +119,25 @@ class PlaylistQueueController extends ChangeNotifier {
   bool get hasError => _status == PlaybackStatus.error;
   bool get isEnded => _status == PlaybackStatus.ended;
   bool get isReconnecting => _status == PlaybackStatus.reconnecting;
-  bool get hasNext => _index < _tracks.length - 1;
-  bool get hasPrevious => _index > 0;
+  bool get hasNext => _relative(1) != null;
+  bool get hasPrevious => _relative(-1) != null;
+
+  /// Piste à jouer [offset] rangs plus loin dans l'ordre de lecture, ou `null`
+  /// s'il n'y en a pas. La répétition de la file (`all`) reboucle aux deux
+  /// extrémités ; celle d'une piste (`one`) ne bloque pas les sauts manuels.
+  int? _relative(int offset) =>
+      _order.relative(_index, offset, wrap: _repeatMode == QueueRepeatMode.all);
 
   /// Lance [tracks] à partir de [startIndex] et démarre la lecture.
+  ///
+  /// [shuffle] force la lecture aléatoire (entrée « Lire en aléatoire ») ;
+  /// omis, le mode courant est conservé d'une playlist à l'autre.
   Future<void> play({
     required String playlistId,
     required String playlistName,
     required List<PlaylistTrack> tracks,
     int startIndex = 0,
+    bool? shuffle,
   }) async {
     if (tracks.isEmpty) return;
 
@@ -120,7 +158,38 @@ class PlaylistQueueController extends ChangeNotifier {
     _playlistName = playlistName;
     _index = startIndex.clamp(0, tracks.length - 1);
     _retryCount = 0;
+    // Ordre provisoire, remplacé par celui du lecteur une fois la file chargée.
+    // Sans lui, l'ordre de la playlist précédente resterait affiché le temps du
+    // chargement — et survivrait à un chargement qui échoue.
+    _order = PlaybackOrder.natural(_tracks.length);
+    if (shuffle != null) _shuffleEnabled = shuffle;
     await _load(fromIndex: _index);
+  }
+
+  /// Bascule la lecture aléatoire (US-05-05). Le lecteur tire un nouvel ordre
+  /// en gardant la piste courante en tête : ce qu'on écoute n'est pas coupé,
+  /// seule la suite change.
+  Future<void> toggleShuffle() async {
+    _shuffleEnabled = !_shuffleEnabled;
+    if (!_disposed) notifyListeners();
+    if (_tracks.isEmpty) return;
+    await _service.setShuffleEnabled(_shuffleEnabled);
+    _refreshOrder();
+  }
+
+  /// Fait défiler les modes de répétition : aucune → toute la file → la piste.
+  ///
+  /// Un seul bouton pour trois états plutôt que deux boutons : c'est la
+  /// convention des lecteurs audio, et les trois modes sont exclusifs.
+  Future<void> cycleRepeat() async {
+    _repeatMode = switch (_repeatMode) {
+      QueueRepeatMode.off => QueueRepeatMode.all,
+      QueueRepeatMode.all => QueueRepeatMode.one,
+      QueueRepeatMode.one => QueueRepeatMode.off,
+    };
+    if (!_disposed) notifyListeners();
+    if (_tracks.isEmpty) return;
+    await _service.setRepeat(_repeatMode);
   }
 
   /// Saute à la piste [index] de la file (« sauter à n'importe quelle piste »).
@@ -141,15 +210,23 @@ class PlaylistQueueController extends ChangeNotifier {
     await _service.play();
   }
 
-  Future<void> next() => hasNext ? skipTo(_index + 1) : Future.value();
-  Future<void> previous() => hasPrevious ? skipTo(_index - 1) : Future.value();
+  Future<void> next() => _skipRelative(1);
+  Future<void> previous() => _skipRelative(-1);
+
+  Future<void> _skipRelative(int offset) {
+    final target = _relative(offset);
+    return target == null ? Future.value() : skipTo(target);
+  }
 
   /// Bascule lecture/pause ; relance la file si elle est terminée ou en erreur.
   Future<void> togglePlayPause() async {
     if (_tracks.isEmpty) return;
     if (isEnded || hasError) {
       _retryCount = 0;
-      await _load(fromIndex: isEnded ? 0 : _index);
+      // Relancer une file terminée repart de sa **première piste jouée**, pas
+      // de la première de la playlist : en aléatoire, les deux diffèrent.
+      final first = _order.isEmpty ? 0 : _order.indices.first;
+      await _load(fromIndex: isEnded ? first : _index);
       return;
     }
     if (isBusy || isReconnecting) return;
@@ -192,6 +269,14 @@ class PlaylistQueueController extends ChangeNotifier {
       final token = await _token(forceRefresh: refreshToken);
       if (_disposed || generation != _generation) return;
 
+      // Modes réappliqués avant chaque chargement : le lecteur est partagé avec
+      // le direct, qui les remet à zéro en prenant la main. Et l'aléatoire doit
+      // être actif **avant** que la file n'arrive, pour que le lecteur mélange
+      // la source neuve au lieu de l'enchaîner dans l'ordre.
+      await _service.setRepeat(_repeatMode);
+      await _service.setShuffleEnabled(_shuffleEnabled);
+      if (_disposed || generation != _generation) return;
+
       await _service.loadQueue(
         [
           for (final track in _tracks)
@@ -210,11 +295,23 @@ class PlaylistQueueController extends ChangeNotifier {
         headers: token == null ? const {} : {'Authorization': 'Bearer $token'},
       );
       if (_disposed || generation != _generation) return;
+      _refreshOrder();
       await _service.play();
     } catch (e) {
       if (generation != _generation) return;
       _onError(e);
     }
+  }
+
+  /// Relève l'ordre de lecture auprès du lecteur (il vient de le tirer). Un
+  /// ordre qui ne couvre pas exactement la file est ignoré au profit de l'ordre
+  /// naturel : mieux vaut afficher la playlist en clair qu'une file trouée.
+  void _refreshOrder() {
+    final order = _service.playbackOrder;
+    _order = order.indices.length == _tracks.length
+        ? order
+        : PlaybackOrder.natural(_tracks.length);
+    if (!_disposed) notifyListeners();
   }
 
   void _onPlayerState(PlayerState state) {
@@ -310,6 +407,9 @@ class PlaylistQueueController extends ChangeNotifier {
     _playlistId = null;
     _playlistName = null;
     _index = 0;
+    // Les modes de lecture survivent : ce sont des préférences d'écoute, pas
+    // l'état d'une file. Seul l'ordre, qui décrit cette file, disparaît avec elle.
+    _order = PlaybackOrder.empty;
     _retryCount = 0;
     _generation++;
     _status = PlaybackStatus.idle;

--- a/mobile/lib/features/playlists/presentation/providers/playlist_queue_controller.dart
+++ b/mobile/lib/features/playlists/presentation/providers/playlist_queue_controller.dart
@@ -163,7 +163,9 @@ class PlaylistQueueController extends ChangeNotifier {
     // chargement — et survivrait à un chargement qui échoue.
     _order = PlaybackOrder.natural(_tracks.length);
     if (shuffle != null) _shuffleEnabled = shuffle;
-    await _load(fromIndex: _index);
+    // Seul lancement **demandé** : c'est le seul endroit où un nouvel ordre
+    // aléatoire doit être tiré.
+    await _load(fromIndex: _index, keepOrder: false);
   }
 
   /// Bascule la lecture aléatoire (US-05-05). Le lecteur tire un nouvel ordre
@@ -258,10 +260,17 @@ class PlaylistQueueController extends ChangeNotifier {
   /// (Re)charge la file dans le lecteur à partir de [fromIndex], à [position]
   /// dans cette piste. [refreshToken] force une rotation de l'access token
   /// (première reprise après échec).
+  ///
+  /// [keepOrder] conserve l'ordre de lecture courant au lieu d'en faire tirer un
+  /// neuf. Vrai par défaut : tous les rechargements sauf [play] sont **subis**
+  /// (reprise après erreur, relance d'une file terminée), et l'auditeur n'a pas
+  /// demandé que la suite change. Une expiration d'access token survenant toutes
+  /// les 15 minutes, sans ça la file se réarrangerait à ce rythme.
   Future<void> _load({
     required int fromIndex,
     Duration position = Duration.zero,
     bool refreshToken = false,
+    bool keepOrder = true,
   }) async {
     final generation = ++_generation;
     _setStatus(PlaybackStatus.loading);
@@ -293,6 +302,9 @@ class PlaylistQueueController extends ChangeNotifier {
         initialIndex: fromIndex,
         initialPosition: position,
         headers: token == null ? const {} : {'Authorization': 'Bearer $token'},
+        // Un ordre naturel n'a rien à imposer : le laisser à `null` évite de
+        // figer une file qui n'est pas mélangée.
+        order: keepOrder && _shuffleEnabled && !_order.isEmpty ? _order : null,
       );
       if (_disposed || generation != _generation) return;
       _refreshOrder();

--- a/mobile/lib/features/playlists/presentation/screens/playlist_detail_screen.dart
+++ b/mobile/lib/features/playlists/presentation/screens/playlist_detail_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -119,7 +121,10 @@ class _PlaylistDetailBodyState extends State<_PlaylistDetailBody> {
   /// niveau application, il ne peut pas suivre les mutations d'un écran qu'on
   /// quitte. Réordonner ou retirer une piste ne change donc pas ce qui joue
   /// tant que l'utilisateur n'a pas relancé la lecture.
-  Future<void> _onPlay({int startIndex = 0}) async {
+  ///
+  /// [shuffle] non nul force le mode de lecture (« Lire en aléatoire »
+  /// US-05-05) ; omis, le mode courant est conservé.
+  Future<void> _onPlay({int startIndex = 0, bool? shuffle}) async {
     final controller = context.read<PlaylistDetailController>();
     if (controller.tracks.isEmpty) return;
 
@@ -128,6 +133,7 @@ class _PlaylistDetailBodyState extends State<_PlaylistDetailBody> {
           playlistName: widget.title,
           tracks: controller.tracks,
           startIndex: startIndex,
+          shuffle: shuffle,
         );
   }
 
@@ -156,6 +162,20 @@ class _PlaylistDetailBodyState extends State<_PlaylistDetailBody> {
       appBar: AppBar(
         title: Text(widget.title),
         actions: [
+          IconButton(
+            key: const Key('playlist_shuffle_play_button'),
+            icon: const Icon(Icons.shuffle),
+            tooltip: 'Lire en aléatoire',
+            // Point de départ tiré au sort : le lecteur mélange la suite mais
+            // garde la piste de départ en tête. Partir systématiquement de la
+            // première ferait une lecture aléatoire qui commence toujours pareil.
+            onPressed: controller.tracks.isEmpty
+                ? null
+                : () => _onPlay(
+                      startIndex: Random().nextInt(controller.tracks.length),
+                      shuffle: true,
+                    ),
+          ),
           IconButton(
             key: const Key('playlist_add_track_button'),
             icon: const Icon(Icons.playlist_add),

--- a/mobile/lib/features/playlists/presentation/widgets/playback_queue_sheet.dart
+++ b/mobile/lib/features/playlists/presentation/widgets/playback_queue_sheet.dart
@@ -62,17 +62,24 @@ class PlaybackQueueSheet extends StatelessWidget {
               overflow: TextOverflow.ellipsis,
             ),
             trailing: Text(
-              '${queue.currentIndex + 1}/${queue.tracks.length}',
+              '${queue.positionInOrder + 1}/${queue.tracks.length}',
               style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant),
             ),
           ),
+          // Les modes vivent ici plutôt que sur le mini-player : celui-ci n'a
+          // que 60 px de haut et porte déjà quatre boutons, et c'est la file
+          // affichée juste dessous qui rend leur effet lisible.
+          const _QueueModeBar(),
           const Divider(height: 1),
           Flexible(
             child: ListView.builder(
               key: const Key('playback_queue_list'),
               shrinkWrap: true,
-              itemCount: queue.tracks.length,
-              itemBuilder: (context, index) {
+              itemCount: queue.playbackOrder.length,
+              itemBuilder: (context, position) {
+                // La liste suit l'**ordre de lecture** : en aléatoire, elle
+                // annonce donc la suite réelle et non l'ordre de la playlist.
+                final index = queue.playbackOrder[position];
                 final track = queue.tracks[index];
                 final isCurrent = index == queue.currentIndex;
                 return ListTile(
@@ -80,7 +87,7 @@ class PlaybackQueueSheet extends StatelessWidget {
                   selected: isCurrent,
                   leading: queueTrackLeading(
                     context,
-                    index: index,
+                    index: position,
                     isCurrent: isCurrent,
                   ),
                   title: Text(
@@ -104,6 +111,97 @@ class PlaybackQueueSheet extends StatelessWidget {
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+/// Modes de lecture de la file (US-05-05) : aléatoire et répétition.
+///
+/// Deux boutons **libellés** plutôt que deux icônes nues : un mode actif se
+/// distingue déjà par sa couleur, mais « répéter la piste » et « répéter la
+/// file » ne se devinent pas d'une icône barrée d'un « 1 ».
+class _QueueModeBar extends StatelessWidget {
+  const _QueueModeBar();
+
+  @override
+  Widget build(BuildContext context) {
+    final queue = context.watch<PlaylistQueueController>();
+
+    final (IconData repeatIcon, String repeatLabel) = switch (queue.repeatMode) {
+      QueueRepeatMode.off => (Icons.repeat, 'Répétition'),
+      QueueRepeatMode.all => (Icons.repeat, 'Répéter la file'),
+      QueueRepeatMode.one => (Icons.repeat_one, 'Répéter la piste'),
+    };
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      child: Row(
+        children: [
+          Expanded(
+            child: _ModeButton(
+              buttonKey: const Key('queue_shuffle_button'),
+              icon: Icons.shuffle,
+              label: 'Aléatoire',
+              active: queue.shuffleEnabled,
+              tooltip: queue.shuffleEnabled
+                  ? 'Désactiver la lecture aléatoire'
+                  : 'Activer la lecture aléatoire',
+              onPressed: () =>
+                  context.read<PlaylistQueueController>().toggleShuffle(),
+            ),
+          ),
+          Expanded(
+            child: _ModeButton(
+              buttonKey: const Key('queue_repeat_button'),
+              icon: repeatIcon,
+              label: repeatLabel,
+              active: queue.repeatMode != QueueRepeatMode.off,
+              tooltip: 'Changer le mode de répétition',
+              onPressed: () =>
+                  context.read<PlaylistQueueController>().cycleRepeat(),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ModeButton extends StatelessWidget {
+  const _ModeButton({
+    required this.buttonKey,
+    required this.icon,
+    required this.label,
+    required this.active,
+    required this.tooltip,
+    required this.onPressed,
+  });
+
+  final Key buttonKey;
+  final IconData icon;
+  final String label;
+  final bool active;
+  final String tooltip;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return Tooltip(
+      message: tooltip,
+      child: TextButton.icon(
+        key: buttonKey,
+        onPressed: onPressed,
+        style: TextButton.styleFrom(
+          foregroundColor: active ? colors.primary : colors.onSurfaceVariant,
+        ),
+        icon: Icon(icon),
+        label: Text(
+          label,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
       ),
     );
   }

--- a/mobile/lib/features/playlists/presentation/widgets/queue_mini_player.dart
+++ b/mobile/lib/features/playlists/presentation/widgets/queue_mini_player.dart
@@ -25,8 +25,10 @@ class QueueMiniPlayer extends StatelessWidget {
       PlaybackStatus.ended => ('File d\'attente terminée', colors.error),
       PlaybackStatus.error => ('Lecture impossible', colors.error),
       PlaybackStatus.reconnecting => ('Reconnexion…', colors.onSurfaceVariant),
+      // Rang dans l'ordre de lecture, pas dans la playlist : en aléatoire, la
+      // 1re piste jouée n'est pas la 1re de la liste.
       _ => (
-          '${queue.currentIndex + 1}/${queue.tracks.length} · '
+          '${queue.positionInOrder + 1}/${queue.tracks.length} · '
               '${track.artist ?? 'Artiste inconnu'}',
           colors.onSurfaceVariant,
         ),

--- a/mobile/test/core/audio/playback_order_test.dart
+++ b/mobile/test/core/audio/playback_order_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:streampulse/core/audio/playback_order.dart';
+
+void main() {
+  group('PlaybackOrder — ordre naturel (US-05-05)', () {
+    test('avance et recule d\'un rang', () {
+      final order = PlaybackOrder.natural(3);
+
+      expect(order.relative(0, 1, wrap: false), 1);
+      expect(order.relative(2, -1, wrap: false), 1);
+    });
+
+    test('sans répétition, les extrémités n\'ont pas de suite', () {
+      final order = PlaybackOrder.natural(3);
+
+      expect(order.relative(2, 1, wrap: false), isNull);
+      expect(order.relative(0, -1, wrap: false), isNull);
+    });
+
+    test('la répétition de la file reboucle des deux côtés', () {
+      final order = PlaybackOrder.natural(3);
+
+      expect(order.relative(2, 1, wrap: true), 0);
+      expect(order.relative(0, -1, wrap: true), 2);
+    });
+  });
+
+  group('PlaybackOrder — ordre mélangé (US-05-05)', () {
+    // La file d'origine est [0, 1, 2] ; le lecteur la jouera 2, 0, 1.
+    const shuffled = PlaybackOrder([2, 0, 1]);
+
+    test('le rang affiché suit l\'ordre de lecture, pas la playlist', () {
+      expect(shuffled.positionOf(2), 0);
+      expect(shuffled.positionOf(1), 2);
+    });
+
+    test('le saut suit l\'ordre mélangé et non l\'index de la playlist', () {
+      // Depuis la piste 2 (1re jouée), la suivante est la piste 0.
+      expect(shuffled.relative(2, 1, wrap: false), 0);
+      expect(shuffled.relative(0, -1, wrap: false), 2);
+    });
+
+    test('la dernière piste jouée n\'a de suite qu\'avec la répétition', () {
+      expect(shuffled.relative(1, 1, wrap: false), isNull);
+      expect(shuffled.relative(1, 1, wrap: true), 2);
+    });
+  });
+
+  group('PlaybackOrder — cas limites', () {
+    test('file vide : aucun saut', () {
+      expect(PlaybackOrder.empty.relative(0, 1, wrap: true), isNull);
+      expect(PlaybackOrder.empty.isEmpty, isTrue);
+    });
+
+    test('piste absente de l\'ordre : aucun saut plutôt qu\'un saut faux', () {
+      const order = PlaybackOrder([0, 1]);
+
+      expect(order.positionOf(7), -1);
+      expect(order.relative(7, 1, wrap: true), isNull);
+    });
+
+    test('file d\'une seule piste : la répétition la redonne', () {
+      final order = PlaybackOrder.natural(1);
+
+      expect(order.relative(0, 1, wrap: false), isNull);
+      expect(order.relative(0, 1, wrap: true), 0);
+    });
+  });
+}

--- a/mobile/test/features/playlists/presentation/playlist_queue_controller_test.dart
+++ b/mobile/test/features/playlists/presentation/playlist_queue_controller_test.dart
@@ -42,6 +42,13 @@ final _tracks = [
   return (controller: controller, service: service);
 }
 
+/// Laisse filer le backoff (1/2/4 s) sans attendre en temps réel. Partagé par
+/// les tests de reprise et ceux de l'ordre de lecture, qui reposent dessus.
+void elapse(FakeAsync async, {int seconds = 10}) {
+  async.elapse(Duration(seconds: seconds));
+  async.flushMicrotasks();
+}
+
 Future<void> _play(
   PlaylistQueueController controller, {
   int startIndex = 0,
@@ -236,12 +243,6 @@ void main() {
   });
 
   group('PlaylistQueueController — reprise après erreur', () {
-    /// Laisse filer le backoff (1/2/4 s) sans attendre en temps réel.
-    Future<void> elapse(FakeAsync async, {int seconds = 10}) async {
-      async.elapse(Duration(seconds: seconds));
-      async.flushMicrotasks();
-    }
-
     test('la reprise attend le backoff, force UN refresh et garde la position',
         () {
       fakeAsync((async) {
@@ -456,6 +457,57 @@ void main() {
       // playlist.
       expect(t.controller.hasNext, isFalse);
       expect(t.controller.hasPrevious, isTrue);
+    });
+
+    test('une reprise après erreur rejoue le même ordre (retour de revue)', () {
+      fakeAsync((async) {
+        final t = _build();
+        t.service.shuffledOrder = [2, 0, 1];
+        _play(t.controller, shuffle: true);
+        async.flushMicrotasks();
+        expect(t.controller.playbackOrder, [2, 0, 1]);
+        expect(t.service.lastOrder, isNull,
+            reason: 'un lancement demandé tire un ordre neuf');
+
+        // Coupure réseau / access token expiré (toutes les 15 min en pratique).
+        t.service.emitError(Exception('coupure'));
+        async.flushMicrotasks();
+        elapse(async);
+
+        expect(t.service.loadCalls, 2);
+        expect(t.service.lastOrder?.indices, [2, 0, 1],
+            reason: 'le rechargement subi impose l\'ordre en cours');
+        expect(t.controller.playbackOrder, [2, 0, 1],
+            reason: 'la suite annoncée ne doit pas bouger sous l\'auditeur');
+      });
+    });
+
+    test('relancer volontairement la playlist retire un ordre', () async {
+      final t = _build();
+      t.service.shuffledOrder = [1, 2, 0];
+      await _play(t.controller, shuffle: true);
+
+      await _play(t.controller);
+
+      expect(t.service.lastOrder, isNull);
+      expect(t.controller.playbackOrder, [1, 2, 0],
+          reason: 'nouvel ordre relevé auprès du lecteur, pas celui d\'avant');
+    });
+
+    test('une file non mélangée n\'impose aucun ordre au rechargement', () {
+      fakeAsync((async) {
+        final t = _build();
+        _play(t.controller);
+        async.flushMicrotasks();
+
+        t.service.emitError(Exception('coupure'));
+        async.flushMicrotasks();
+        elapse(async);
+
+        expect(t.service.loadCalls, 2);
+        expect(t.service.lastOrder, isNull,
+            reason: 'rien à figer sur une lecture dans l\'ordre');
+      });
     });
 
     test('le mode survit à l\'arrêt : c\'est une préférence d\'écoute',

--- a/mobile/test/features/playlists/presentation/playlist_queue_controller_test.dart
+++ b/mobile/test/features/playlists/presentation/playlist_queue_controller_test.dart
@@ -46,12 +46,14 @@ Future<void> _play(
   PlaylistQueueController controller, {
   int startIndex = 0,
   List<PlaylistTrack>? tracks,
+  bool? shuffle,
 }) {
   return controller.play(
     playlistId: 'p-1',
     playlistName: 'My Favorites',
     tracks: tracks ?? _tracks,
     startIndex: startIndex,
+    shuffle: shuffle,
   );
 }
 
@@ -389,6 +391,141 @@ void main() {
 
       expect(t.controller.hasQueue, isFalse);
       expect(t.controller.status, PlaybackStatus.idle);
+    });
+  });
+
+  group('PlaylistQueueController — lecture aléatoire (US-05-05)', () {
+    test('sans shuffle, l\'ordre de lecture est celui de la playlist',
+        () async {
+      final t = _build();
+
+      await _play(t.controller);
+
+      expect(t.controller.shuffleEnabled, isFalse);
+      expect(t.controller.playbackOrder, [0, 1, 2]);
+      expect(t.service.shuffleEnabled, isFalse);
+    });
+
+    test('lancer en aléatoire mélange la file dès le chargement', () async {
+      final t = _build();
+      t.service.shuffledOrder = [2, 0, 1];
+
+      await _play(t.controller, startIndex: 2, shuffle: true);
+
+      expect(t.service.shuffleEnabled, isTrue);
+      expect(t.controller.playbackOrder, [2, 0, 1]);
+      // La piste de départ est bien la première **jouée** (« 1/3 »).
+      expect(t.controller.positionInOrder, 0);
+    });
+
+    test('la bascule en cours de lecture relève le nouvel ordre', () async {
+      final t = _build();
+      await _play(t.controller);
+      t.service.shuffledOrder = [1, 2, 0];
+
+      await t.controller.toggleShuffle();
+
+      expect(t.controller.shuffleEnabled, isTrue);
+      expect(t.service.shuffleEnabled, isTrue);
+      expect(t.controller.playbackOrder, [1, 2, 0]);
+    });
+
+    test('« suivant » suit l\'ordre mélangé, pas l\'index de la playlist',
+        () async {
+      final t = _build();
+      t.service.shuffledOrder = [1, 2, 0];
+      await _play(t.controller, startIndex: 1, shuffle: true);
+
+      await t.controller.next();
+
+      // Depuis la piste 1 (1re jouée), la suivante est la 2 — pas la 2 par
+      // hasard : c'est l'ordre mélangé qui le dit, l'index+1 aurait donné 2
+      // aussi, d'où le second saut ci-dessous qui les départage.
+      expect(t.service.skips, [2]);
+      await t.controller.next();
+      expect(t.service.skips, [2, 0]);
+      expect(t.controller.currentIndex, 0);
+    });
+
+    test('la dernière piste jouée n\'a pas de suivante', () async {
+      final t = _build();
+      t.service.shuffledOrder = [1, 2, 0];
+      await _play(t.controller, startIndex: 0, shuffle: true);
+
+      // La piste 0 est la dernière de l'ordre mélangé, bien que première de la
+      // playlist.
+      expect(t.controller.hasNext, isFalse);
+      expect(t.controller.hasPrevious, isTrue);
+    });
+
+    test('le mode survit à l\'arrêt : c\'est une préférence d\'écoute',
+        () async {
+      final t = _build();
+      await _play(t.controller);
+      await t.controller.toggleShuffle();
+
+      await t.controller.stop();
+
+      expect(t.controller.shuffleEnabled, isTrue);
+    });
+  });
+
+  group('PlaylistQueueController — répétition (US-05-05)', () {
+    test('le bouton fait défiler aucune → file → piste → aucune', () async {
+      final t = _build();
+      await _play(t.controller);
+
+      await t.controller.cycleRepeat();
+      expect(t.controller.repeatMode, QueueRepeatMode.all);
+      expect(t.service.repeatMode, QueueRepeatMode.all);
+
+      await t.controller.cycleRepeat();
+      expect(t.controller.repeatMode, QueueRepeatMode.one);
+
+      await t.controller.cycleRepeat();
+      expect(t.controller.repeatMode, QueueRepeatMode.off);
+    });
+
+    test('répéter la file : la dernière piste a une suivante, qui reboucle',
+        () async {
+      final t = _build();
+      await _play(t.controller, startIndex: 2);
+      expect(t.controller.hasNext, isFalse);
+
+      await t.controller.cycleRepeat(); // → all
+
+      expect(t.controller.hasNext, isTrue);
+      await t.controller.next();
+      expect(t.service.skips, [0]);
+    });
+
+    test('répéter la piste ne bloque pas le saut manuel', () async {
+      final t = _build();
+      await _play(t.controller);
+      await t.controller.cycleRepeat(); // all
+      await t.controller.cycleRepeat(); // one
+
+      await t.controller.next();
+
+      // just_audio ferait redémarrer la piste courante ; un bouton « suivant »
+      // qui ne change pas de piste passerait pour une panne.
+      expect(t.service.skips, [1]);
+    });
+
+    test('les modes sont réappliqués au lecteur à chaque chargement', () async {
+      final t = _build();
+      await _play(t.controller);
+      await t.controller.cycleRepeat(); // → all
+      await t.controller.toggleShuffle(); // → aléatoire
+
+      // Le direct a pu prendre le lecteur entre-temps et remettre ses modes à
+      // zéro : relancer une file doit les rétablir.
+      t.service.repeatMode = QueueRepeatMode.off;
+      t.service.shuffleEnabled = false;
+      await _play(t.controller);
+
+      expect(t.service.repeatMode, QueueRepeatMode.all);
+      expect(t.service.shuffleEnabled, isTrue);
     });
   });
 }

--- a/mobile/test/features/playlists/presentation/screens/playlist_detail_screen_test.dart
+++ b/mobile/test/features/playlists/presentation/screens/playlist_detail_screen_test.dart
@@ -215,6 +215,38 @@ void main() {
       expect(find.byKey(const Key('playlist_play_button')), findsNothing);
     });
 
+    testWidgets('« Lire en aléatoire » lance la file mélangée (US-05-05)',
+        (tester) async {
+      final repo = _FakePlaylistRepository(
+        initial: [_track('t1', 'Midnight Drive', 0), _track('t2', 'Sunrise', 1)],
+      );
+      final service = FakeQueuePlaybackService();
+      final queue = _queueController(service);
+      addTearDown(queue.dispose);
+      addTearDown(service.dispose);
+
+      await tester.pumpWidget(_harness(repo, queue: queue));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('playlist_shuffle_play_button')));
+      await tester.pumpAndSettle();
+
+      expect(queue.shuffleEnabled, isTrue);
+      expect(service.shuffleEnabled, isTrue);
+      // Toute la playlist est chargée ; seul l'ordre de lecture change.
+      expect(service.lastItems.map((i) => i.id).toList(), ['t1', 't2']);
+    });
+
+    testWidgets('playlist vide : « Lire en aléatoire » est neutralisé',
+        (tester) async {
+      await tester.pumpWidget(_harness(_FakePlaylistRepository()));
+      await tester.pumpAndSettle();
+
+      final button = tester.widget<IconButton>(
+        find.byKey(const Key('playlist_shuffle_play_button')),
+      );
+      expect(button.onPressed, isNull);
+    });
+
     testWidgets('playlist vide : message dédié + appel à l\'action',
         (tester) async {
       await tester.pumpWidget(_harness(_FakePlaylistRepository()));

--- a/mobile/test/features/playlists/presentation/widgets/queue_ui_test.dart
+++ b/mobile/test/features/playlists/presentation/widgets/queue_ui_test.dart
@@ -159,6 +159,43 @@ void main() {
       expect(t.controller.currentIndex, 2);
     });
 
+    testWidgets('les modes de lecture sont réglables depuis la file (US-05-05)',
+        (tester) async {
+      final t = await _pumpPlaying(tester, const QueueMiniPlayer());
+      await _openQueueSheet(tester);
+
+      expect(find.byKey(const Key('queue_shuffle_button')), findsOneWidget);
+      expect(find.text('Répétition'), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('queue_repeat_button')));
+      await tester.pumpAndSettle();
+      expect(find.text('Répéter la file'), findsOneWidget);
+      expect(t.service.repeatMode, QueueRepeatMode.all);
+
+      await tester.tap(find.byKey(const Key('queue_repeat_button')));
+      await tester.pumpAndSettle();
+      expect(find.text('Répéter la piste'), findsOneWidget);
+    });
+
+    testWidgets('en aléatoire, la file affiche l\'ordre réellement joué',
+        (tester) async {
+      final t = await _pumpPlaying(tester, const QueueMiniPlayer());
+      // Le lecteur jouera t2, t3, t1.
+      t.service.shuffledOrder = [1, 2, 0];
+      await _openQueueSheet(tester);
+
+      await tester.tap(find.byKey(const Key('queue_shuffle_button')));
+      await tester.pumpAndSettle();
+
+      expect(t.service.shuffleEnabled, isTrue);
+      double y(String id) =>
+          tester.getTopLeft(find.byKey(Key('queue_item_$id'))).dy;
+      expect(y('t2'), lessThan(y('t3')));
+      expect(y('t3'), lessThan(y('t1')));
+      // La piste en cours (t1) n'est plus la 1re jouée mais la dernière.
+      expect(t.controller.positionInOrder, 2);
+    });
+
     testWidgets('la feuille se referme si la file s\'arrête pendant', (
       tester,
     ) async {

--- a/mobile/test/support/fake_queue_playback_service.dart
+++ b/mobile/test/support/fake_queue_playback_service.dart
@@ -30,6 +30,14 @@ class FakeQueuePlaybackService implements QueuePlaybackService {
   final List<int> skips = [];
   bool _playing = false;
 
+  bool shuffleEnabled = false;
+  QueueRepeatMode repeatMode = QueueRepeatMode.off;
+
+  /// Ordre rendu quand l'aléatoire est actif. Fixé (et non tiré au sort) pour
+  /// que les tests décrivent un ordre précis ; à défaut, l'ordre inverse suffit
+  /// à distinguer « mélangé » de « naturel ».
+  List<int>? shuffledOrder;
+
   void emitState(PlayerState state) {
     if (!_stateCtrl.isClosed) _stateCtrl.add(state);
   }
@@ -66,6 +74,23 @@ class FakeQueuePlaybackService implements QueuePlaybackService {
     final err = loadError;
     if (err != null) throw err;
   }
+
+  /// Ordre de lecture simulé : naturel, ou mélangé quand l'aléatoire est actif
+  /// — comme le lecteur natif, qui tire son ordre au chargement.
+  @override
+  PlaybackOrder get playbackOrder {
+    if (!shuffleEnabled) return PlaybackOrder.natural(lastItems.length);
+    return PlaybackOrder(
+      shuffledOrder ??
+          List.generate(lastItems.length, (i) => lastItems.length - 1 - i),
+    );
+  }
+
+  @override
+  Future<void> setShuffleEnabled(bool enabled) async => shuffleEnabled = enabled;
+
+  @override
+  Future<void> setRepeat(QueueRepeatMode mode) async => repeatMode = mode;
 
   @override
   Future<void> skipToIndex(int index) async => skips.add(index);

--- a/mobile/test/support/fake_queue_playback_service.dart
+++ b/mobile/test/support/fake_queue_playback_service.dart
@@ -38,6 +38,13 @@ class FakeQueuePlaybackService implements QueuePlaybackService {
   /// à distinguer « mélangé » de « naturel ».
   List<int>? shuffledOrder;
 
+  /// Ordre imposé au dernier [loadQueue] (`null` = nouveau tirage demandé).
+  PlaybackOrder? lastOrder;
+
+  /// Ordre effectivement conservé par le lecteur simulé, comme le vrai handler :
+  /// un ordre imposé prime sur le tirage.
+  List<int>? _keptOrder;
+
   void emitState(PlayerState state) {
     if (!_stateCtrl.isClosed) _stateCtrl.add(state);
   }
@@ -65,12 +72,15 @@ class FakeQueuePlaybackService implements QueuePlaybackService {
     int initialIndex = 0,
     Duration initialPosition = Duration.zero,
     Map<String, String> headers = const {},
+    PlaybackOrder? order,
   }) async {
     loadCalls++;
     lastItems = items;
     lastInitialIndex = initialIndex;
     lastInitialPosition = initialPosition;
     lastHeaders = headers;
+    lastOrder = order;
+    _keptOrder = order == null ? null : List.of(order.indices);
     final err = loadError;
     if (err != null) throw err;
   }
@@ -80,6 +90,8 @@ class FakeQueuePlaybackService implements QueuePlaybackService {
   @override
   PlaybackOrder get playbackOrder {
     if (!shuffleEnabled) return PlaybackOrder.natural(lastItems.length);
+    final kept = _keptOrder;
+    if (kept != null) return PlaybackOrder(kept);
     return PlaybackOrder(
       shuffledOrder ??
           List.generate(lastItems.length, (i) => lastItems.length - 1 - i),
@@ -87,7 +99,11 @@ class FakeQueuePlaybackService implements QueuePlaybackService {
   }
 
   @override
-  Future<void> setShuffleEnabled(bool enabled) async => shuffleEnabled = enabled;
+  Future<void> setShuffleEnabled(bool enabled) async {
+    shuffleEnabled = enabled;
+    // Comme le vrai handler : activer l'aléatoire tire un ordre neuf.
+    if (enabled) _keptOrder = null;
+  }
 
   @override
   Future<void> setRepeat(QueueRepeatMode mode) async => repeatMode = mode;


### PR DESCRIPTION
Ferme [STR-134](https://linear.app/streampulse/issue/STR-134) (US-05-05).

## Ce que ça fait

Lecture aléatoire et répétition (aucune / toute la file / la piste) sur la file d'attente de l'US-05-04.

Le mélange et la répétition sont **délégués au lecteur natif** (`setShuffleModeEnabled` + `shuffle()`, `LoopMode`), comme l'était déjà l'enchaînement : l'application règle les modes et **lit** l'ordre obtenu (`effectiveIndices`), elle ne calcule aucune permutation. Un enchaînement automatique, un appui dans l'app et un appui sur la notification donnent donc forcément la même piste.

## Décisions

| Point | Choix |
|---|---|
| Règle du saut | `PlaybackOrder` (`core/audio/`), objet **pur** partagé par le contrôleur et le handler |
| `repeat one` | Ne gouverne que l'enchaînement **automatique**. `seekToNext()`/`seekToPrevious()` sont remplacés : sous `LoopMode.one` just_audio y rejoue la piste courante, et un bouton « suivant » qui ne change pas de piste passe pour une panne |
| Modes | Portés par le contrôleur (le direct remet ceux du lecteur à zéro en prenant la main), réappliqués à chaque chargement, conservés après `stop()`, perdus au redémarrage |
| `shuffle()` | Appelé avant l'activation (garde la piste courante en tête → lecture pas coupée) **et** après chaque `loadQueue` (une source neuve arrive avec un ordre naturel) |
| Nommage | `QueueRepeatMode` : `material.dart` exporte déjà un `RepeatMode` (animations) |
| Affichage | File et « n/total » suivent l'**ordre de lecture**, pas l'ordre de la playlist |

Détails et alternatives écartées : [ADR 035](docs/adr/035-modes-shuffle-et-repeat.md).

## UI

- Toggles « Aléatoire » et répétition (3 états, libellés) dans la feuille de file d'attente.
- Action « Lire en aléatoire » dans l'AppBar du détail de playlist, avec **piste de départ tirée au sort** (le lecteur gardant la piste de départ en tête, partir toujours de la première rendrait un aléatoire qui commence toujours pareil).

## Vérification

`flutter analyze` : 0 issue. `flutter test` : 403 tests, tous verts (+23 : 9 sur `PlaybackOrder`, 10 sur le contrôleur, 4 widgets).

QA sur device physique (Galaxy S20, Android 13), chaque saut confirmé par le **binaire réellement servi** par l'API :

- aléatoire en cours de lecture : ordre retiré, piste courante gardée en tête, son non coupé ; OFF → ordre playlist restauré ;
- repeat-piste : enchaînement auto rejoue la même piste, mais **« suivant » avance** (`Afterglow → Sunrise → Midnight Drive`) — même règle depuis les boutons de la **notification système**, et l'app suit ;
- repeat-file : wrap `3/3 → 1/3` ; repeat-piste sur la dernière piste : « suivant » neutralisé (pas de wrap) ;
- « Lire en aléatoire » : 3 tirages, départs et ordres différents ;
- cycler la répétition ne modifie pas l'ordre.

Aucune exception, aucun 5xx. Une expiration d'access token est survenue pendant la session : la reprise bornée de l'US-05-04 a fait son travail (rotation + rechargement, lecture jamais interrompue à l'écran).

## Limites assumées

Modes perdus au redémarrage ; une reprise après erreur retire un nouvel ordre ; modes non exposés aux commandes système (l'état ne serait pas relu → dérive app/lecteur). Toutes documentées dans l'ADR.
