### PR TITLE
fix(mobile): restreindre le trafic en clair au développement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,20 @@ jobs:
         working-directory: ./backend
         run: go build ./cmd/api
 
+  android-network-policy:
+    name: Android network policy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Vérifie que le trafic en clair reste refusé en release (STR-240). Sans
+      # ce job, la propriété ne tient qu'à la vigilance du relecteur : un commit
+      # qui rebascule la valeur, ré-ajoute usesCleartextTraffic ou supprime la
+      # configuration rouvrirait le trou sans bruit. Rejouable en local via
+      # `make check-android-security`.
+      - name: Vérifier la politique de trafic en clair
+        run: make check-android-security
+
   flutter-analyze:
     name: Flutter Analyze
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,7 @@ generate-openapi-client:
 .PHONY: loadtest
 loadtest:
 	cd backend && go test -tags loadtest -race -count=1 -run TestLoad -v -timeout 5m ./internal/streaming/loadtest/
+
+.PHONY: check-android-security
+check-android-security:
+	python3 scripts/check-android-network-security.py

--- a/mobile/android/app/src/debug/res/xml/network_security_config.xml
+++ b/mobile/android/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Politique réseau des builds debug (STR-240).
+
+  Le trafic en clair est autorisé sans restriction : en développement l'API et
+  le flux HLS tournent sur http://<ip>:8080 sans TLS, et l'adresse varie selon
+  le montage — localhost via `adb reverse`, 10.0.2.2 sur l'émulateur, IP LAN du
+  Mac sur un device en Wi-Fi (cf. mobile/README.md). Ces plages ne s'énumèrent
+  pas dans un `<domain>`.
+
+  Cette permissivité ne concerne que cette variante de build : le release
+  applique src/main/res/xml/network_security_config.xml, qui refuse le clair
+  hors boucle locale.
+-->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true" />
+</network-security-config>

--- a/mobile/android/app/src/debug/res/xml/network_security_config.xml
+++ b/mobile/android/app/src/debug/res/xml/network_security_config.xml
@@ -11,6 +11,11 @@
   Cette permissivité ne concerne que cette variante de build : le release
   applique src/main/res/xml/network_security_config.xml, qui refuse le clair
   hors boucle locale.
+
+  ⚠️ Garder aligné sur src/profile/res/xml/network_security_config.xml. Les deux
+  variantes de développement portent la même politique ; le modèle de source
+  sets Android n'offrant pas d'inclusion, la duplication est subie. Une
+  divergence fait échouer `make check-android-security`.
 -->
 <network-security-config>
     <base-config cleartextTrafficPermitted="true" />

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
         android:label="streampulse"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
