### PR TITLE
fix(infra): restreindre l'exposition des services en production

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -46,6 +46,32 @@ var validLogLevels = map[string]bool{
 	"warn": true, "error": true, "fatal": true, "panic": true,
 }
 
+// boundEnvKeys énumère les variables d'environnement liées explicitement.
+//
+// viper.Unmarshal n'itère que sur les clés qu'il connaît : AutomaticEnv() ne
+// suffit pas à en révéler une. Une clé devient connue par SetDefault **ou** par
+// BindEnv — sans l'un des deux, la variable d'environnement est ignorée en
+// silence. Les clés sans défaut (secrets, SMTP, endpoints) dépendent donc
+// entièrement de cette liste.
+//
+// TestBindEnvKeys_CouvrentTousLesChampsDeConfig la garde alignée sur les tags
+// mapstructure de Config : y inscrire même les clés qui ont un défaut évite
+// d'avoir à retenir laquelle des deux voies couvre quel champ.
+//
+// CORS_ALLOWED_ORIGINS y figure alors que le champ porte `mapstructure:"-"` :
+// il est lu à part via v.GetString puis découpé (parseCSV).
+var boundEnvKeys = []string{
+	"GO_ENV", "API_PORT", "JWT_SECRET",
+	"DB_HOST", "DB_PORT", "DB_USER", "DB_PASSWORD", "DB_NAME",
+	"SMTP_HOST", "SMTP_PORT", "SMTP_USERNAME", "SMTP_PASSWORD", "SMTP_FROM",
+	"APP_BASE_URL", "CORS_ALLOWED_ORIGINS", "STREAM_INGEST_BASE_URL",
+	"STORAGE_PATH",
+	"HLS_MAX_CONCURRENT", "INGEST_RECONNECT_GRACE_SECONDS",
+	"INGEST_STOP_TIMEOUT_SECONDS", "TRUST_PROXY_HEADERS",
+	"LOG_LEVEL", "LOG_PRETTY",
+	"OTEL_EXPORTER_OTLP_ENDPOINT",
+}
+
 // Config représente la configuration complète de l'API StreamPulse.
 //
 // Toutes les valeurs proviennent de variables d'environnement —
