### PR TITLE
feat(mobile): lecture d'une piste depuis la bibliothèque (STR-231)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -441,7 +441,12 @@ Voir [ADR 023](docs/adr/023-lecteur-audio-hls-mobile.md) (lecteur HLS),
 Voir [ADR 034](docs/adr/034-lecture-dune-playlist-avec-file-dattente.md).
 
 - **`PlaylistQueueController`** (app-level, `features/playlists/presentation/providers/`) : lance une
-  playlist, expose la file et l'index courant. L'**enchaînement est délégué au lecteur natif**
+  file de pistes, expose la file et l'index courant. Sa source est une playlist **ou** la
+  bibliothèque (STR-231) : `play(tracks:, sourceName:, playlistId:)` prend des `Track` (le type sans
+  position), `playlistId` reste nul hors playlist — c'est lui qui permet à l'écran de détail de
+  souligner « la piste en cours **de cette** playlist ». Un appui sur une ligne de « Mes pistes »
+  lance **toute** la bibliothèque à partir d'elle : une file d'un seul élément rendrait
+  précédent/suivant et les modes de lecture sans objet. L'**enchaînement est délégué au lecteur natif**
   (`ConcatenatingAudioSource`, qui précharge la suivante) ; le contrôleur suit
   `currentIndexStream` — un saut fait depuis la notification système remonte donc par le même
   chemin qu'un appui dans l'app, sans seconde source de vérité.

--- a/mobile/lib/features/playlists/domain/entities/playlist_track.dart
+++ b/mobile/lib/features/playlists/domain/entities/playlist_track.dart
@@ -1,5 +1,7 @@
 import 'package:equatable/equatable.dart';
 