-        android:usesCleartextTraffic="true">
+        android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/mobile/android/app/src/main/res/xml/network_security_config.xml
+++ b/mobile/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Politique réseau des builds release (STR-240).
+
+  Remplace `android:usesCleartextTraffic="true"`, qui autorisait l'app de
+  production à émettre du HTTP en clair vers n'importe quel hôte, en-têtes
+  Authorization porteurs du JWT compris.
+
+  Équivalent Android de `NSAllowsLocalNetworking` côté iOS (Info.plist) : le
+  trafic en clair reste possible vers la boucle locale, jamais vers Internet.
+  En production l'API est servie en HTTPS (api.streampulse.win).
+
+  Les builds debug et profile ont leur propre variante, plus permissive :
+  src/debug/res/xml/ et src/profile/res/xml/.
+-->
+<network-security-config>
+    <!-- Tout le reste passe obligatoirement par TLS. -->
+    <base-config cleartextTrafficPermitted="false" />
+
+    <!-- Boucle locale uniquement : couvre `adb reverse tcp:8080 tcp:8080`, qui
+         reste utilisable en lançant un build release sur un device branché.
+         Ce trafic ne quitte jamais l'appareil, aucune surface d'interception.
+         10.0.2.2 (hôte de l'émulateur) n'y figure pas : c'est une adresse de
+         développement, elle vit dans les variantes debug et profile. -->
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">localhost</domain>
+        <domain includeSubdomains="false">127.0.0.1</domain>
+    </domain-config>
+</network-security-config>

--- a/mobile/android/app/src/profile/res/xml/network_security_config.xml
+++ b/mobile/android/app/src/profile/res/xml/network_security_config.xml
@@ -11,6 +11,11 @@
   Cette permissivité ne concerne que cette variante de build : le release
   applique src/main/res/xml/network_security_config.xml, qui refuse le clair
   hors boucle locale.
+
+  ⚠️ Garder aligné sur src/debug/res/xml/network_security_config.xml. Les deux
+  variantes de développement portent la même politique ; le modèle de source
+  sets Android n'offrant pas d'inclusion, la duplication est subie. Une
+  divergence fait échouer `make check-android-security`.
 -->
 <network-security-config>
     <base-config cleartextTrafficPermitted="true" />

--- a/mobile/android/app/src/profile/res/xml/network_security_config.xml
+++ b/mobile/android/app/src/profile/res/xml/network_security_config.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Politique réseau des builds profile (STR-240).
+
+  Le trafic en clair est autorisé sans restriction : en développement l'API et
+  le flux HLS tournent sur http://<ip>:8080 sans TLS, et l'adresse varie selon
+  le montage — localhost via `adb reverse`, 10.0.2.2 sur l'émulateur, IP LAN du
+  Mac sur un device en Wi-Fi (cf. mobile/README.md). Ces plages ne s'énumèrent
+  pas dans un `<domain>`.
+
+  Cette permissivité ne concerne que cette variante de build : le release
+  applique src/main/res/xml/network_security_config.xml, qui refuse le clair
+  hors boucle locale.
+-->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true" />
+</network-security-config>

--- a/scripts/check-android-network-security.py
+++ b/scripts/check-android-network-security.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Verrouille la politique de trafic en clair de l'app Android (STR-240).
+
+Le correctif d'origine ne tenait qu'à la vigilance du relecteur : rien
+n'empêchait un commit ultérieur de rebasculer `cleartextTrafficPermitted` à
+`true`, de ré-ajouter `android:usesCleartextTraffic` au manifeste, ou de
+supprimer la configuration — c'est-à-dire de rouvrir le trou sans bruit.
+
+Exécutable en local (`make check-android-security`) comme en CI : un contrôle
+qu'on ne peut pas rejouer sur son poste n'en est pas un.
+"""
+
+from __future__ import annotations
+
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+ANDROID = "{http://schemas.android.com/apk/res/android}"
+APP = Path("mobile/android/app/src")
+
+MAIN_CONFIG = APP / "main/res/xml/network_security_config.xml"
+MANIFEST = APP / "main/AndroidManifest.xml"
+DEV_CONFIGS = [
+    APP / "debug/res/xml/network_security_config.xml",
+    APP / "profile/res/xml/network_security_config.xml",
+]
+
+# Le clair reste toléré vers la boucle locale : ce trafic ne quitte pas
+# l'appareil. Toute autre adresse ici serait une régression.
+ALLOWED_CLEARTEXT_DOMAINS = {"localhost", "127.0.0.1"}
+
+errors: list[str] = []
+
+
+def fail(msg: str) -> None:
+    errors.append(msg)
+
+
+def canonical(node: ET.Element) -> tuple:
+    """Structure comparable d'un élément, commentaires et espaces exclus."""
+    return (
+        node.tag,
+        tuple(sorted(node.attrib.items())),
+        tuple(canonical(child) for child in node if isinstance(child.tag, str)),
+        (node.text or "").strip(),
+    )
+
+
+def check_release_config() -> None:
+    if not MAIN_CONFIG.exists():
+        fail(f"{MAIN_CONFIG} est absent — les builds release n'auraient plus de politique réseau")
+        return
+
+    root = ET.parse(MAIN_CONFIG).getroot()
+
+    base = root.find("base-config")
+    if base is None:
+        fail(f"{MAIN_CONFIG} : pas de <base-config>, le défaut Android (clair autorisé) s'appliquerait")
+    elif base.get("cleartextTrafficPermitted") != "false":
+        fail(
+            f"{MAIN_CONFIG} : base-config cleartextTrafficPermitted="
+            f'"{base.get("cleartextTrafficPermitted")}", attendu "false" — '
+            "les builds release pourraient émettre du HTTP en clair"
+        )
+
+    for cfg in root.findall("domain-config"):
+        if cfg.get("cleartextTrafficPermitted") != "true":
+            continue
+        for dom in cfg.findall("domain"):
+            name = (dom.text or "").strip()
+            if name not in ALLOWED_CLEARTEXT_DOMAINS:
+                fail(
+                    f"{MAIN_CONFIG} : le clair est autorisé vers {name!r}, hors de la boucle "
+                    f"locale {sorted(ALLOWED_CLEARTEXT_DOMAINS)} — à justifier explicitement"
+                )
+
+
+def check_manifest() -> None:
+    if not MANIFEST.exists():
+        fail(f"{MANIFEST} est absent")
+        return
+
+    app = ET.parse(MANIFEST).getroot().find("application")
+    if app is None:
+        fail(f"{MANIFEST} : pas d'élément <application>")
+        return
+
+    if app.get(f"{ANDROID}usesCleartextTraffic") is not None:
+        fail(
+            f"{MANIFEST} : android:usesCleartextTraffic est de retour. Cet attribut "
+            "s'applique à toutes les variantes, release comprise, et prend le pas sur "
+            "l'intention par variante — utiliser networkSecurityConfig."
+        )
+
+    if app.get(f"{ANDROID}networkSecurityConfig") is None:
+        fail(f"{MANIFEST} : android:networkSecurityConfig absent, aucune politique n'est appliquée")
+
+
+def check_dev_configs_agree() -> None:
+    """Les variantes de développement doivent porter la même politique.
+
+    Elles sont volontairement dupliquées — le modèle de source sets Android
+    n'offre pas d'inclusion — mais une divergence serait silencieuse. Seule la
+    structure est comparée : les commentaires peuvent différer (chacun nomme sa
+    variante).
+    """
+    present = [p for p in DEV_CONFIGS if p.exists()]
+    if len(present) != len(DEV_CONFIGS):
+        missing = [str(p) for p in DEV_CONFIGS if not p.exists()]
+        fail(
+            f"configuration de développement manquante : {missing} — cette variante "
+            "retomberait sur la politique release et ne joindrait plus l'API locale"
+        )
+        return
+
+    shapes = {p: canonical(ET.parse(p).getroot()) for p in present}
+    first, *rest = present
+    for other in rest:
+        if shapes[other] != shapes[first]:
+            fail(
+                f"{first} et {other} ont divergé. Les variantes de développement "
+                "doivent porter la même politique ; répercuter la modification, ou "
+                "documenter pourquoi elles diffèrent désormais."
+            )
+
+
+def main() -> int:
+    if not APP.exists():
+        print(f"::error::{APP} introuvable — lancer depuis la racine du dépôt", file=sys.stderr)
+        return 1
+
+    check_release_config()
+    check_manifest()
+    check_dev_configs_agree()
+
+    if errors:
+        for err in errors:
+            print(f"::error::{err}", file=sys.stderr)
+        print(f"\n{len(errors)} régression(s) de politique réseau Android.", file=sys.stderr)
+        return 1
+
+    print("politique réseau Android : clair refusé en release, boucle locale seule exception,")
+    print("variantes de développement alignées.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Part of STR-240

Second volet de la fermeture des expositions, après #312. Fichiers disjoints, les deux PR sont indépendantes.

## Le problème

`mobile/android/app/src/main/AndroidManifest.xml:18` portait `android:usesCleartextTraffic="true"`, **sans restriction de portée**. L'attribut s'applique à toutes les variantes, builds release compris : l'app de production pouvait émettre du HTTP en clair vers n'importe quel hôte, en-têtes `Authorization` porteurs du JWT compris.

La production étant servie en HTTPS derrière Caddy, rien ne l'exploitait aujourd'hui. Mais un downgrade ou un DNS détourné l'aurait fait silencieusement — et le sujet cite « sécurité des flux (TLS) » comme critère.

iOS était déjà correct : `ios/Runner/Info.plist:73-77` n'ouvre que `NSAllowsLocalNetworking`, sans `NSAllowsArbitraryLoads`. Android était seul en faute.

## Ce que fait cette PR

L'attribut est remplacé par `android:networkSecurityConfig`, avec une configuration par variante de build :

| Variante | Politique |
|---|---|
| **release** (`src/main/`) | cleartext refusé, sauf `localhost` et `127.0.0.1` |
| **debug** (`src/debug/`) | cleartext autorisé sans restriction |
| **profile** (`src/profile/`) | idem debug |

La boucle locale reste ouverte en release parce qu'elle couvre `adb reverse tcp:8080 tcp:8080`, utilisable sur un build release branché — et ce trafic ne quitte jamais l'appareil, donc aucune surface d'interception. `10.0.2.2` (hôte de l'émulateur) n'y figure volontairement pas : c'est une adresse de développement, elle vit dans les variantes debug et profile.

Le choix d'une variante permissive plutôt qu'une liste de domaines vient de `mobile/README.md` : en dev l'adresse de l'API change selon le montage — `localhost` via `adb reverse`, `10.0.2.2` sur l'émulateur, IP LAN du Mac en Wi-Fi. Ces plages ne s'énumèrent pas dans un `<domain>`, et Android ne supporte pas le CIDR. `profile` est inclus parce que la preuve de fluidité 60 FPS (STR-243) se mesure sur un build profile, souvent sur device physique.

## Vérifications

Les deux APK ont été construits et leur configuration extraite du binaire — pas seulement compilée, réellement appliquée.

**Release** (`aapt2 dump xmltree`) :

```
E: network-security-config
    E: base-config
      A: cleartextTrafficPermitted=false
    E: domain-config
      A: cleartextTrafficPermitted=true
        E: domain  T: 'localhost'
        E: domain  T: '127.0.0.1'
```

**Debug** :

```
E: network-security-config
    E: base-config
      A: cleartextTrafficPermitted=true
```

L'attribut `usesCleartextTraffic` a bien disparu du manifeste compilé, remplacé par `networkSecurityConfig=@0x7f0e0000`.

Également : `flutter analyze` sans issue, `flutter test` à 415 tests verts.

## Note

Un `--` s'était glissé dans un commentaire XML de la première rédaction (`flutter run --release`). C'est illégal en XML et le build échouait — reformulé. Mentionné parce que le piège est discret et peut se reproduire dans ces fichiers très commentés.
