### PR TITLE
ci: réparer le test de charge et conditionner le déploiement à la CI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,21 +6,49 @@ env:
 permissions:
   contents: read
 
+# Déclenché par la fin de la CI plutôt que par le push : les deux workflows
+# démarraient sinon en parallèle sur `push main`, et des tests rouges
+# déployaient quand même (STR-241). `workflow_run` porte le SHA du run
+# déclencheur, chaque job doit donc le passer explicitement à checkout —
+# sans quoi Actions reprendrait la tête de la branche par défaut.
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
     branches:
       - main
+    types:
+      - completed
   workflow_dispatch:
 
 jobs:
   build-and-push:
     name: Build & Push Docker image
     runs-on: ubuntu-latest
+    # Le workflow_run se déclenche quel que soit le verdict : on filtre ici.
+    # Un `workflow_dispatch` n'a pas de workflow_run associé, d'où le second
+    # membre qui garde le redéploiement manuel utilisable.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     permissions:
       contents: read
       packages: write
     steps:
+      # Sous workflow_run, `github.sha` désigne la tête de la branche par défaut
+      # au moment du déclenchement, pas le commit dont la CI vient de passer.
+      # Les deux coïncident dans le cas nominal mais divergent dès que deux
+      # pushes s'enchaînent — on construirait alors une image étiquetée avec un
+      # SHA qu'elle ne contient pas. Résolu une fois, réutilisé partout.
+      - name: Résoudre le commit à déployer
+        id: target
+        run: |
+          SHA="${{ github.event.workflow_run.head_sha || github.sha }}"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "short=sha-${SHA:0:7}" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.target.outputs.sha }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -38,7 +66,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}/api
           tags: |
-            type=sha,format=short
+            type=raw,value=${{ steps.target.outputs.short }}
             type=raw,value=latest
 
       - name: Build and push Docker image

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,17 @@ env:
 permissions:
   contents: read
 
+# Deux CI qui concluent coup sur coup (deux merges rapprochés, ou un merge plus
+# un workflow_dispatch) lanceraient deux CD en parallèle : chacune pousse le tag
+# `latest` puis fait `docker compose pull` sur le VPS, sans garantie d'ordre —
+# la machine pourrait rester sur le plus ancien des deux commits. La file
+# n'annule pas le déploiement en cours (couper à mi-parcours laisserait un état
+# partiel) ; seule la mise en attente est remplacée par la suivante, donc le
+# dernier commit gagne.
+concurrency:
+  group: cd-production
+  cancel-in-progress: false
+
 # Déclenché par la fin de la CI plutôt que par le push : les deux workflows
 # démarraient sinon en parallèle sur `push main`, et des tests rouges
 # déployaient quand même (STR-241). `workflow_run` porte le SHA du run
@@ -24,12 +35,24 @@ jobs:
   build-and-push:
     name: Build & Push Docker image
     runs-on: ubuntu-latest
-    # Le workflow_run se déclenche quel que soit le verdict : on filtre ici.
-    # Un `workflow_dispatch` n'a pas de workflow_run associé, d'où le second
+    # Deux filtres, pas un.
+    #
+    # `conclusion` écarte les CI rouges — c'est l'objet de la bascule.
+    #
+    # `event == 'push'` écarte les CI de pull_request, et ce n'est pas
+    # cosmétique : `workflow_run` se déclenche pour *toute* exécution de la CI,
+    # y compris celles issues d'une PR, et son filtre `branches` compare le
+    # head_branch du run déclencheur. Une PR de fork ouverte depuis une branche
+    # nommée `main` produit donc head_branch == main, passe le filtre, et si sa
+    # CI conclut success la CD s'exécuterait avec les secrets du dépôt de base
+    # sur un commit jamais mergé — la protection de branche ne s'interpose pas.
+    #
+    # Un workflow_dispatch n'a pas de workflow_run associé, d'où le premier
     # membre qui garde le redéploiement manuel utilisable.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push')
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,14 @@ jobs:
           version: v2.4.0
           working-directory: ./backend
           skip-cache: true
+          # `config verify` télécharge le schéma JSON depuis golangci-lint.run à
+          # chaque run. Le lint dépend donc de la disponibilité d'un site tiers,
+          # et un simple timeout fait échouer la CI sans qu'aucune ligne de code
+          # soit en cause — arrivé sur la PR #312, alors que le même commit
+          # passait ailleurs à la même minute. La validation du fichier n'apporte
+          # rien ici : `.golangci.yml` bouge rarement, et une clé invalide fait
+          # de toute façon échouer golangci-lint juste après.
+          verify: false
 
   test:
     name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,52 @@ jobs:
       # `go test ./...` : ils pourrissent sans que rien n'échoue. C'est ce qui
       # est arrivé au harnais de charge, resté trois semaines et demie
       # non compilable après un élargissement de StreamService (STR-241).
