### PR TITLE
feat(mobile): barre de progression et navigation dans la piste (STR-230)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -462,6 +462,12 @@ Voir [ADR 034](docs/adr/034-lecture-dune-playlist-avec-file-dattente.md).
   piste), `QueueMiniPlayer` (précédent/play/suivant/croix), `PlaybackQueueSheet` (file visible,
   appui = saut). La file est une **photo** des pistes au lancement : réordonner la playlist ne
   change pas ce qui joue tant qu'on ne relance pas.
+- **Avancement et navigation dans la piste (STR-230)** : `positionStream` / `bufferedPositionStream`
+  / `durationStream` / `seek` vivent sur `QueuePlaybackService` **et pas** sur `PlaybackTransport`
+  (un direct n'a pas de position). Rendu par `queue_progress.dart` : trait de 2 px sur le bandeau,
+  `Slider` manipulable dans la feuille (le bandeau fait 60 px, on n'y vise pas au pouce). Durée lue
+  dans le **lecteur**, `duration_s` de la base ne servant que de valeur d'attente (déclaré par le
+  client à l'upload, il peut mentir). Le serveur ne coûte rien : `Range` déjà géré (ADR 034 §1).
 
 ### Modes shuffle et repeat (US-05-05)
 
@@ -536,6 +542,14 @@ Choisir **le plus simple qui suffit**, dans cet ordre :
 - `context.watch<T>()` dans `build()` uniquement — reconstruit à chaque `notifyListeners()`
 - `context.read<T>()` dans les callbacks (`onPressed`, `_onSubmit`) uniquement — ne reconstruit pas
 - `notifyListeners()` après chaque mutation d'un notifier
+- ⚠️ **Un flux haute fréquence ne traverse jamais un `ChangeNotifier` app-level.** Position de
+  lecture, niveau audio, chrono : à ~5 Hz, un `notifyListeners()` reconstruit tout l'arbre sous le
+  contrôleur. Le contrôleur expose le `Stream` tel quel, le widget qui l'affiche s'y abonne seul
+  (exemple : `queue_progress.dart`, STR-230).
+- ⚠️ **Un getter de `Stream` rend souvent un objet neuf à chaque accès** (`StreamController.stream`
+  le fait) : un `StreamBuilder` branché dessus se réabonne à chaque reconstruction. Sans conséquence
+  sur un flux continu, fatal sur un flux qui n'émet qu'une fois (une durée de piste). S'abonner une
+  fois dans `initState` quand la valeur compte.
 
 ### Conventions Flutter — Async & cycle de vie
 

--- a/mobile/lib/core/audio/queue_playback_service.dart
+++ b/mobile/lib/core/audio/queue_playback_service.dart
@@ -46,6 +46,26 @@ abstract class QueuePlaybackService implements PlaybackTransport {
   /// pour repartir d'où l'auditeur en était, plutôt que du début de la piste.
   Duration get position;
 
+  /// Position de lecture, en continu (STR-230). Émet plusieurs fois par
+  /// seconde : à consommer **au plus près du widget** qui l'affiche, jamais via
+  /// le `notifyListeners` d'un contrôleur applicatif — tout l'arbre sous lui se
+  /// reconstruirait à cette cadence.
+  Stream<Duration> get positionStream;
+
+  /// Portion déjà téléchargée de la piste en cours. Rend la barre honnête sur
+  /// un réseau lent : sans elle, une lecture qui va bufferiser paraît figée.
+  Stream<Duration> get bufferedPositionStream;
+
+  /// Durée de la piste en cours, `null` tant que le lecteur ne l'a pas lue dans
+  /// le fichier. Vient du lecteur et non de la base : `duration_s` est déclaré
+  /// par le client à l'upload (ADR 032), il peut mentir.
+  Stream<Duration?> get durationStream;
+
+  /// Déplace la lecture dans la piste en cours. Sert la navigation manuelle
+  /// (glissement sur la barre) ; le serveur la rend gratuite en honorant les
+  /// requêtes `Range` (ADR 034 §1).
+  Future<void> seek(Duration position);
+
   /// Ordre dans lequel le lecteur enchaînera la file chargée (US-05-05) :
   /// identité en lecture normale, permutation en lecture aléatoire.
   ///

--- a/mobile/lib/core/audio/stream_audio_handler.dart
+++ b/mobile/lib/core/audio/stream_audio_handler.dart
@@ -74,6 +74,12 @@ class StreamAudioHandler extends BaseAudioHandler
   @override
   Duration get position => _player.position;
   @override
+  Stream<Duration> get positionStream => _player.positionStream;
+  @override
+  Stream<Duration> get bufferedPositionStream => _player.bufferedPositionStream;
+  @override
+  Stream<Duration?> get durationStream => _player.durationStream;
+  @override
   bool get playing => _player.playing;
 
   /// Ordre de lecture effectif tel que le lecteur natif le tient (US-05-05).

--- a/mobile/lib/core/widgets/mini_player_shell.dart
+++ b/mobile/lib/core/widgets/mini_player_shell.dart
@@ -17,6 +17,7 @@ class MiniPlayerShell extends StatelessWidget {
     required this.actions,
     this.subtitle,
     this.subtitleColor,
+    this.progress,
   });
 
   final IconData icon;
@@ -32,51 +33,63 @@ class MiniPlayerShell extends StatelessWidget {
   final String? subtitle;
   final Color? subtitleColor;
 
+  /// Trait d'avancement collé sous le bandeau (STR-230). Fourni par la file
+  /// d'attente ; le direct le laisse nul — un flux live n'a pas de position à
+  /// montrer, c'est déjà pour ça que sa notification masque sa barre.
+  final Widget? progress;
+
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).colorScheme;
     final text = Theme.of(context).textTheme;
-    final line = subtitle;
+    final status = subtitle;
+    final line = progress;
 
     return Material(
       color: colors.surfaceContainerHighest,
       child: InkWell(
         onTap: onTap,
-        child: SizedBox(
-          height: 60,
-          child: Row(
-            children: [
-              const SizedBox(width: 14),
-              Icon(icon, color: colors.primary),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      title,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style:
-                          text.titleSmall?.copyWith(fontWeight: FontWeight.w600),
-                    ),
-                    if (line != null && line.isNotEmpty)
-                      Text(
-                        line,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: text.bodySmall?.copyWith(
-                          color: subtitleColor ?? colors.onSurfaceVariant,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            SizedBox(
+              height: 60,
+              child: Row(
+                children: [
+                  const SizedBox(width: 14),
+                  Icon(icon, color: colors.primary),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          title,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: text.titleSmall
+                              ?.copyWith(fontWeight: FontWeight.w600),
                         ),
-                      ),
-                  ],
-                ),
+                        if (status != null && status.isNotEmpty)
+                          Text(
+                            status,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: text.bodySmall?.copyWith(
+                              color: subtitleColor ?? colors.onSurfaceVariant,
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                  ...actions,
+                  const SizedBox(width: 4),
+                ],
               ),
-              ...actions,
-              const SizedBox(width: 4),
-            ],
-          ),
+            ),
+            if (line != null) line,
+          ],
         ),
       ),
     );