+import 'track.dart';
+
 /// Piste au sein d'une playlist (US-05-02). artist et durationS sont nullables
 /// (la table tracks les autorise nuls).
 class PlaylistTrack extends Equatable {
@@ -16,6 +18,14 @@ class PlaylistTrack extends Equatable {
   final String? artist;
   final int? durationS;
   final int position;
+
+  /// Oublie la position pour ne garder que la piste (STR-231).
+  ///
+  /// La file d'attente joue des pistes, d'où qu'elles viennent : une playlist a
+  /// un ordre, la bibliothèque non, et le lecteur n'a que faire de la
+  /// différence. C'est [Track] qu'il reçoit dans les deux cas.
+  Track toTrack() =>
+      Track(id: id, title: title, artist: artist, durationS: durationS);
 
   @override
   List<Object?> get props => [id, title, artist, durationS, position];

--- a/mobile/lib/features/playlists/presentation/providers/playlist_queue_controller.dart
+++ b/mobile/lib/features/playlists/presentation/providers/playlist_queue_controller.dart
@@ -6,7 +6,7 @@ import 'package:just_audio/just_audio.dart' show PlayerState, ProcessingState;
 import '../../../../core/audio/playback_auth.dart';
 import '../../../../core/audio/queue_playback_service.dart';
 import '../../../../core/constants/api_constants.dart';
-import '../../domain/entities/playlist_track.dart';
+import '../../domain/entities/track.dart';
 
 export '../../../../core/audio/queue_playback_service.dart'
     show PlaybackStatus, QueueRepeatMode;
@@ -50,9 +50,9 @@ class PlaylistQueueController extends ChangeNotifier {
   StreamSubscription<Object>? _errorSub;
   Timer? _retryTimer;
 
-  List<PlaylistTrack> _tracks = const [];
+  List<Track> _tracks = const [];
   String? _playlistId;
-  String? _playlistName;
+  String? _sourceName;
   int _index = 0;
   PlaybackStatus _status = PlaybackStatus.idle;
   bool _disposed = false;
@@ -85,9 +85,16 @@ class PlaylistQueueController extends ChangeNotifier {
   /// abandonné plutôt que d'écraser l'état de la nouvelle.
   int _generation = 0;
 
-  List<PlaylistTrack> get tracks => _tracks;
+  List<Track> get tracks => _tracks;
+
+  /// Playlist d'origine de la file, `null` quand elle vient de la bibliothèque
+  /// (STR-231) : sert aux écrans qui soulignent « la piste en cours **de cette**
+  /// playlist ».
   String? get playlistId => _playlistId;
-  String? get playlistName => _playlistName;
+
+  /// Ce qui est en train d'être écouté, tel qu'annoncé à l'auditeur : nom de la
+  /// playlist, ou « Ma bibliothèque ».
+  String? get sourceName => _sourceName;
   int get currentIndex => _index;
   PlaybackStatus get status => _status;
   bool get shuffleEnabled => _shuffleEnabled;
@@ -110,7 +117,7 @@ class PlaylistQueueController extends ChangeNotifier {
   bool get hasQueue =>
       _tracks.isNotEmpty && _status != PlaybackStatus.idle;
 
-  PlaylistTrack? get currentTrack =>
+  Track? get currentTrack =>
       _index >= 0 && _index < _tracks.length ? _tracks[_index] : null;
 
   bool get isPlaying => _status == PlaybackStatus.playing;
@@ -130,12 +137,18 @@ class PlaylistQueueController extends ChangeNotifier {
 
   /// Lance [tracks] à partir de [startIndex] et démarre la lecture.
   ///
+  /// [sourceName] est ce qu'on annonce à l'auditeur (nom de la playlist, « Ma
+  /// bibliothèque »…). [playlistId] n'est renseigné que si la file vient bien
+  /// d'une playlist : la bibliothèque n'en a pas, et les écrans qui soulignent
+  /// « la piste en cours de cette playlist » doivent pouvoir faire la
+  /// différence (STR-231).
+  ///
   /// [shuffle] force la lecture aléatoire (entrée « Lire en aléatoire ») ;
-  /// omis, le mode courant est conservé d'une playlist à l'autre.
+  /// omis, le mode courant est conservé d'une source à l'autre.
   Future<void> play({
-    required String playlistId,
-    required String playlistName,
-    required List<PlaylistTrack> tracks,
+    required List<Track> tracks,
+    required String sourceName,
+    String? playlistId,
     int startIndex = 0,
     bool? shuffle,
   }) async {
@@ -155,7 +168,7 @@ class PlaylistQueueController extends ChangeNotifier {
 
     _tracks = List.unmodifiable(tracks);
     _playlistId = playlistId;
-    _playlistName = playlistName;
+    _sourceName = sourceName;
     _index = startIndex.clamp(0, tracks.length - 1);
     _retryCount = 0;
     // Ordre provisoire, remplacé par celui du lecteur une fois la file chargée.
@@ -417,7 +430,7 @@ class PlaylistQueueController extends ChangeNotifier {
     _retryTimer?.cancel();
     _tracks = const [];
     _playlistId = null;
-    _playlistName = null;
+    _sourceName = null;
     _index = 0;
     // Les modes de lecture survivent : ce sont des préférences d'écoute, pas
     // l'état d'une file. Seul l'ordre, qui décrit cette file, disparaît avec elle.

--- a/mobile/lib/features/playlists/presentation/screens/playlist_detail_screen.dart
+++ b/mobile/lib/features/playlists/presentation/screens/playlist_detail_screen.dart
@@ -129,9 +129,11 @@ class _PlaylistDetailBodyState extends State<_PlaylistDetailBody> {
     if (controller.tracks.isEmpty) return;
 
     await context.read<PlaylistQueueController>().play(
+          // La file joue des pistes : l'ordre de la playlist est déjà celui de
+          // la liste, la position de chacune n'a plus d'usage une fois partie.
+          tracks: [for (final track in controller.tracks) track.toTrack()],
+          sourceName: widget.title,
           playlistId: controller.playlistId,
-          playlistName: widget.title,
-          tracks: controller.tracks,
           startIndex: startIndex,
           shuffle: shuffle,
         );

--- a/mobile/lib/features/playlists/presentation/screens/playlists_screen.dart
+++ b/mobile/lib/features/playlists/presentation/screens/playlists_screen.dart
@@ -11,6 +11,7 @@ import '../../data/repositories/playlist_repository_impl.dart';
 import '../../domain/entities/playlist.dart';
 import '../../domain/entities/track.dart';
 import '../../domain/repositories/playlist_repository.dart';
+import '../providers/playlist_queue_controller.dart';
 import '../providers/playlists_controller.dart';
 import '../track_labels.dart';
 import '../widgets/playlist_form_sheet.dart';
@@ -297,31 +298,57 @@ class _PlaylistsBodyState extends State<_PlaylistsBody> {
             ),
           )
         else
-          ...controller.tracks.map((track) => _TrackTile(track: track)),
+          for (var i = 0; i < controller.tracks.length; i++)
+            _TrackTile(
+              track: controller.tracks[i],
+              // Toute la bibliothèque part en file, à partir de la piste
+              // touchée : une file d'un seul élément rendrait précédent,
+              // suivant, aléatoire et répétition sans objet (STR-231).
+              onPlay: () => context.read<PlaylistQueueController>().play(
+                    tracks: controller.tracks,
+                    sourceName: 'Ma bibliothèque',
+                    startIndex: i,
+                  ),
+            ),
       ],
     );
   }
 }
 
-/// Ligne d'une piste de la bibliothèque (section « Mes pistes »). Lecture seule
-/// pour l'US-05-01 : ni menu ni lecture (hors périmètre).
+/// Ligne d'une piste de la bibliothèque (section « Mes pistes »). Un appui lance
+/// la lecture de toute la bibliothèque à partir d'elle (STR-231).
 class _TrackTile extends StatelessWidget {
-  const _TrackTile({required this.track});
+  const _TrackTile({required this.track, required this.onPlay});
 
   final Track track;
+  final VoidCallback onPlay;
 
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).colorScheme;
+    // Comparaison par id : la file est une photo, elle peut décrire une piste
+    // que la bibliothèque affichée a entre-temps réordonnée ou retirée.
+    final isCurrent = context.select<PlaylistQueueController, bool>(
+      (queue) => queue.hasQueue && queue.currentTrack?.id == track.id,
+    );
 
     return ListTile(
       key: Key('track_tile_${track.id}'),
+      onTap: onPlay,
       contentPadding: EdgeInsets.zero,
       leading: CircleAvatar(
         backgroundColor: colors.surfaceContainerHighest,
-        child: Icon(Icons.music_note, color: colors.onSurfaceVariant),
+        child: Icon(
+          isCurrent ? Icons.graphic_eq : Icons.music_note,
+          color: isCurrent ? colors.primary : colors.onSurfaceVariant,
+        ),
       ),
-      title: Text(track.title, maxLines: 1, overflow: TextOverflow.ellipsis),
+      title: Text(
+        track.title,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: isCurrent ? TextStyle(color: colors.primary) : null,
+      ),
       subtitle: Text(
         trackSubtitle(artist: track.artist, durationS: track.durationS),
         maxLines: 1,

--- a/mobile/lib/features/playlists/presentation/widgets/playback_queue_sheet.dart
+++ b/mobile/lib/features/playlists/presentation/widgets/playback_queue_sheet.dart
@@ -57,7 +57,7 @@ class PlaybackQueueSheet extends StatelessWidget {
             leading: const Icon(Icons.queue_music),
             title: const Text('File d\'attente'),
             subtitle: Text(
-              queue.playlistName ?? 'Playlist',
+              queue.sourceName ?? 'Lecture en cours',
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
             ),

--- a/mobile/test/app/shell/player_bar_test.dart
+++ b/mobile/test/app/shell/player_bar_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 
 import 'package:streampulse/app/shell/player_bar.dart';
-import 'package:streampulse/features/playlists/domain/entities/playlist_track.dart';
+import 'package:streampulse/features/playlists/domain/entities/track.dart';
 import 'package:streampulse/features/playlists/presentation/providers/playlist_queue_controller.dart';
 import 'package:streampulse/features/playlists/presentation/widgets/queue_mini_player.dart';
 import 'package:streampulse/features/streams/presentation/providers/audio_player_controller.dart';
@@ -15,13 +15,7 @@ import '../../support/fake_queue_playback_service.dart';
 const _now = NowPlaying(streamId: 's1', title: 'Radio Nova', broadcaster: 'DJ');
 
 const _tracks = [
-  PlaylistTrack(
-    id: 't1',
-    title: 'Midnight Drive',
-    artist: 'Neon Lights',
-    durationS: 214,
-    position: 0,
-  ),
+  Track(id: 't1', title: 'Midnight Drive', artist: 'Neon Lights', durationS: 214),
 ];
 
 /// Reproduit le câblage croisé d'`app_providers` : démarrer une file arrête le
@@ -81,9 +75,9 @@ void main() {
 
       await c.live.load(_now);
       await c.queue.play(
-        playlistId: 'p-1',
-        playlistName: 'My Favorites',
         tracks: _tracks,
+        sourceName: 'My Favorites',
+        playlistId: 'p-1',
       );
       await tester.pumpWidget(_host(c.live, c.queue));
 
@@ -101,9 +95,9 @@ void main() {
       final c = _controllers(liveService, queueService);
 
       await c.queue.play(
-        playlistId: 'p-1',
-        playlistName: 'My Favorites',
         tracks: _tracks,
+        sourceName: 'My Favorites',
+        playlistId: 'p-1',
       );
       await c.live.load(_now);
       await tester.pumpWidget(_host(c.live, c.queue));

--- a/mobile/test/features/playlists/presentation/playlist_queue_controller_test.dart
+++ b/mobile/test/features/playlists/presentation/playlist_queue_controller_test.dart
@@ -2,23 +2,22 @@ import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:just_audio/just_audio.dart' show PlayerState, ProcessingState;
 import 'package:streampulse/core/constants/api_constants.dart';
-import 'package:streampulse/features/playlists/domain/entities/playlist_track.dart';
+import 'package:streampulse/features/playlists/domain/entities/track.dart';
 import 'package:streampulse/features/playlists/presentation/providers/playlist_queue_controller.dart';
 
 import '../../../support/fake_queue_playback_service.dart';
 
-PlaylistTrack _track(String id, String title, int position) => PlaylistTrack(
+Track _track(String id, String title) => Track(
       id: id,
       title: title,
       artist: 'Neon Lights',
       durationS: 214,
-      position: position,
     );
 
 final _tracks = [
-  _track('t1', 'Midnight Drive', 0),
-  _track('t2', 'Sunrise', 1),
-  _track('t3', 'Afterglow', 2),
+  _track('t1', 'Midnight Drive'),
+  _track('t2', 'Sunrise'),
+  _track('t3', 'Afterglow'),
 ];
 
 /// Contrôleur sous test + fake associé. [tokens] permet d'observer les demandes
@@ -52,13 +51,13 @@ void elapse(FakeAsync async, {int seconds = 10}) {
 Future<void> _play(
   PlaylistQueueController controller, {
   int startIndex = 0,
-  List<PlaylistTrack>? tracks,
+  List<Track>? tracks,
   bool? shuffle,
 }) {
   return controller.play(
-    playlistId: 'p-1',
-    playlistName: 'My Favorites',
     tracks: tracks ?? _tracks,
+    sourceName: 'My Favorites',
+    playlistId: 'p-1',
     startIndex: startIndex,
     shuffle: shuffle,
   );
@@ -84,7 +83,7 @@ void main() {
       expect(t.service.lastItems.first.url, ApiConstants.trackStream('t1'));
       expect(t.service.lastItems.first.duration, const Duration(seconds: 214));
       expect(t.controller.hasQueue, isTrue);
-      expect(t.controller.playlistName, 'My Favorites');
+      expect(t.controller.sourceName, 'My Favorites');
     });
 
     test('démarre à la piste demandée (appui sur une ligne de la playlist)',
@@ -105,6 +104,25 @@ void main() {
       await _play(t.controller);
 
       expect(liveStopped, isTrue);
+    });
+
+    test('une file peut venir de la bibliothèque, sans playlist (STR-231)',
+        () async {
+      final t = _build();
+
+      await t.controller.play(
+        tracks: _tracks,
+        sourceName: 'Ma bibliothèque',
+        startIndex: 1,
+      );
+
+      expect(t.service.lastItems.map((i) => i.id).toList(), ['t1', 't2', 't3']);
+      expect(t.service.lastInitialIndex, 1);
+      expect(t.controller.sourceName, 'Ma bibliothèque');
+      // Pas de playlist : les écrans qui soulignent « la piste en cours de
+      // cette playlist » ne doivent souligner nulle part.
+      expect(t.controller.playlistId, isNull);
+      expect(t.controller.hasNext, isTrue);
     });
 
     test('une playlist vide ne lance rien', () async {

--- a/mobile/test/features/playlists/presentation/screens/playlist_detail_screen_test.dart
+++ b/mobile/test/features/playlists/presentation/screens/playlist_detail_screen_test.dart
@@ -181,7 +181,7 @@ void main() {
 
       expect(service.lastItems.map((i) => i.id).toList(), ['t1', 't2']);
       expect(service.lastInitialIndex, 0);
-      expect(queue.playlistName, 'My Favorites');
+      expect(queue.sourceName, 'My Favorites');
       // La ligne en cours est repérable : son numéro cède la place à l'icône.
       expect(find.byIcon(Icons.graphic_eq), findsOneWidget);
     });

--- a/mobile/test/features/playlists/presentation/screens/playlists_screen_test.dart
+++ b/mobile/test/features/playlists/presentation/screens/playlists_screen_test.dart
@@ -1,11 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
 import 'package:toastification/toastification.dart';
 
 import 'package:streampulse/features/playlists/domain/entities/playlist.dart';
 import 'package:streampulse/features/playlists/domain/entities/playlist_track.dart';
 import 'package:streampulse/features/playlists/domain/entities/track.dart';
 import 'package:streampulse/features/playlists/domain/repositories/playlist_repository.dart';
+
+import '../../../../support/fake_queue_playback_service.dart';
+import 'package:streampulse/features/playlists/presentation/providers/playlist_queue_controller.dart';
 import 'package:streampulse/features/playlists/presentation/screens/playlists_screen.dart';
 
 Playlist _playlist(String id, String name, {int trackCount = 0}) => Playlist(
@@ -83,14 +87,27 @@ class _FakePlaylistRepository implements PlaylistRepository {
 Widget _harness(
   PlaylistRepository repository, {
   bool isAuthenticated = true,
+  PlaylistQueueController? queue,
 }) {
-  return ToastificationWrapper(
-    child: MaterialApp(
-      home: PlaylistsScreen(
-        repository: repository,
-        isAuthenticated: isAuthenticated,
+  // L'écran lit la file d'attente app-level (STR-231) : lancer une piste de la
+  // bibliothèque et souligner celle en cours passent par elle.
+  return ChangeNotifierProvider<PlaylistQueueController>.value(
+    value: queue ?? _queueController(FakeQueuePlaybackService()),
+    child: ToastificationWrapper(
+      child: MaterialApp(
+        home: PlaylistsScreen(
+          repository: repository,
+          isAuthenticated: isAuthenticated,
+        ),
       ),
     ),
+  );
+}
+
+PlaylistQueueController _queueController(FakeQueuePlaybackService service) {
+  return PlaylistQueueController(
+    service: service,
+    token: ({bool forceRefresh = false}) async => 'jwt',
   );
 }
 
@@ -130,6 +147,53 @@ void main() {
       expect(find.text('Mes pistes'), findsOneWidget);
       expect(find.byKey(const Key('track_tile_t-1')), findsOneWidget);
       expect(find.text('Midnight Drive'), findsOneWidget);
+    });
+
+    testWidgets('un appui sur une piste lance toute la bibliothèque (STR-231)',
+        (tester) async {
+      final repo = _FakePlaylistRepository()
+        ..libraryTracksList = const [
+          Track(id: 't-1', title: 'Midnight Drive', artist: 'Neon', durationS: 214),
+          Track(id: 't-2', title: 'Sunrise', artist: 'Neon', durationS: 187),
+          Track(id: 't-3', title: 'Afterglow', artist: 'Neon', durationS: 201),
+        ];
+      final service = FakeQueuePlaybackService();
+      final queue = _queueController(service);
+      addTearDown(queue.dispose);
+      addTearDown(service.dispose);
+
+      await tester.pumpWidget(_harness(repo, queue: queue));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('track_tile_t-2')));
+      await tester.pumpAndSettle();
+
+      // Toute la bibliothèque part en file : une file d'un élément rendrait
+      // précédent/suivant et les modes de lecture sans objet.
+      expect(service.lastItems.map((i) => i.id).toList(), ['t-1', 't-2', 't-3']);
+      expect(service.lastInitialIndex, 1);
+      expect(queue.sourceName, 'Ma bibliothèque');
+      expect(queue.playlistId, isNull,
+          reason: 'la bibliothèque n\'est pas une playlist');
+    });
+
+    testWidgets('la piste en cours est repérable dans la bibliothèque',
+        (tester) async {
+      final repo = _FakePlaylistRepository()
+        ..libraryTracksList = const [
+          Track(id: 't-1', title: 'Midnight Drive', artist: 'Neon', durationS: 214),
+          Track(id: 't-2', title: 'Sunrise', artist: 'Neon', durationS: 187),
+        ];
+      final service = FakeQueuePlaybackService();
+      final queue = _queueController(service);
+      addTearDown(queue.dispose);
+      addTearDown(service.dispose);
+
+      await tester.pumpWidget(_harness(repo, queue: queue));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('track_tile_t-2')));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.graphic_eq), findsOneWidget);
     });
 
     testWidgets('invité : pas de bouton +, invitation à se connecter',

--- a/mobile/test/features/playlists/presentation/widgets/queue_ui_test.dart
+++ b/mobile/test/features/playlists/presentation/widgets/queue_ui_test.dart
@@ -3,24 +3,23 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:just_audio/just_audio.dart' show PlayerState, ProcessingState;
 import 'package:provider/provider.dart';
 
-import 'package:streampulse/features/playlists/domain/entities/playlist_track.dart';
+import 'package:streampulse/features/playlists/domain/entities/track.dart';
 import 'package:streampulse/features/playlists/presentation/providers/playlist_queue_controller.dart';
 import 'package:streampulse/features/playlists/presentation/widgets/queue_mini_player.dart';
 
 import '../../../../support/fake_queue_playback_service.dart';
 
-PlaylistTrack _track(String id, String title, int position) => PlaylistTrack(
+Track _track(String id, String title) => Track(
       id: id,
       title: title,
       artist: 'Neon Lights',
       durationS: 214,
-      position: position,
     );
 
 final _tracks = [
-  _track('t1', 'Midnight Drive', 0),
-  _track('t2', 'Sunrise', 1),
-  _track('t3', 'Afterglow', 2),
+  _track('t1', 'Midnight Drive'),
+  _track('t2', 'Sunrise'),
+  _track('t3', 'Afterglow'),
 ];
 
 Widget _host(PlaylistQueueController controller, Widget child) {
@@ -53,9 +52,9 @@ Future<
   addTearDown(service.dispose);
 
   await controller.play(
-    playlistId: 'p-1',
-    playlistName: 'My Favorites',
     tracks: _tracks,
+    sourceName: 'My Favorites',
+    playlistId: 'p-1',
     startIndex: startIndex,
   );
   await tester.pumpWidget(_host(controller, child));


### PR DESCRIPTION
Ferme [STR-231](https://linear.app/streampulse/issue/STR-231/lancer-la-lecture-depuis-mes-pistes-bibliotheque).

## Le manque

La section « Mes pistes » de l'écran Bibliothèque listait les pistes uploadées (US-05-01) sans qu'aucune puisse être écoutée : il fallait d'abord les ranger dans une playlist. L'US-05-04 n'avait câblé la lecture que sur les playlists — `play()` exigeait `playlistId`, `playlistName` et des `PlaylistTrack`, alors que la bibliothèque manipule des `Track`.

## Décisions

| Point | Choix |
|---|---|
| Type de domaine de la file | `Track` (sans position). Une playlist a un ordre, la bibliothèque non, et le lecteur n'a que faire de la différence : `PlaylistTrack.toTrack()` fait la conversion au lancement |
| Signature | `play(tracks:, sourceName:, playlistId:)`. `sourceName` est ce qu'on annonce (« My Favorites », « Ma bibliothèque »), `playlistId` **reste nul hors playlist** — c'est lui qui permet à l'écran de détail de ne souligner que « la piste en cours **de cette** playlist » |
| Comportement de l'appui | Lance **toute la bibliothèque à partir de la piste touchée**, pas une file d'un seul élément : celle-ci rendrait précédent, suivant, aléatoire et répétition sans objet, et l'utilisateur croirait la fonctionnalité cassée |
| Repère visuel | La ligne en cours porte l'icône d'équaliseur, comme dans une playlist. Comparaison **par id** : la file est une photo, elle peut décrire une piste que la bibliothèque affichée a entre-temps réordonnée |

## Vérification

`flutter analyze` : 0 issue. `flutter test` : 409 tests verts (+3 : file lancée depuis la bibliothèque côté contrôleur, appui qui charge toute la bibliothèque au bon index, piste en cours repérable).

## ADR

**Aucun**, conformément à l'arbitrage du ticket. La file reste une **photo** de pistes qui ne suit pas les mutations de sa source : la prémisse de l'ADR 034 §6 porte sur les mutations, pas sur la provenance, et élargir le type d'entrée n'invalide aucun arbitrage écrit. `CLAUDE.md` documente la nouvelle signature et la règle « toute la bibliothèque, pas une piste seule ».

Un ADR ne redeviendra nécessaire que si l'on introduit une véritable abstraction de source (favoris, recherche, hors-ligne STR-201) ou si la file change de nature (suivi des mutations, persistance).

## Note de revue

Touche `queue_mini_player.dart` et `playback_queue_sheet.dart`, comme #292 (STR-230) — lignes différentes, mais si #292 passe en premier, un rebase trivial peut être nécessaire.