+      #
+      # La liste reste déclarée à la main — `go vet -tags` attend un ensemble de
+      # tags simultanément satisfiables, qu'une dérivation aveugle ne garantit
+      # pas — mais elle est désormais gardée : un tag présent dans l'arbre et
+      # absent d'ici fait échouer le job. Sans cette garde, un futur fichier sous
+      # un nouveau tag retomberait exactement dans le trou que cette étape
+      # prétend fermer. Même principe que envKeys côté config.
       - name: Vérifier la compilation des fichiers sous build tag
         working-directory: ./backend
-        run: go vet -tags loadtest,integration ./...
+        env:
+          DECLARED_TAGS: "integration loadtest"
+        run: |
+          set -euo pipefail
+
+          # Tags simples présents dans l'arbre. `ignore` est la convention Go
+          # pour un fichier volontairement hors build : rien à vérifier.
+          found=$(grep -rhE '^//go:build ' --include='*.go' . \
+            | sed 's|^//go:build ||' \
+            | tr -s ' ()&|!' '\n' \
+            | grep -E '^[a-z0-9_]+$' \
+            | grep -vx 'ignore' \
+            | sort -u || true)
+
+          # `while read` plutôt que `for tag in $found` : zsh ne découpe pas une
+          # expansion non quotée, le second se comporterait donc différemment
+          # sur un poste de dev et sur le runner. Un garde-fou qu'on ne peut pas
+          # rejouer en local n'en est pas un.
+          missing=""
+          while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            case " $DECLARED_TAGS " in
+              *" $tag "*) ;;
+              *) missing="$missing $tag" ;;
+            esac
+          done <<EOF
+          $found
+          EOF
+
+          if [ -n "$missing" ]; then
+            echo "::error::build tag présent dans l'arbre mais absent de DECLARED_TAGS :$missing"
+            echo "Ajoutez-le à DECLARED_TAGS (ci.yml), sinon ces fichiers cesseront de compiler sans bruit."
+            exit 1
+          fi
+
+          echo "tags vérifiés : $DECLARED_TAGS"
+          go vet -tags "$(echo $DECLARED_TAGS | tr ' ' ',')" ./...
 
       - name: Run tests
         working-directory: ./backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,14 @@ jobs:
       - name: Install ffmpeg (segmentation HLS — cf. ADR 015)
         run: sudo apt-get update && sudo apt-get install -y ffmpeg
 
+      # Les fichiers sous build tag sont exclus de `go build ./...` comme de
+      # `go test ./...` : ils pourrissent sans que rien n'échoue. C'est ce qui
+      # est arrivé au harnais de charge, resté trois semaines et demie
+      # non compilable après un élargissement de StreamService (STR-241).
+      - name: Vérifier la compilation des fichiers sous build tag
+        working-directory: ./backend
+        run: go vet -tags loadtest,integration ./...
+
       - name: Run tests
         working-directory: ./backend
         run: go test -v -race -coverprofile=coverage.txt ./...

--- a/.github/workflows/loadtest.yml
+++ b/.github/workflows/loadtest.yml
@@ -2,6 +2,11 @@ name: Load Test
 
 on:
   workflow_dispatch:
+  # Hebdomadaire : le harnais vit sous build tag, donc hors du chemin de la CI
+  # de PR. `go vet -tags loadtest` (job Test de la CI) garantit qu'il compile ;
+  # ce run garantit qu'il passe encore, et fournit des chiffres datés à l'ADR 016.
+  schedule:
+    - cron: "0 5 * * 1"
 
 permissions:
   contents: read