--- a/mobile/lib/features/playlists/presentation/providers/playlist_queue_controller.dart
+++ b/mobile/lib/features/playlists/presentation/providers/playlist_queue_controller.dart
@@ -113,13 +113,32 @@ class PlaylistQueueController extends ChangeNotifier {
   ///
   /// Sans effet sur une file terminée ou en erreur : la source native n'y est
   /// plus exploitable, c'est une relance qu'il faut, pas un déplacement.
+  ///
+  /// Sans effet non plus **pendant une reprise** (`reconnecting`, `loading`) :
+  /// une reprise en vol rechargera la file à la position qu'elle a relevée
+  /// *avant* le déplacement, et écraserait donc celui-ci quelques secondes plus
+  /// tard — l'auditeur verrait la lecture revenir en arrière toute seule
+  /// (retour de revue #292). Même règle que `togglePlayPause`.
   Future<void> seek(Duration position) async {
-    if (_tracks.isEmpty || isEnded || hasError) return;
+    if (!canSeek) return;
     // Action utilisateur : elle réarme les reprises automatiques, comme un saut
     // de piste (cf. `_retryCount`).
     _retryCount = 0;
     await _service.seek(position);
   }
+
+  /// Un déplacement a-t-il un sens maintenant ?
+  ///
+  /// Exposé pour que la barre se neutralise exactement quand [seek] refuse :
+  /// une poignée qui glisse sans rien déplacer est pire que pas de poignée.
+  /// La mise en mémoire tampon, elle, n'empêche rien — le lecteur sait
+  /// déplacer une lecture qui bufferise.
+  bool get canSeek =>
+      _tracks.isNotEmpty &&
+      !isEnded &&
+      !hasError &&
+      !isReconnecting &&
+      _status != PlaybackStatus.loading;
 
   /// Rang de la piste courante dans l'ordre de lecture (base 0), pour l'affichage
   /// « n/total ». Retombe sur l'index brut si l'ordre n'est pas encore connu.

--- a/mobile/lib/features/playlists/presentation/providers/playlist_queue_controller.dart
+++ b/mobile/lib/features/playlists/presentation/providers/playlist_queue_controller.dart
@@ -98,6 +98,29 @@ class PlaylistQueueController extends ChangeNotifier {
   /// pendant une lecture aléatoire annoncerait une suite qui n'arrivera pas.
   List<int> get playbackOrder => _order.indices;
 
+  /// Avancement de la piste en cours (STR-230), exposé **tel quel** depuis le
+  /// lecteur.
+  ///
+  /// Ces flux émettent plusieurs fois par seconde : ils ne passent délibérément
+  /// pas par `notifyListeners`, sans quoi tout l'arbre sous ce contrôleur
+  /// app-level se reconstruirait à cette cadence. Les widgets s'y abonnent
+  /// individuellement (`StreamBuilder`).
+  Stream<Duration> get positionStream => _service.positionStream;
+  Stream<Duration> get bufferedPositionStream => _service.bufferedPositionStream;
+  Stream<Duration?> get durationStream => _service.durationStream;
+
+  /// Déplace la lecture dans la piste en cours (glissement sur la barre).
+  ///
+  /// Sans effet sur une file terminée ou en erreur : la source native n'y est
+  /// plus exploitable, c'est une relance qu'il faut, pas un déplacement.
+  Future<void> seek(Duration position) async {
+    if (_tracks.isEmpty || isEnded || hasError) return;
+    // Action utilisateur : elle réarme les reprises automatiques, comme un saut
+    // de piste (cf. `_retryCount`).
+    _retryCount = 0;
+    await _service.seek(position);
+  }
+
   /// Rang de la piste courante dans l'ordre de lecture (base 0), pour l'affichage
   /// « n/total ». Retombe sur l'index brut si l'ordre n'est pas encore connu.
   int get positionInOrder {

--- a/mobile/lib/features/playlists/presentation/widgets/playback_queue_sheet.dart
+++ b/mobile/lib/features/playlists/presentation/widgets/playback_queue_sheet.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../providers/playlist_queue_controller.dart';
 import '../track_labels.dart';
+import 'queue_progress.dart';
 import 'queue_track_visuals.dart';
 
 /// File d'attente en cours de lecture (US-05-04), en feuille modale.
@@ -66,6 +67,9 @@ class PlaybackQueueSheet extends StatelessWidget {
               style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant),
             ),
           ),
+          // Avancement manipulable (STR-230) : c'est la surface qui a la place
+          // d'accueillir un pouce, contrairement au bandeau.
+          const QueueProgressSlider(),
           // Les modes vivent ici plutôt que sur le mini-player : celui-ci n'a
           // que 60 px de haut et porte déjà quatre boutons, et c'est la file
           // affichée juste dessous qui rend leur effet lisible.

--- a/mobile/lib/features/playlists/presentation/widgets/queue_mini_player.dart
+++ b/mobile/lib/features/playlists/presentation/widgets/queue_mini_player.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../../../../core/widgets/mini_player_shell.dart';
 import '../providers/playlist_queue_controller.dart';
 import 'playback_queue_sheet.dart';
+import 'queue_progress.dart';
 
 /// Mini-player de la file d'attente (US-05-04) : pendant du mini-player du
 /// direct, avec les contrôles que seule une file justifie (précédent/suivant).
@@ -40,6 +41,10 @@ class QueueMiniPlayer extends StatelessWidget {
       title: track.title,
       subtitle: subtitle,
       subtitleColor: subtitleColor,
+      // Avancement de la piste (STR-230) : un trait, pas de manipulation — le
+      // bandeau fait 60 px, viser un pouce dessus serait une loterie. La barre
+      // manipulable vit dans la file d'attente, à un appui d'ici.
+      progress: const QueueProgressLine(),
       onTap: () => PlaybackQueueSheet.show(context),
       actions: [
         IconButton(

--- a/mobile/lib/features/playlists/presentation/widgets/queue_progress.dart
+++ b/mobile/lib/features/playlists/presentation/widgets/queue_progress.dart
@@ -1,0 +1,225 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/playlist_queue_controller.dart';
+import '../track_labels.dart';
+
+/// Avancement de la piste en cours (STR-230), en deux formes : un trait sur le
+/// mini-player ([QueueProgressLine]) et une barre manipulable dans la file
+/// d'attente ([QueueProgressSlider]).
+///
+/// Les deux s'abonnent **directement** aux flux du contrôleur plutôt que de
+/// lire un état exposé par `notifyListeners` : la position émet plusieurs fois
+/// par seconde, la faire transiter par le contrôleur app-level reconstruirait
+/// tout l'arbre (mini-player, file, écran en cours) à cette cadence.
+///
+/// La durée vient du **lecteur**, pas de la base : `duration_s` est déclaré par
+/// le client à l'upload (ADR 032) et peut être faux. Celle de la piste ne sert
+/// que de valeur d'attente, le temps que le lecteur ouvre le fichier — sans
+/// elle, la barre resterait vide une seconde à chaque changement de piste.
+class QueueProgressLine extends StatelessWidget {
+  const QueueProgressLine({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+
+    return _ProgressBuilder(
+      builder: (context, position, buffered, duration) {
+        if (duration == null || duration == Duration.zero) {
+          return const SizedBox(height: 2);
+        }
+        return SizedBox(
+          height: 2,
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              LinearProgressIndicator(
+                value: _fraction(buffered, duration),
+                backgroundColor: colors.surfaceContainerHighest,
+                color: colors.primary.withValues(alpha: 0.25),
+              ),
+              LinearProgressIndicator(
+                value: _fraction(position, duration),
+                backgroundColor: Colors.transparent,
+                color: colors.primary,
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// Barre manipulable : glisser dedans déplace la lecture.
+class QueueProgressSlider extends StatefulWidget {
+  const QueueProgressSlider({super.key});
+
+  @override
+  State<QueueProgressSlider> createState() => _QueueProgressSliderState();
+}
+
+class _QueueProgressSliderState extends State<QueueProgressSlider> {
+  /// Position sous le pouce pendant un glissement. Tant qu'elle est posée, les
+  /// positions venant du lecteur sont ignorées : sinon le pouce se ferait
+  /// doubler par la lecture qui continue, et la barre tremblerait.
+  Duration? _dragging;
+
+  Future<void> _onChangeEnd(Duration target) async {
+    await context.read<PlaylistQueueController>().seek(target);
+    if (!mounted) return;
+    // Relâchée seulement après le déplacement : l'effacer avant ferait revenir
+    // le pouce à l'ancienne position le temps que le lecteur rattrape.
+    setState(() => _dragging = null);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final text = Theme.of(context).textTheme;
+    final colors = Theme.of(context).colorScheme;
+
+    return _ProgressBuilder(
+      builder: (context, position, buffered, duration) {
+        final total = duration ?? Duration.zero;
+        final shown = _dragging ?? position;
+        final enabled = total > Duration.zero;
+
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            SliderTheme(
+              data: SliderTheme.of(context).copyWith(
+                trackHeight: 2,
+                thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 6),
+                overlayShape: const RoundSliderOverlayShape(overlayRadius: 14),
+              ),
+              child: Slider(
+                key: const Key('queue_progress_slider'),
+                min: 0,
+                // Un maximum nul ferait lever le Slider : tant que la durée est
+                // inconnue, on garde une échelle d'une seconde, désactivée.
+                max: enabled ? total.inMilliseconds.toDouble() : 1,
+                value: enabled
+                    ? shown.inMilliseconds
+                        .clamp(0, total.inMilliseconds)
+                        .toDouble()
+                    : 0,
+                onChanged: enabled
+                    ? (value) => setState(
+                          () => _dragging =
+                              Duration(milliseconds: value.round()),
+                        )
+                    : null,
+                onChangeEnd: enabled
+                    ? (value) =>
+                        _onChangeEnd(Duration(milliseconds: value.round()))
+                    : null,
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    formatTrackDuration(shown.inSeconds),
+                    style: text.bodySmall
+                        ?.copyWith(color: colors.onSurfaceVariant),
+                  ),
+                  Text(
+                    enabled ? formatTrackDuration(total.inSeconds) : '--:--',
+                    style: text.bodySmall
+                        ?.copyWith(color: colors.onSurfaceVariant),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+/// Assemble les trois flux d'avancement en un seul `builder`.
+///
+/// **Un seul abonnement par flux, posé à la construction** — et surtout pas des
+/// `StreamBuilder` imbriqués : `Stream` n'est pas une valeur stable ici (un
+/// getter de flux rend un objet neuf à chaque accès), si bien qu'à chaque
+/// reconstruction un `StreamBuilder` se réabonnerait. Sur un flux continu ça ne
+/// coûte qu'un tick, mais la **durée n'est émise qu'une fois par piste** : elle
+/// serait perdue et la barre resterait muette.
+///
+/// Le tampon est facultatif au sens strict, mais sans lui une lecture qui
+/// bufferise paraît figée : la barre grise montre que ça télécharge.
+class _ProgressBuilder extends StatefulWidget {
+  const _ProgressBuilder({required this.builder});
+
+  final Widget Function(
+    BuildContext context,
+    Duration position,
+    Duration buffered,
+    Duration? duration,
+  ) builder;
+
+  @override
+  State<_ProgressBuilder> createState() => _ProgressBuilderState();
+}
+
+class _ProgressBuilderState extends State<_ProgressBuilder> {
+  final _subscriptions = <StreamSubscription<Object?>>[];
+
+  Duration _position = Duration.zero;
+  Duration _buffered = Duration.zero;
+  Duration? _duration;
+
+  @override
+  void initState() {
+    super.initState();
+    final queue = context.read<PlaylistQueueController>();
+    _subscriptions.addAll([
+      queue.positionStream.listen((v) => _set(() => _position = v)),
+      queue.bufferedPositionStream.listen((v) => _set(() => _buffered = v)),
+      queue.durationStream.listen((v) => _set(() => _duration = v)),
+    ]);
+  }
+
+  /// `setState` ne reconstruit que cette barre : c'est tout l'intérêt de garder
+  /// ces flux hors du contrôleur app-level.
+  void _set(VoidCallback change) {
+    if (!mounted) return;
+    setState(change);
+  }
+
+  @override
+  void dispose() {
+    for (final subscription in _subscriptions) {
+      subscription.cancel();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Durée déclarée de la piste : valeur d'attente le temps que le lecteur
+    // lise la vraie dans le fichier. Suivie par `watch` pour se rafraîchir au
+    // changement de piste.
+    final declared =
+        context.watch<PlaylistQueueController>().currentTrack?.durationS;
+
+    return widget.builder(
+      context,
+      _position,
+      _buffered,
+      _duration ?? (declared == null ? null : Duration(seconds: declared)),
+    );
+  }
+}
+
+double _fraction(Duration value, Duration total) =>
+    total <= Duration.zero
+        ? 0
+        : (value.inMilliseconds / total.inMilliseconds).clamp(0, 1).toDouble();

--- a/mobile/lib/features/playlists/presentation/widgets/queue_progress.dart
+++ b/mobile/lib/features/playlists/presentation/widgets/queue_progress.dart
@@ -38,7 +38,10 @@ class QueueProgressLine extends StatelessWidget {
             children: [
               LinearProgressIndicator(
                 value: _fraction(buffered, duration),
-                backgroundColor: colors.surfaceContainerHighest,
+                // `outlineVariant` et non la couleur du bandeau : celui-ci est
+                // déjà en `surfaceContainerHighest`, la portion restante y
+                // serait invisible (retour de revue #292).
+                backgroundColor: colors.outlineVariant,
                 color: colors.primary.withValues(alpha: 0.25),
               ),
               LinearProgressIndicator(
@@ -69,11 +72,15 @@ class _QueueProgressSliderState extends State<QueueProgressSlider> {
   Duration? _dragging;
 
   Future<void> _onChangeEnd(Duration target) async {
-    await context.read<PlaylistQueueController>().seek(target);
-    if (!mounted) return;
-    // Relâchée seulement après le déplacement : l'effacer avant ferait revenir
-    // le pouce à l'ancienne position le temps que le lecteur rattrape.
-    setState(() => _dragging = null);
+    try {
+      await context.read<PlaylistQueueController>().seek(target);
+    } finally {
+      // Relâchée seulement après le déplacement : l'effacer avant ferait revenir
+      // le pouce à l'ancienne position le temps que le lecteur rattrape. Mais
+      // relâchée **quoi qu'il arrive** : un `seek` qui échoue laisserait sinon
+      // le curseur figé jusqu'au changement de piste (retour de revue #292).
+      if (mounted) setState(() => _dragging = null);
+    }
   }
 
   @override
@@ -81,11 +88,17 @@ class _QueueProgressSliderState extends State<QueueProgressSlider> {
     final text = Theme.of(context).textTheme;
     final colors = Theme.of(context).colorScheme;
 
+    // La poignée se neutralise exactement quand le contrôleur refuserait le
+    // déplacement (file terminée, en erreur, en reprise) : une poignée qui
+    // glisse sans rien déplacer est pire que pas de poignée (revue #292).
+    final canSeek =
+        context.select<PlaylistQueueController, bool>((q) => q.canSeek);
+
     return _ProgressBuilder(
       builder: (context, position, buffered, duration) {
         final total = duration ?? Duration.zero;
         final shown = _dragging ?? position;
-        final enabled = total > Duration.zero;
+        final enabled = total > Duration.zero && canSeek;
 
         return Column(
           mainAxisSize: MainAxisSize.min,
@@ -171,19 +184,30 @@ class _ProgressBuilder extends StatefulWidget {
 
 class _ProgressBuilderState extends State<_ProgressBuilder> {
   final _subscriptions = <StreamSubscription<Object?>>[];
+  late final PlaylistQueueController _queue;
 
   Duration _position = Duration.zero;
   Duration _buffered = Duration.zero;
   Duration? _duration;
 
+  /// Piste à laquelle [_duration] se rapporte. Le lecteur n'émet une durée
+  /// qu'une fois par piste : sans ce repère, celle de la piste précédente
+  /// resterait affichée le temps que la nouvelle soit lue (revue #292).
+  String? _durationTrackId;
+
   @override
   void initState() {
     super.initState();
-    final queue = context.read<PlaylistQueueController>();
+    _queue = context.read<PlaylistQueueController>();
     _subscriptions.addAll([
-      queue.positionStream.listen((v) => _set(() => _position = v)),
-      queue.bufferedPositionStream.listen((v) => _set(() => _buffered = v)),
-      queue.durationStream.listen((v) => _set(() => _duration = v)),
+      _queue.positionStream.listen((v) => _set(() => _position = v)),
+      _queue.bufferedPositionStream.listen((v) => _set(() => _buffered = v)),
+      _queue.durationStream.listen(
+        (v) => _set(() {
+          _duration = v;
+          _durationTrackId = _queue.currentTrack?.id;
+        }),
+      ),
     ]);
   }
 
@@ -207,14 +231,17 @@ class _ProgressBuilderState extends State<_ProgressBuilder> {
     // Durée déclarée de la piste : valeur d'attente le temps que le lecteur
     // lise la vraie dans le fichier. Suivie par `watch` pour se rafraîchir au
     // changement de piste.
-    final declared =
-        context.watch<PlaylistQueueController>().currentTrack?.durationS;
+    final track = context.watch<PlaylistQueueController>().currentTrack;
+    final declared = track?.durationS;
+    // Une durée qui décrit la piste précédente est fausse : on retombe sur la
+    // valeur déclarée en attendant celle du lecteur.
+    final measured = _durationTrackId == track?.id ? _duration : null;
 
     return widget.builder(
       context,
       _position,
       _buffered,
-      _duration ?? (declared == null ? null : Duration(seconds: declared)),
+      measured ?? (declared == null ? null : Duration(seconds: declared)),
     );
   }
 }

--- a/mobile/test/features/playlists/presentation/playlist_queue_controller_test.dart
+++ b/mobile/test/features/playlists/presentation/playlist_queue_controller_test.dart
@@ -332,6 +332,30 @@ void main() {
       });
     });
 
+    test('un déplacement pendant une reprise est ignoré (revue #292)', () {
+      fakeAsync((async) {
+        final t = _build();
+        _play(t.controller);
+        async.flushMicrotasks();
+
+        t.service.position = const Duration(seconds: 30);
+        t.service.emitError(Exception('coupure'));
+        async.flushMicrotasks();
+        expect(t.controller.status, PlaybackStatus.reconnecting);
+        expect(t.controller.canSeek, isFalse);
+
+        t.controller.seek(const Duration(seconds: 90));
+        async.flushMicrotasks();
+
+        // La reprise en vol rechargerait à la position relevée AVANT (30 s) :
+        // accepter le déplacement le ferait annuler quelques secondes plus tard,
+        // et l'auditeur verrait la lecture revenir en arrière toute seule.
+        expect(t.service.seeks, isEmpty);
+        elapse(async);
+        expect(t.service.lastInitialPosition, const Duration(seconds: 30));
+      });
+    });
+
     test('avancer dans la file réarme les reprises', () {
       fakeAsync((async) {
         final t = _build();

--- a/mobile/test/features/playlists/presentation/widgets/queue_ui_test.dart
+++ b/mobile/test/features/playlists/presentation/widgets/queue_ui_test.dart
@@ -259,6 +259,52 @@ void main() {
       expect(slider.max, 214000);
     });
 
+    testWidgets('file terminée : la poignée est neutralisée (revue #292)',
+        (tester) async {
+      final t = await _pumpPlaying(tester, const QueueMiniPlayer());
+      await _openQueueSheet(tester);
+      t.service.emitDuration(const Duration(seconds: 200));
+      await tester.pump();
+      await tester.pump();
+
+      t.service.emitState(PlayerState(false, ProcessingState.completed));
+      await tester.pumpAndSettle();
+
+      final slider = tester.widget<Slider>(
+        find.byKey(const Key('queue_progress_slider')),
+      );
+      // `seek` refuserait de toute façon : une poignée qui glisse sans rien
+      // déplacer est pire que pas de poignée.
+      expect(slider.onChanged, isNull);
+    });
+
+    testWidgets('changement de piste : pas de durée périmée (revue #292)',
+        (tester) async {
+      final t = await _pumpPlaying(tester, const QueueMiniPlayer());
+      await _openQueueSheet(tester);
+      t.service.emitDuration(const Duration(seconds: 200));
+      await tester.pump();
+      await tester.pump();
+      expect(
+        tester
+            .widget<Slider>(find.byKey(const Key('queue_progress_slider')))
+            .max,
+        200000,
+      );
+
+      // Piste suivante : le lecteur n'a pas encore lu sa durée.
+      t.service.emitIndex(1);
+      await tester.pumpAndSettle();
+
+      expect(
+        tester
+            .widget<Slider>(find.byKey(const Key('queue_progress_slider')))
+            .max,
+        214000,
+        reason: 'la durée déclarée de la nouvelle piste, pas celle d\'avant',
+      );
+    });
+
     testWidgets('la feuille se referme si la file s\'arrête pendant', (
       tester,
     ) async {

--- a/mobile/test/features/playlists/presentation/widgets/queue_ui_test.dart
+++ b/mobile/test/features/playlists/presentation/widgets/queue_ui_test.dart
@@ -196,6 +196,69 @@ void main() {
       expect(t.controller.positionInOrder, 2);
     });
 
+    testWidgets('la barre affiche l\'avancement de la piste (STR-230)',
+        (tester) async {
+      final t = await _pumpPlaying(tester, const QueueMiniPlayer());
+      await _openQueueSheet(tester);
+
+      t.service.emitDuration(const Duration(seconds: 200));
+      t.service.emitPosition(const Duration(seconds: 50));
+      // Deux frames : la première laisse les flux délivrer, la seconde peint
+      // l'état qu'ils viennent de poser.
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('0:50'), findsOneWidget);
+      expect(find.text('3:20'), findsOneWidget);
+      final slider = tester.widget<Slider>(
+        find.byKey(const Key('queue_progress_slider')),
+      );
+      expect(slider.value, 50000);
+      expect(slider.max, 200000);
+    });
+
+    testWidgets('glisser la barre déplace la lecture (STR-230)',
+        (tester) async {
+      final t = await _pumpPlaying(tester, const QueueMiniPlayer());
+      await _openQueueSheet(tester);
+      t.service.emitDuration(const Duration(seconds: 200));
+      t.service.emitPosition(Duration.zero);
+      await tester.pump();
+      await tester.pump();
+
+      // Le geste démarre au centre de la barre (= 100 s sur 200) et pousse d'un
+      // quart de sa largeur vers la droite : on relâche donc aux trois quarts.
+      final slider = find.byKey(const Key('queue_progress_slider'));
+      await tester.drag(slider, Offset(tester.getSize(slider).width / 4, 0));
+      await tester.pumpAndSettle();
+
+      expect(t.service.seeks, hasLength(1));
+      expect(
+        t.service.seeks.single.inSeconds,
+        closeTo(150, 15),
+        reason: 'le déplacement suit la position relâchée sur la barre',
+      );
+    });
+
+    testWidgets('durée inconnue : barre neutralisée plutôt que fausse',
+        (tester) async {
+      final t = await _pumpPlaying(tester, const QueueMiniPlayer());
+      await _openQueueSheet(tester);
+
+      // Piste dont la durée n'est ni déclarée ni encore lue par le lecteur.
+      t.service.emitDuration(null);
+      await tester.pump();
+      await tester.pump();
+
+      final slider = tester.widget<Slider>(
+        find.byKey(const Key('queue_progress_slider')),
+      );
+      // La durée déclarée de la piste (0:12 dans _tracks) sert de valeur
+      // d'attente : la barre reste utilisable, elle ne prétend pas 0:00.
+      expect(slider.onChanged, isNotNull);
+      expect(slider.max, 214000);
+    });
+
     testWidgets('la feuille se referme si la file s\'arrête pendant', (
       tester,
     ) async {

--- a/mobile/test/support/fake_queue_playback_service.dart
+++ b/mobile/test/support/fake_queue_playback_service.dart
@@ -11,6 +11,12 @@ class FakeQueuePlaybackService implements QueuePlaybackService {
   final _stateCtrl = StreamController<PlayerState>.broadcast();
   final _indexCtrl = StreamController<int?>.broadcast();
   final _errorCtrl = StreamController<Object>.broadcast();
+  final _positionCtrl = StreamController<Duration>.broadcast();
+  final _bufferedCtrl = StreamController<Duration>.broadcast();
+  final _durationCtrl = StreamController<Duration?>.broadcast();
+
+  /// Déplacements demandés par l'application (STR-230).
+  final List<Duration> seeks = [];
 
   /// Si non nul, [loadQueue] lève cette erreur (simule une source injoignable,
   /// typiquement un 401 sur un access token périmé).
@@ -57,6 +63,18 @@ class FakeQueuePlaybackService implements QueuePlaybackService {
     if (!_errorCtrl.isClosed) _errorCtrl.add(error);
   }
 
+  /// Avancement simulé (STR-230). La durée est poussée séparément : le vrai
+  /// lecteur ne la connaît qu'après avoir ouvert le fichier.
+  void emitPosition(Duration position, {Duration? buffered}) {
+    if (!_positionCtrl.isClosed) _positionCtrl.add(position);
+    if (!_bufferedCtrl.isClosed) _bufferedCtrl.add(buffered ?? position);
+  }
+
+  void emitDuration(Duration? duration) {
+    _duration = duration;
+    if (!_durationCtrl.isClosed) _durationCtrl.add(duration);
+  }
+
   @override
   Stream<PlayerState> get playerStateStream => _stateCtrl.stream;
   @override
@@ -64,7 +82,29 @@ class FakeQueuePlaybackService implements QueuePlaybackService {
   @override
   Stream<Object> get playbackErrors => _errorCtrl.stream;
   @override
+  Stream<Duration> get positionStream => _positionCtrl.stream;
+  @override
+  Stream<Duration> get bufferedPositionStream => _bufferedCtrl.stream;
+
+  /// Rejoue la dernière durée connue à chaque nouvel abonné, comme le
+  /// `BehaviorSubject` de just_audio : sans ça, un widget monté après le
+  /// chargement de la piste n'apprendrait jamais sa durée.
+  @override
+  Stream<Duration?> get durationStream async* {
+    yield _duration;
+    yield* _durationCtrl.stream;
+  }
+
+  Duration? _duration;
+  @override
   bool get playing => _playing;
+
+  @override
+  Future<void> seek(Duration to) async {
+    seeks.add(to);
+    position = to;
+    emitPosition(to);
+  }
 
   @override
   Future<void> loadQueue(
@@ -130,5 +170,8 @@ class FakeQueuePlaybackService implements QueuePlaybackService {
     await _stateCtrl.close();
     await _indexCtrl.close();
     await _errorCtrl.close();
+    await _positionCtrl.close();
+    await _bufferedCtrl.close();
+    await _durationCtrl.close();
   }
 }


### PR DESCRIPTION
Ferme [STR-230](https://linear.app/streampulse/issue/STR-230/barre-de-progression-et-navigation-dans-la-piste-seek-cote-app).

## Le manque

La notification système avait un scrubber, l'application non. Le handler publiait déjà `updatePosition`, `bufferedPosition` et la durée du `MediaItem` — mais uniquement comme **commande système** (`BaseAudioHandler`). Côté app, aucun flux de position, `seek` absent des interfaces : ni barre d'avancement, ni moyen d'avancer ou reculer dans une piste.

Côté backend, rien à faire : `http.ServeContent` honore déjà les requêtes `Range` (ADR 034 §1).

## Décisions

| Point | Choix |
|---|---|
| Où poser position/tampon/durée/`seek` | Sur **`QueuePlaybackService`**, pas sur `PlaybackTransport` : un direct HLS n'a pas de position qui veuille dire quelque chose (`isLive`, sa notification masque déjà sa barre). Le contrôleur de direct n'hérite pas de méthodes qu'il n'utilise pas |
| Cadence | Les flux **ne passent pas** par `notifyListeners` : à ~5 Hz, tout l'arbre sous le contrôleur app-level se reconstruirait. Le contrôleur les expose tels quels, la barre s'y abonne seule |
| Abonnement | **Une fois dans `initState`**, pas des `StreamBuilder` imbriqués : `StreamController.stream` rend un objet neuf à chaque accès (vérifié : `identical` → `false`), donc un `StreamBuilder` se réabonne à chaque reconstruction. Sans effet sur un flux continu, fatal sur la **durée**, émise une seule fois par piste |
| Durée affichée | Celle du **lecteur**. `duration_s` de la base est déclaré par le client à l'upload (ADR 032) et peut mentir : il ne sert que de valeur d'attente, le temps que le lecteur ouvre le fichier |
| Glissement | Les positions du lecteur sont ignorées tant que le pouce est posé, et la valeur n'est relâchée qu'une fois le `seek` effectué — sinon le pouce se fait doubler, puis revient en arrière |

## UI

- **Bandeau** : trait de 2 px (tampon en fond, position par-dessus). Pas manipulable — 60 px de haut, viser au pouce serait une loterie.
- **Feuille de file d'attente** : `Slider` + minutage `position / durée`, avec `--:--` tant que la durée est inconnue plutôt qu'un `0:00` faux.

## Vérification

`flutter analyze` : 0 issue. `flutter test` : 409 tests verts (+3 : avancement affiché, glissement qui déplace la lecture, durée inconnue qui neutralise la barre au lieu de mentir).

## ADR

**Aucun**, comme arbitré dans le ticket : les requêtes `Range` et la scission `PlaybackTransport` / `QueuePlaybackService` étaient déjà décidées (ADR 034 §1 et §2), on ne fait que les appliquer. `CLAUDE.md` gagne en revanche deux conventions Flutter tirées de ce travail : un flux haute fréquence ne traverse jamais un `ChangeNotifier` app-level, et un getter de `Stream` n'est pas une valeur stable.