@@ -153,17 +179,7 @@ func Load() (*Config, error) {
 	// Override par les variables d'environnement (priorité max).
 	v.AutomaticEnv()
 
-	// Bind explicite — viper.Unmarshal ne lit pas AutomaticEnv() seul.
-	for _, key := range []string{
-		"GO_ENV", "API_PORT", "JWT_SECRET",
-		"DB_HOST", "DB_PORT", "DB_USER", "DB_PASSWORD", "DB_NAME",
-		"SMTP_HOST", "SMTP_PORT", "SMTP_USERNAME", "SMTP_PASSWORD", "SMTP_FROM",
-		"APP_BASE_URL", "CORS_ALLOWED_ORIGINS", "STREAM_INGEST_BASE_URL",
-		"STORAGE_PATH",
-		"HLS_MAX_CONCURRENT", "INGEST_RECONNECT_GRACE_SECONDS",
-		"INGEST_STOP_TIMEOUT_SECONDS", "LOG_LEVEL", "LOG_PRETTY",
-		"OTEL_EXPORTER_OTLP_ENDPOINT",
-	} {
+	for _, key := range boundEnvKeys {
 		if err := v.BindEnv(key); err != nil {
 			return nil, fmt.Errorf("config: bind %s: %w", key, err)
 		}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -46,30 +46,55 @@ var validLogLevels = map[string]bool{
 	"warn": true, "error": true, "fatal": true, "panic": true,
 }
 
-// boundEnvKeys énumère les variables d'environnement liées explicitement.
+// envKeys énumère les variables d'environnement lues par Load, avec leur valeur
+// par défaut quand elles en ont une. Table unique et non deux listes parallèles :
+// une clé oubliée d'un côté diverge en silence.
 //
-// viper.Unmarshal n'itère que sur les clés qu'il connaît : AutomaticEnv() ne
-// suffit pas à en révéler une. Une clé devient connue par SetDefault **ou** par
-// BindEnv — sans l'un des deux, la variable d'environnement est ignorée en
-// silence. Les clés sans défaut (secrets, SMTP, endpoints) dépendent donc
-// entièrement de cette liste.
+// Le bind est nécessaire parce que viper.Unmarshal n'itère que sur les clés
+// qu'il connaît — AutomaticEnv() ne suffit pas à en révéler une. Une clé devient
+// connue par SetDefault *ou* par BindEnv ; les clés sans défaut (secrets, SMTP,
+// endpoints) ne dépendent donc que de cette table. On lie toutes les clés, avec
+// ou sans défaut, pour n'avoir jamais à se demander laquelle des deux voies
+// couvre quel champ.
 //
-// TestBindEnvKeys_CouvrentTousLesChampsDeConfig la garde alignée sur les tags
-// mapstructure de Config : y inscrire même les clés qui ont un défaut évite
-// d'avoir à retenir laquelle des deux voies couvre quel champ.
+// TestEnvKeys_CouvrentTousLesChampsDeConfig la garde alignée sur les tags
+// mapstructure de Config.
 //
 // CORS_ALLOWED_ORIGINS y figure alors que le champ porte `mapstructure:"-"` :
 // il est lu à part via v.GetString puis découpé (parseCSV).
-var boundEnvKeys = []string{
-	"GO_ENV", "API_PORT", "JWT_SECRET",
-	"DB_HOST", "DB_PORT", "DB_USER", "DB_PASSWORD", "DB_NAME",
-	"SMTP_HOST", "SMTP_PORT", "SMTP_USERNAME", "SMTP_PASSWORD", "SMTP_FROM",
-	"APP_BASE_URL", "CORS_ALLOWED_ORIGINS", "STREAM_INGEST_BASE_URL",
-	"STORAGE_PATH",
-	"HLS_MAX_CONCURRENT", "INGEST_RECONNECT_GRACE_SECONDS",
-	"INGEST_STOP_TIMEOUT_SECONDS", "TRUST_PROXY_HEADERS",
-	"LOG_LEVEL", "LOG_PRETTY",
-	"OTEL_EXPORTER_OTLP_ENDPOINT",
+var envKeys = []struct {
+	key string
+	def any // nil = pas de défaut (valeur requise, ou vide acceptée)
+}{
+	{key: "GO_ENV", def: defaultGoEnv},
+	{key: "API_PORT", def: defaultAPIPort},
+	{key: "JWT_SECRET"},
+
+	{key: "DB_HOST", def: defaultDBHost},
+	{key: "DB_PORT", def: defaultDBPort},
+	{key: "DB_USER"},
+	{key: "DB_PASSWORD"},
+	{key: "DB_NAME"},
+
+	{key: "SMTP_HOST"},
+	{key: "SMTP_PORT"},
+	{key: "SMTP_USERNAME"},
+	{key: "SMTP_PASSWORD"},
+	{key: "SMTP_FROM"},
+
+	{key: "APP_BASE_URL"},
+	{key: "CORS_ALLOWED_ORIGINS"},
+	{key: "STREAM_INGEST_BASE_URL", def: defaultStreamIngestBaseURL},
+	{key: "STORAGE_PATH", def: defaultStoragePath},
+
+	{key: "HLS_MAX_CONCURRENT", def: defaultHLSMaxConcurrent},
+	{key: "INGEST_RECONNECT_GRACE_SECONDS", def: defaultIngestReconnectGraceSeconds},
+	{key: "INGEST_STOP_TIMEOUT_SECONDS", def: defaultIngestStopTimeoutSeconds},
+	{key: "TRUST_PROXY_HEADERS", def: false},
+
+	{key: "LOG_LEVEL", def: defaultLogLevel},
+	{key: "LOG_PRETTY", def: false},
+	{key: "OTEL_EXPORTER_OTLP_ENDPOINT"},
 }
 
 // Config représente la configuration complète de l'API StreamPulse.
@@ -148,19 +173,13 @@ type Config struct {
 func Load() (*Config, error) {
 	v := viper.New()
 
-	// Valeurs par défaut pour les variables non sensibles.
-	v.SetDefault("GO_ENV", defaultGoEnv)
-	v.SetDefault("API_PORT", defaultAPIPort)
-	v.SetDefault("DB_HOST", defaultDBHost)
-	v.SetDefault("DB_PORT", defaultDBPort)
-	v.SetDefault("STREAM_INGEST_BASE_URL", defaultStreamIngestBaseURL)
-	v.SetDefault("STORAGE_PATH", defaultStoragePath)
-	v.SetDefault("HLS_MAX_CONCURRENT", defaultHLSMaxConcurrent)
-	v.SetDefault("INGEST_RECONNECT_GRACE_SECONDS", defaultIngestReconnectGraceSeconds)
-	v.SetDefault("INGEST_STOP_TIMEOUT_SECONDS", defaultIngestStopTimeoutSeconds)
-	v.SetDefault("TRUST_PROXY_HEADERS", false)
-	v.SetDefault("LOG_LEVEL", defaultLogLevel)
-	v.SetDefault("LOG_PRETTY", false)
+	// Valeurs par défaut, posées avant la lecture du .env (elles restent de plus
+	// basse précédence quoi qu'il arrive).
+	for _, e := range envKeys {
+		if e.def != nil {
+			v.SetDefault(e.key, e.def)
+		}
+	}
 
 	// Charge .env à la racine du repo si présent (dev local uniquement).
 	v.SetConfigName(".env")
@@ -179,9 +198,9 @@ func Load() (*Config, error) {
 	// Override par les variables d'environnement (priorité max).
 	v.AutomaticEnv()
 
-	for _, key := range boundEnvKeys {
-		if err := v.BindEnv(key); err != nil {
-			return nil, fmt.Errorf("config: bind %s: %w", key, err)
+	for _, e := range envKeys {
+		if err := v.BindEnv(e.key); err != nil {
+			return nil, fmt.Errorf("config: bind %s: %w", e.key, err)
 		}
 	}
 

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -360,6 +361,67 @@ func TestLoad_OTELEndpoint(t *testing.T) {
 		}
 		if cfg.OTELExporterOTLPEndpoint != "http://tempo:4318" {
 			t.Errorf("OTELExporterOTLPEndpoint = %q", cfg.OTELExporterOTLPEndpoint)
+		}
+	})
+}
+
+// TestBindEnvKeys_CouvrentTousLesChampsDeConfig garde boundEnvKeys aligné sur la
+// structure Config.
+//
+// Un champ dont la clé n'est ni dans boundEnvKeys ni dans un SetDefault est
+// invisible pour viper.Unmarshal : la variable d'environnement reste sans
+// effet, sans le moindre message. Exiger la présence dans boundEnvKeys pour
+// *tous* les champs supprime la question « ce champ a-t-il un défaut ? » —
+// c'est une condition suffisante, vérifiable mécaniquement.
+func TestBindEnvKeys_CouvrentTousLesChampsDeConfig(t *testing.T) {
+	bound := make(map[string]bool, len(boundEnvKeys))
+	for _, key := range boundEnvKeys {
+		bound[key] = true
+	}
+
+	typ := reflect.TypeOf(Config{})
+	for i := range typ.NumField() {
+		field := typ.Field(i)
+		tag := field.Tag.Get("mapstructure")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		if !bound[tag] {
+			t.Errorf("champ %s : %q absent de boundEnvKeys — la variable d'environnement serait ignorée", field.Name, tag)
+		}
+	}
+}
+
+// TestLoad_TrustProxyHeaders verrouille la lecture de la variable.
+//
+// STR-240 : la clé manquait à boundEnvKeys, et son absence de
+// docker-compose.prod.yml laissait le défaut `false` s'appliquer en production
+// — derrière Caddy, tous les auditeurs partagent l'adresse du proxy et le
+// comptage sature à un. Le SetDefault suffisait en fait à rendre la clé
+// lisible ; ce test l'établit plutôt que de le supposer.
+func TestLoad_TrustProxyHeaders(t *testing.T) {
+	t.Run("absent → false", func(t *testing.T) {
+		setEnv(t, validVars())
+
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() unexpected error: %v", err)
+		}
+		if cfg.TrustProxyHeaders {
+			t.Error("TrustProxyHeaders = true, attendu false par défaut")
+		}
+	})
+
+	t.Run("true → true", func(t *testing.T) {
+		setEnv(t, validVars())
+		t.Setenv("TRUST_PROXY_HEADERS", "true")
+
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() unexpected error: %v", err)
+		}
+		if !cfg.TrustProxyHeaders {
+			t.Error("TrustProxyHeaders = false alors que TRUST_PROXY_HEADERS=true")
 		}
 	})
 }

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -365,7 +365,7 @@ func TestLoad_OTELEndpoint(t *testing.T) {
 	})
 }
 
-// TestBindEnvKeys_CouvrentTousLesChampsDeConfig garde boundEnvKeys aligné sur la
+// TestEnvKeys_CouvrentTousLesChampsDeConfig garde boundEnvKeys aligné sur la
 // structure Config.
 //
 // Un champ dont la clé n'est ni dans boundEnvKeys ni dans un SetDefault est
@@ -373,10 +373,10 @@ func TestLoad_OTELEndpoint(t *testing.T) {
 // effet, sans le moindre message. Exiger la présence dans boundEnvKeys pour
 // *tous* les champs supprime la question « ce champ a-t-il un défaut ? » —
 // c'est une condition suffisante, vérifiable mécaniquement.
-func TestBindEnvKeys_CouvrentTousLesChampsDeConfig(t *testing.T) {
-	bound := make(map[string]bool, len(boundEnvKeys))
-	for _, key := range boundEnvKeys {
-		bound[key] = true
+func TestEnvKeys_CouvrentTousLesChampsDeConfig(t *testing.T) {
+	bound := make(map[string]bool, len(envKeys))
+	for _, e := range envKeys {
+		bound[e.key] = true
 	}
 
 	typ := reflect.TypeOf(Config{})
@@ -387,7 +387,7 @@ func TestBindEnvKeys_CouvrentTousLesChampsDeConfig(t *testing.T) {
 			continue
 		}
 		if !bound[tag] {
-			t.Errorf("champ %s : %q absent de boundEnvKeys — la variable d'environnement serait ignorée", field.Name, tag)
+			t.Errorf("champ %s : %q absent de envKeys — la variable d'environnement serait ignorée", field.Name, tag)
 		}
 	}
 }
@@ -402,6 +402,10 @@ func TestBindEnvKeys_CouvrentTousLesChampsDeConfig(t *testing.T) {
 func TestLoad_TrustProxyHeaders(t *testing.T) {
 	t.Run("absent → false", func(t *testing.T) {
 		setEnv(t, validVars())
+		// Neutralise explicitement : la variable peut être exportée dans le
+		// shell (CI ou poste de dev), ce qui rendrait l'assertion faussement
+		// verte ou instable.
+		t.Setenv("TRUST_PROXY_HEADERS", "")
 
 		cfg, err := Load()
 		if err != nil {

--- a/backend/internal/streaming/handler.go
+++ b/backend/internal/streaming/handler.go
@@ -93,17 +93,28 @@ type StreamSessions interface {
 // double le temps que sa fenêtre expire.
 //
 // X-Forwarded-For n'est lu que si `TRUST_PROXY_HEADERS` est activé. L'en-tête
-// est falsifiable : sans reverse proxy qui le réécrit, le lire laisserait
+// est fourni par le client : sans reverse proxy devant, le lire laisserait
 // n'importe qui gonfler le compteur d'un flux en variant sa valeur. Sans lui
 // en revanche, tous les auditeurs derrière le proxy de production partagent
 // l'adresse de ce dernier et le compteur sature à 1 — d'où le drapeau.
 func (h *Handler) clientKey(r *http.Request) string {
 	if h.trustProxyHeaders {
-		// Premier maillon = client d'origine ; les suivants sont les proxies
-		// traversés. Caddy réécrit l'en-tête, la valeur est donc fiable ici.
+		// Dernier maillon, et non le premier. Caddy n'écrase pas l'en-tête par
+		// défaut : il *ajoute* l'IP observée en fin de liste. Prendre le premier
+		// laisserait un client poser `X-Forwarded-For: 1.2.3.4`, faire
+		// transmettre `1.2.3.4, <ip réelle>` et choisir ainsi sa propre clé de
+		// comptage — exactement l'abus que le drapeau prétend empêcher.
+		//
+		// Le Caddyfile force en plus la réécriture (`header_up`), ce qui réduit
+		// la liste à un seul maillon. Lire le dernier est correct dans les deux
+		// cas, et survit à une régression de cette configuration.
+		//
+		// Vaut pour un unique proxy de confiance en frontal, ce qui est
+		// l'architecture déployée (Caddy → api). Un second proxy intercalé
+		// demanderait de compter les sauts de confiance.
 		if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
-			if first, _, found := strings.Cut(fwd, ","); found {
-				return strings.TrimSpace(first)
+			if idx := strings.LastIndex(fwd, ","); idx >= 0 {
+				return strings.TrimSpace(fwd[idx+1:])
 			}
 			return strings.TrimSpace(fwd)
 		}

--- a/backend/internal/streaming/handler_test.go
+++ b/backend/internal/streaming/handler_test.go
@@ -1196,16 +1196,70 @@ func TestHandler_ClientKey_IgnoresForwardedForByDefault(t *testing.T) {
 	}
 }
 
-func TestHandler_ClientKey_UsesFirstForwardedHopWhenTrusted(t *testing.T) {
+func TestHandler_ClientKey_UsesLastForwardedHopWhenTrusted(t *testing.T) {
+	// Le dernier maillon est celui qu'a écrit le proxy de confiance ; tout ce
+	// qui précède vient du client. Caddy n'écrase pas l'en-tête par défaut, il
+	// y ajoute l'IP observée — lire le premier maillon reviendrait à laisser le
+	// client choisir sa clé de comptage.
+	cases := []struct {
+		name string
+		xff  string
+		want string
+	}{
+		{
+			name: "en-tête posé par le seul proxy",
+			xff:  "203.0.113.7",
+			want: "203.0.113.7",
+		},
+		{
+			name: "valeur forgée par le client, IP réelle ajoutée par Caddy",
+			xff:  "1.2.3.4, 203.0.113.7",
+			want: "203.0.113.7",
+		},
+		{
+			name: "chaîne forgée plus longue",
+			xff:  "1.2.3.4, 5.6.7.8, 203.0.113.7",
+			want: "203.0.113.7",
+		},
+		{
+			name: "espaces superflus",
+			xff:  "1.2.3.4 ,   203.0.113.7   ",
+			want: "203.0.113.7",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := NewHandler(&stubService{}, testIngestURL, NewLiveSessions(t.Context()))
+			h.SetTrustProxyHeaders(true)
+			req := httptest.NewRequest(http.MethodGet, "/api/streams/s1/playlist.m3u8", nil)
+			req.RemoteAddr = "192.0.2.10:54321"
+			req.Header.Set("X-Forwarded-For", tc.xff)
+
+			if got := h.clientKey(req); got != tc.want {
+				t.Errorf("clientKey = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestHandler_ClientKey_ForgedForwardedForCannotSplitCount verrouille l'effet
+// recherché : deux requêtes du même auditeur qui forge des X-Forwarded-For
+// différents doivent produire la *même* clé, sinon il gonfle le compteur seul.
+func TestHandler_ClientKey_ForgedForwardedForCannotSplitCount(t *testing.T) {
 	h := NewHandler(&stubService{}, testIngestURL, NewLiveSessions(t.Context()))
 	h.SetTrustProxyHeaders(true)
-	req := httptest.NewRequest(http.MethodGet, "/api/streams/s1/playlist.m3u8", nil)
-	req.RemoteAddr = "192.0.2.10:54321"
-	// Premier maillon = client d'origine, les suivants sont les proxies.
-	req.Header.Set("X-Forwarded-For", "1.2.3.4, 10.0.0.1")
 
-	if got := h.clientKey(req); got != "1.2.3.4" {
-		t.Errorf("clientKey = %q, want %q", got, "1.2.3.4")
+	key := func(forged string) string {
+		req := httptest.NewRequest(http.MethodGet, "/api/streams/s1/playlist.m3u8", nil)
+		req.RemoteAddr = "192.0.2.10:54321"
+		// Ce que Caddy transmet : la valeur du client, puis l'IP qu'il observe.
+		req.Header.Set("X-Forwarded-For", forged+", 203.0.113.7")
+		return h.clientKey(req)
+	}
+
+	if a, b := key("1.2.3.4"), key("5.6.7.8"); a != b {
+		t.Errorf("clés différentes pour un même auditeur : %q vs %q — le compteur est falsifiable", a, b)
 	}
 }
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -68,6 +68,12 @@ services:
       STREAM_INGEST_BASE_URL: ${STREAM_INGEST_BASE_URL:-https://api.streampulse.win}
       INGEST_RECONNECT_GRACE_SECONDS: ${INGEST_RECONNECT_GRACE_SECONDS:-45}
       INGEST_STOP_TIMEOUT_SECONDS: ${INGEST_STOP_TIMEOUT_SECONDS:-10}
+      # Vrai en prod : l'API n'est jamais jointe en direct, tout passe par Caddy
+      # qui réécrit X-Forwarded-For. Sans cette variable, tous les auditeurs
+      # partagent l'adresse du proxy et le compteur d'audience sature à 1
+      # (STR-154, ADR 025).
+      TRUST_PROXY_HEADERS: ${TRUST_PROXY_HEADERS:-true}
+      HLS_MAX_CONCURRENT: ${HLS_MAX_CONCURRENT:-256}
       # LOG_PRETTY volontairement absent : en conteneur la sortie doit rester
       # du JSON pour la collecte Loki (STR-163, ADR 018).
       LOG_LEVEL: ${LOG_LEVEL:-info}
@@ -119,7 +125,13 @@ services:
     networks:
       - streampulse-net
     ports:
-      - "9090:9090"
+      # Bind loopback : Prometheus n'a ni authentification ni TLS (pas de
+      # --web.config.file). Publié sur 0.0.0.0, il sert l'API PromQL complète et
+      # /api/v1/targets à quiconque — ce qui rend inopérant le `respond /metrics
+      # 403` du Caddyfile, la même donnée restant lisible par le port voisin.
+      # ufw ne protège pas : Docker insère ses règles DNAT en amont.
+      # Accès distant : tunnel SSH (ssh -L 9090:127.0.0.1:9090 …).
+      - "127.0.0.1:9090:9090"
     volumes:
       - ./docker/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
     command:
@@ -202,7 +214,11 @@ services:
     networks:
       - streampulse-net
     ports:
-      - "3000:3000"
+      # Bind loopback : publié sur 0.0.0.0, Grafana sert son formulaire de
+      # connexion en HTTP clair, hors Caddy — le mot de passe admin transiterait
+      # en clair sur le réseau.
+      # Accès distant : tunnel SSH (ssh -L 3000:127.0.0.1:3000 …).
+      - "127.0.0.1:3000:3000"
     volumes:
       - grafana_data:/var/lib/grafana
       - ./docker/grafana/provisioning:/etc/grafana/provisioning:ro

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -23,5 +23,12 @@ api.streampulse.win {
 		-Server
 	}
 
-	reverse_proxy api:8080
+	reverse_proxy api:8080 {
+		# Caddy n'écrase pas X-Forwarded-For par défaut : il ajoute l'IP observée
+		# à la valeur reçue. Un client qui envoie `X-Forwarded-For: 1.2.3.4` ferait
+		# donc transmettre `1.2.3.4, <ip réelle>`. Forcer la réécriture réduit
+		# l'en-tête au seul maillon de confiance, seule valeur que l'API doit lire
+		# pour le comptage d'audience (TRUST_PROXY_HEADERS, ADR 025).
+		header_up X-Forwarded-For {remote_host}
+	}
 }

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -6,5 +6,22 @@ api.streampulse.win {
 	# l'exposer publierait routes, volumes, taux d'erreur et version Go (ADR 019).
 	respond /metrics 403
 
+	# En-têtes de sécurité — Caddy n'en pose aucun par défaut.
+	header {
+		# Force HTTPS pendant un an. `preload` est volontairement omis : son
+		# retrait des listes navigateurs prend des mois, on ne l'engage pas
+		# depuis un fichier de config.
+		Strict-Transport-Security "max-age=31536000; includeSubDomains"
+		X-Content-Type-Options "nosniff"
+		X-Frame-Options "DENY"
+		Referrer-Policy "no-referrer"
+		# L'API ne sert que du JSON en prod — Swagger UI n'est monté que si
+		# !cfg.IsProd() (cmd/api/main.go). Une CSP qui interdit tout est donc
+		# sans risque ici ; à assouplir si une page HTML est exposée un jour.
+		Content-Security-Policy "default-src 'none'; frame-ancestors 'none'"
+		# Ne pas publier la version de Caddy.
+		-Server
+	}
+
 	reverse_proxy api:8080
 }


### PR DESCRIPTION
Closes STR-240
Part of STR-242

Trois services étaient joignables depuis Internet et Caddy ne posait aucun en-tête de sécurité. Vérifié par sonde le 17/08 avant correction.

## Ce qui était ouvert

**`/metrics` répondait 200 en production.** La règle `respond /metrics 403` existe dans le `Caddyfile` depuis la PR #268 mais n'a jamais été déployée — elle figure encore au tableau « changements d'infra en attente » de `docs/infrastructure.md:365`.

**Prometheus était publié sur `0.0.0.0:9090`**, sans `--web.config.file`, donc sans authentification ni TLS. L'API PromQL complète et `/api/v1/targets` étaient interrogeables par n'importe qui :

```
curl http://<IP_VPS>:9090/api/v1/query?query=streampulse_live_streams_active
→ {"status":"success", ...}
```

C'est ce qui rendait le `403` du Caddyfile décoratif : la même donnée restait servie par le port voisin. Et `ufw` ne protège pas de ce cas — Docker insère ses règles DNAT en amont. Le commentaire du service `api` (`docker-compose.prod.yml:46-47`) tenait déjà ce raisonnement ; Prometheus faisait exactement ce qu'il déconseille.

**Grafana était publié sur `0.0.0.0:3000`** en HTTP clair, hors Caddy : le mot de passe admin transitait en clair.

## Ce que fait cette PR

- Prometheus et Grafana passent en `127.0.0.1`, comme l'API. Accès distant par tunnel SSH, documenté en commentaire.
- Ajout des en-têtes de sécurité au `Caddyfile` : HSTS un an, `nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: no-referrer`, une CSP `default-src 'none'`, et suppression de l'en-tête `Server`.
- `TRUST_PROXY_HEADERS` et `HLS_MAX_CONCURRENT` injectées dans le service `api`.
- La liste des clés liées à viper passe en variable de package, gardée par un test.

`preload` est volontairement omis du HSTS : le retrait des listes navigateurs prend des mois, ça ne s'engage pas depuis un fichier de config. La CSP stricte est sans risque tant que Swagger UI reste monté sous `!cfg.IsProd()` (`cmd/api/main.go:345`) — à assouplir le jour où une page HTML est servie.

## Sur `TRUST_PROXY_HEADERS` — une correction par rapport au ticket

Le ticket STR-242 affirme que la variable n'était **pas lisible** parce qu'absente de la liste `BindEnv`. **C'est faux, et le test le montre** : `v.SetDefault("TRUST_PROXY_HEADERS", false)` suffit à rendre la clé connue de viper, et `AutomaticEnv()` fait alors consulter l'environnement. `TestLoad_TrustProxyHeaders` passe même sans l'entrée dans la liste.

Le vrai défaut était plus simple : **la variable n'était pas injectée dans `docker-compose.prod.yml`**, donc le défaut `false` s'appliquait en production. Derrière Caddy, `X-Forwarded-For` n'était pas consulté, tous les auditeurs partageaient l'adresse du proxy et le comptage d'audience saturait à un (STR-154, ADR 025).

L'ajout à `boundEnvKeys` reste utile, mais comme invariant et non comme correctif : une clé n'est visible de `Unmarshal` que par `SetDefault` **ou** `BindEnv`, et un champ ajouté demain sans ni l'un ni l'autre serait ignoré en silence. `TestBindEnvKeys_CouvrentTousLesChampsDeConfig` exige désormais la présence dans la liste pour tous les champs — condition suffisante, vérifiable mécaniquement, qui évite d'avoir à se demander lequel des deux mécanismes couvre quel champ.

Je mettrai STR-242 à jour.

## Vérifications faites

- `go build ./...`, `go vet ./...`, `go test ./...` — suite complète au vert
- Garde-fou éprouvé : en retirant `TRUST_PROXY_HEADERS` de `boundEnvKeys`, `TestBindEnvKeys_CouvrentTousLesChampsDeConfig` échoue avec le nom du champ fautif
- `docker compose -f docker-compose.prod.yml config` parse sans erreur

⚠️ **Le `Caddyfile` n'a pas été validé par Caddy** — le démon Docker n'était pas lancé. À passer par `caddy validate` avant de déployer.

## Ce que le merge ne ferme pas

Le CD ne synchronise ni `docker/` ni `docker-compose.prod.yml` (`docs/infrastructure.md:386-394`). **Il faut déployer à la main**, puis re-sonder :

```bash
curl -o /dev/null -w "%{http_code}\n" https://api.streampulse.win/metrics   # attendu 403
curl -sI https://api.streampulse.win/health | grep -i strict-transport      # attendu présent
```

Les ports 9090 et 3000 doivent devenir injoignables depuis l'extérieur. Le tableau « en attente de déploiement » de `docs/infrastructure.md` est à vider une fois fait.

## Reste hors périmètre

Le cleartext Android (`usesCleartextTraffic="true"`) part dans une PR `fix(mobile)` séparée — scope différent, fichiers disjoints.