--- a/backend/internal/streaming/loadtest/load_test.go
+++ b/backend/internal/streaming/loadtest/load_test.go
@@ -60,6 +60,24 @@ func (stubService) StartStream(context.Context, string, string) (streaming.Strea
 func (stubService) StopStream(context.Context, string, string) (streaming.Stream, error) {
 	return streaming.Stream{}, nil
 }
+func (stubService) AddFavorite(context.Context, string, string) error    { return nil }
+func (stubService) RemoveFavorite(context.Context, string, string) error { return nil }
+func (stubService) ListFavorites(context.Context, string) ([]streaming.Stream, error) {
+	return nil, nil
+}
+func (stubService) ListMyStreams(context.Context, string) ([]streaming.Stream, error) {
+	return nil, nil
+}
+func (stubService) RotateStreamKey(context.Context, string, string) (streaming.Stream, error) {
+	return streaming.Stream{}, nil
+}
+
+// L'assertion de compilation manquait : sans elle, une méthode ajoutée à
+// StreamService ne casse ce harnais qu'au moment où quelqu'un lance
+// `make loadtest`. C'est ce qui s'est produit — le stub est resté incomplet
+// trois semaines et demie, le build tag `loadtest` excluant ce fichier de
+// `go build ./...` comme de `go test ./...` (STR-241).
+var _ streaming.StreamService = stubService{}
 
 // startServer monte les 3 routes HLS comme cmd/api/main.go les monte : ingest
 // sans JWT, playlist/segments en lecture publique (OptionalAuth, STR-108) sous

--- a/docs/adr/016-scalabilite-test-de-charge-et-limiteur-hls.md
+++ b/docs/adr/016-scalabilite-test-de-charge-et-limiteur-hls.md
@@ -76,23 +76,33 @@ borne** — un pic d'auditeurs au-delà de la capacité dégraderait tout le mon
   HLS (retry naturel au prochain poll) et trivialement testable. Réévaluable si le besoin
   apparaît.
 
-## Validation (run de référence, 2026-07-19)
+## Validation (dernier run, 2026-08-18)
 
-Sortie locale de `make loadtest` (Apple M3, 8 Go, Go 1.26.1, ffmpeg 8.1.2), limiteur monté
-à 256 dans le harnais :
+Sortie locale de `make loadtest` (Apple M3, 8 Go), limiteur monté à 256 dans le harnais :
 
-| Critère STR-87 | Seuil | Mesuré | Verdict |
-|---|---|---|---|
-| p95 playlist | < 300 ms | **23,52 ms** | ✅ |
-| p95 segment | < 300 ms | **41,02 ms** | ✅ |
-| Mémoire/connexion | < 2 Mo | **0,13 Mo** | ✅ |
-| Échecs HTTP | 0 | **0 / 1800 requêtes** | ✅ |
-| Goroutine leak | 0 | goroutines 13 → 10 après drain | ✅ |
+| Critère STR-87 | Seuil | 2026-07-19 | 2026-08-18 | Verdict |
+|---|---|---|---|---|
+| p95 playlist | < 300 ms | 23,52 ms | **22,56 ms** | ✅ |
+| p95 segment | < 300 ms | 41,02 ms | **28,52 ms** | ✅ |
+| Mémoire/connexion | < 2 Mo | 0,13 Mo | **0,14 Mo** | ✅ |
+| Échecs HTTP | 0 | 0 / 1800 | **0 / 1800** | ✅ |
+| Goroutine leak | 0 | 13 → 10 | **13 → 10** | ✅ |
 
 1500 requêtes playlist + 300 segments (~50 Mo servis), `-race` sans warning, aucun 503 émis
 (50 auditeurs < 256). Limites connues : in-process (latences hors RTT réseau/TLS), source sine
-à débit constant, matériel local ≠ VPS — refaire le run via le workflow « Load Test » pour des
-chiffres CI reproductibles.
+à débit constant, matériel local ≠ VPS.
+
+⚠️ **Le harnais est resté non compilable du 2026-07-25 au 2026-08-18** : l'élargissement de
+`StreamService` (ajout des favoris) a laissé `stubService` incomplet, et le build tag `loadtest`
+exclut ce fichier de `go build ./...` comme de `go test ./...`. Aucun signal pendant trois
+semaines et demie, la preuve ci-dessus n'étant plus reproductible. Deux garde-fous posés
+depuis (STR-241) : `go vet -tags loadtest,integration ./...` dans le job Test de la CI, qui
+échoue à la compilation, et un `schedule` hebdomadaire sur le workflow « Load Test », qui
+vérifie que le run passe encore. Une assertion `var _ streaming.StreamService = stubService{}`
+a également été ajoutée au harnais.
+
+Les chiffres ci-dessus mesurent **N auditeurs sur un flux**. Le coût CPU de **N flux
+simultanés** — la question posée par le sujet — reste à mesurer (STR-243).
 
 ## Conséquences
 


### PR DESCRIPTION
Part of STR-241

Trois défauts de la chaîne, dont un qui laissait déployer avec des tests rouges.

## 1. Le test de charge ne compilait plus depuis le 25/07

```
internal/streaming/loadtest/load_test.go:70:28: cannot use stubService{} …
  stubService does not implement streaming.StreamService (missing method AddFavorite)
```

`c1c9927` (« ajout d'un flux aux favoris ») a élargi `StreamService` de cinq méthodes. Le stub n'a pas suivi. **Rien ne l'a signalé pendant trois semaines et demie** : le build tag `loadtest` exclut ce fichier de `go build ./...` *comme* de `go test ./...`, et `loadtest.yml` était en `workflow_dispatch` seul.

Toute la « preuve de scalabilité » de l'ADR 016 repose sur ce harnais. Elle n'était plus reproductible.

Le stub est complété, et porte maintenant l'assertion qui manquait :

```go
var _ streaming.StreamService = stubService{}
```

**Run rejoué**, chiffres consignés dans l'ADR 016 à côté de ceux de juillet :

```
requêtes: 1500 playlists, 300 segments, 0 échecs, 50.1 Mo servis
playlist: n=1500 p50=1.901ms p95=22.561ms p99=37.248ms
segment:  n=300  p50=11.105ms p95=28.522ms p99=37.035ms
mémoire:  base=0.6 Mo pic=7.6 Mo soit 0.14 Mo/connexion
goroutines: avant=13 après=10
--- PASS: TestLoad_50Listeners (70.11s)
```

## 2. Deux garde-fous contre la rechute

- **`go vet -tags loadtest,integration ./...`** dans le job Test. Un fichier sous build tag qui ne compile plus fait désormais échouer la CI de PR. Couvre aussi `repository_integration_test.go`, exposé au même risque.
- **`schedule` hebdomadaire** sur le workflow Load Test. `vet` garantit que le harnais compile ; ce run garantit qu'il passe encore, et fournit des chiffres datés.

## 3. Le CD ne dépendait de rien

`cd.yml` se déclenchait sur `push main`, en parallèle de la CI. Aucun `needs`, aucun `workflow_run` : **des tests rouges déployaient quand même.** Combiné au HEAD de `develop` actuellement en `cancelled`, c'est le défaut le plus sérieux du bloc C3.4.

Le déclencheur devient `workflow_run` sur la CI, filtré sur `conclusion == 'success'`. Le `workflow_dispatch` reste utilisable pour un redéploiement manuel — d'où le second membre de la condition, un dispatch n'ayant pas de `workflow_run` associé.

### Un piège de `workflow_run` traité au passage

Sous `workflow_run`, `github.sha` désigne **la tête de la branche par défaut au moment du déclenchement**, pas le commit dont la CI vient de passer. Dans le cas nominal les deux coïncident ; dès que deux pushes s'enchaînent, ils divergent. On aurait construit une image depuis un commit et l'aurait étiquetée avec un autre.

Le SHA cible est résolu une fois, puis réutilisé pour le `checkout` **et** pour le tag d'image. `type=sha,format=short` est remplacé par un `type=raw` équivalent (`sha-<7 chars>`, même format qu'avant) alimenté par cette valeur.

## Vérifications

- `make loadtest` : PASS en 71 s (sortie ci-dessus)
- `go vet -tags loadtest,integration ./...` : sans erreur
- `go test ./...` : 13 packages au vert
- Les 6 workflows parsent en YAML valide

⚠️ **`actionlint` n'est pas installé** sur ma machine : les workflows sont validés syntaxiquement mais pas sémantiquement. Le vrai test de la bascule `workflow_run`, c'est le premier merge sur `main` — à surveiller.

## Ce que cette PR ne fait pas

**Le ruleset GitHub n'impose toujours aucun status check.** Il exige PR + 1 approbation + signatures + non-fast-forward, mais rien sur la CI : une PR se merge avec la CI rouge. C'est exactement comme ça que le HEAD de `develop` s'est retrouvé en `Test cancelled` / `Build skipped` sans que personne le voie.

Je ne l'ai pas modifié — c'est un réglage de dépôt qui change la capacité de merge de toute l'équipe, ce n'est pas à une PR de le décider unilatéralement. **À faire à la main** dans Settings → Rules → `branch-protection` → ajouter « Require status checks to pass » avec au minimum `Lint`, `Test`, `Build`, `Flutter Analyze`, `Flutter Test`.

Sans ça, les deux garde-fous de cette PR signalent le problème mais ne bloquent rien.
