### PR TITLE
docs: compléter le README et documenter la répartition des tâches

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,4 +24,3 @@
 # modes de lecture ajoutés par Antony — les deux relisent.
 /mobile/lib/features/playlists/ @Oceloott @LignacAntony
 /mobile/lib/features/tracks/    @Oceloott @LignacAntony
-/mobile/lib/features/library/   @Oceloott @LignacAntony

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,27 @@
+# CODEOWNERS — propriétaires par défaut pour la review des PR.
+# Cohérent avec la répartition des tâches documentée dans le README
+# (section « Équipe et répartition des tâches »).
+# Doc : https://docs.github.com/articles/about-code-owners
+
+# Par défaut : lead technique
+*                       @LignacAntony
+
+# Backend Go, infra Docker, observabilité, CI/CD — Antony
+/backend/               @LignacAntony
+/docker/                @LignacAntony
+/docs/                  @LignacAntony
+/.github/               @LignacAntony
+/docker-compose.yml     @LignacAntony
+/docker-compose.prod.yml @LignacAntony
+
+# Application mobile Flutter — Thierry & Baptiste
+/mobile/                @thierrymgn @Oceloott
+
+# Lecteur audio, lecture en arrière-plan, interruptions — Thierry
+/mobile/lib/core/audio/ @thierrymgn
+
+# Playlists et bibliothèque : créées par Baptiste, file d'attente et
+# modes de lecture ajoutés par Antony — les deux relisent.
+/mobile/lib/features/playlists/ @Oceloott @LignacAntony
+/mobile/lib/features/tracks/    @Oceloott @LignacAntony
+/mobile/lib/features/library/   @Oceloott @LignacAntony

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,12 @@
+# Fusionne les identités git multiples des contributeurs pour que
+# `git shortlog -sne` et les statistiques GitHub reflètent la réalité.
+# Format : Nom canonique <email canonique> <autre email>
+# Voir : https://git-scm.com/docs/gitmailmap
+
+Antony Lignac <lignac.antony@live.fr>
+
+Thierry Maignan <maignan.thierry@outlook.fr>
+Thierry Maignan <maignan.thierry@outlook.fr> <81976242+thierrymgn@users.noreply.github.com>
+
+Baptiste Ballesteros <baptiste.ballesteros@ecole-decode.fr>
+Baptiste Ballesteros <baptiste.ballesteros@ecole-decode.fr> <60733546+Oceloott@users.noreply.github.com>

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 StreamPulse — Antony Lignac, Thierry Maignan, Baptiste Ballesteros
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -11,18 +11,38 @@
 
 ## Sommaire
 
-- [StreamPulse](#streampulse)
-  - [](#)
-  - [Sommaire](#sommaire)
-  - [Stack technique](#stack-technique)
-  - [Structure du repository](#structure-du-repository)
-  - [Prérequis](#prérequis)
-  - [Installation \& lancement](#installation--lancement)
-  - [Documentation API](#documentation-api)
-  - [Variables d'environnement](#variables-denvironnement)
-  - [Workflow Git](#workflow-git)
-  - [Conventions de commit](#conventions-de-commit)
-  - [Contribuer](#contribuer)
+- [Fonctionnalités](#fonctionnalités)
+- [Stack technique](#stack-technique)
+- [Structure du repository](#structure-du-repository)
+- [Prérequis](#prérequis)
+- [Installation \& lancement](#installation--lancement)
+- [Architecture](#architecture)
+- [Tests](#tests)
+- [Déploiement](#déploiement)
+- [Documentation API](#documentation-api)
+- [Variables d'environnement](#variables-denvironnement)
+- [Workflow Git](#workflow-git)
+- [Conventions de commit](#conventions-de-commit)
+- [Équipe et répartition des tâches](#équipe-et-répartition-des-tâches)
+- [Contribuer](#contribuer)
+- [Licence](#licence)
+
+---
+
+## Fonctionnalités
+
+StreamPulse permet à un **diffuseur** de lancer un direct audio depuis son mobile et à des
+**auditeurs** de l'écouter en temps réel, avec en complément une bibliothèque de pistes
+personnelles et des playlists.
+
+| Domaine | Fonctionnalités |
+| --- | --- |
+| **Comptes** | Inscription, connexion JWT (access + refresh avec rotation), réinitialisation de mot de passe par email, gestion du profil, suppression de compte (RGPD) |
+| **Diffusion** | Création d'un flux, capture du micro et push AAC, segmentation HLS via ffmpeg, démarrage/arrêt du direct, rotation de la clé de diffusion, statistiques d'audience en temps réel |
+| **Écoute** | Découverte des flux publics, lecteur HLS (play/pause/volume), lecture en arrière-plan avec contrôles système, gestion des interruptions (appel, casque débranché), favoris |
+| **Bibliothèque** | Upload de pistes audio (MP3/AAC/OGG, quota par compte), playlists, réorganisation des pistes, file d'attente, modes aléatoire et répétition |
+| **Administration** | Tableau de bord utilisateurs (activation/suppression), supervision et interruption des flux actifs, journal d'audit, validation des demandes de rôle diffuseur |
+| **Observabilité** | Logs structurés JSON (Loki), métriques Prometheus, traces OpenTelemetry (Tempo), dashboards et alertes Grafana provisionnés |
 
 ---
 
@@ -75,6 +95,121 @@ cd backend && go run ./cmd/api
 cd mobile && flutter run
 ```
 
+## Architecture
+
+Vue d'ensemble, schéma des composants, flux d'une requête et chaîne d'observabilité :
+**[docs/architecture.md](./docs/architecture.md)** — *point de départ recommandé*.
+
+| Couche | Principe |
+| --- | --- |
+| **Backend Go** | `net/http` + `http.ServeMux`, **sans framework**. Un package par domaine métier (`auth`, `streaming`, `playlist`, `track`, `admin`…), découpé en `handler` / `service` / `repository` ([ADR 008](./docs/adr/008-architecture-handler-service-repository.md)). Accès SQL typé généré par [sqlc](./docs/adr/007-sqlc-generation-code-sql.md). |
+| **Mobile Flutter** | **Clean Architecture** (`domain` / `data` / `presentation`) + `provider` pour l'état ([ADR 005](./docs/adr/005-architecture-flutter-clean.md)). Le client HTTP est **généré** depuis la spec OpenAPI. |
+| **Contrat HTTP** | La spec OpenAPI est la **source de vérité** ([ADR 012](./docs/adr/012-openapi-source-de-verite.md)) : le client Dart en est dérivé, jamais écrit à la main. |
+| **Observabilité** | Stack LGTM — Loki (logs), Grafana (dashboards + alertes), Tempo (traces), Prometheus (métriques) ([ADR 001](./docs/adr/001-choix-stack-observabilite.md)). |
+
+Toutes les décisions d'architecture significatives sont consignées sous forme d'**ADR**
+(*Architecture Decision Records*) — 38 à ce jour, chacune reliée à son ticket Linear :
+
+- **[Index complet de la documentation](./docs/README.md)** — ordre de lecture recommandé
+- **[Index des ADR](./docs/adr/)** — une décision par fichier, numérotée
+
+Le code applique les **principes SOLID** de bout en bout : interfaces étroites côté handler Go
+(ISP), injection systématique des dépendances (DIP), entités du domaine sans dépendance infra.
+
+## Tests
+
+Le projet compte **40 fichiers de tests Go** et **36 fichiers de tests Flutter**. Les tests sont
+**colocalisés avec le code** qu'ils couvrent (`*_test.go` à côté du package, `mobile/test/`
+en miroir de `mobile/lib/`).
+
+```bash
+# Backend Go — tous les tests, avec détecteur de data race
+cd backend && go test -race ./...
+```
+
+```bash
+# Backend Go — couverture (même commande qu'en CI)
+cd backend && go test -race -coverprofile=coverage.txt ./... && go tool cover -func=coverage.txt
+```
+
+```bash
+# Backend Go — un seul package
+cd backend && go test ./internal/streaming/...
+```
+
+```bash
+# Mobile Flutter — tests unitaires et widgets
+cd mobile && flutter test
+```
+
+```bash
+# Test de charge HLS — 50 auditeurs simultanés (STR-90, requiert ffmpeg)
+make loadtest
+```
+
+**Conventions** : tests Go en **stdlib uniquement** (pas de testify), stubs légers pour les
+handlers et `fakeRepo` en mémoire pour les services ; côté Flutter, les abstractions du domaine
+permettent de substituer des fakes (ex. `fake_audio_playback_service.dart`).
+
+### Couverture actuelle (backend Go)
+
+**48,8 %** des instructions sur l'ensemble du module — **54,4 %** en excluant les packages
+`internal/*/db` générés par sqlc, qui ne sont pas censés être testés directement.
+
+| Package | Couverture | | Package | Couverture |
+| --- | --- | --- | --- | --- |
+| `observability` | 94,1 % | | `streaming` | 65,6 % |
+| `shared/httpmw` | 94,0 % | | `auth` | 62,7 % |
+| `config` | 81,3 % | | `track` | 57,4 % |
+| `shared/httpjson` | 75,8 % | | `profiles` | 54,0 % |
+| `openapi` | 73,3 % | | `admin` | 52,4 % |
+| | | | `broadcaster` | 44,8 % |
+| | | | `shared/apperror` | 40,9 % |
+| | | | `playlist` | 40,0 % |
+
+> Chiffres obtenus avec `go test -coverprofile` sur le module complet. Les packages
+> `infrastructure/*` (migrator, seeder, pool) et `cmd/api` sont à 0 % : ils sont couverts par
+> les tests d'intégration sous build tag `integration`, exclus de `go test ./...`.
+
+### Intégration continue
+
+La **CI rejoue lint → tests → build à chaque PR** (et sur `develop` / `main`) et publie
+`coverage.txt` en artefact téléchargeable depuis l'onglet *Actions*.
+
+Le **test de charge ne tourne pas sur les PR** : le harnais vivant sous *build tag*, la CI
+garantit seulement qu'il **compile** (`go vet -tags loadtest`). Son exécution réelle est un
+workflow distinct ([`loadtest.yml`](./.github/workflows/loadtest.yml)), déclenché
+**chaque lundi à 05h00 UTC** ou manuellement, qui publie son rapport en artefact.
+
+## Déploiement
+
+L'API est déployée en continu sur un **VPS Hetzner**, derrière **Caddy** (HTTPS automatique) :
+
+| | |
+| --- | --- |
+| **API de production** | **<https://api.streampulse.win>** — [health](https://api.streampulse.win/health) |
+| **Déclencheur** | **Fin de la CI sur `main`** (`workflow_run`), uniquement si elle est verte — un push ne déploie donc jamais des tests rouges. Aussi déclenchable à la main (`workflow_dispatch`) |
+| **Pipeline** | Build de l'image Docker multi-stage → push sur **GHCR** → déploiement SSH sur le VPS |
+| **Releases** | Automatiques via **release-please** : les Conventional Commits déterminent la version semver, le tag et le [CHANGELOG](./CHANGELOG.md) |
+
+> `/metrics` et les endpoints Swagger ne sont **pas exposés en production** ; le port de l'API
+> est bindé sur `127.0.0.1` et tout transite par Caddy.
+
+**Procédures détaillées** — secrets GitHub à configurer, mise à jour manuelle du compose et des
+configs d'infra, vérifications post-déploiement, troubleshooting :
+**[docs/infrastructure.md](./docs/infrastructure.md)**.
+
+Les **6 workflows** GitHub Actions du projet :
+
+| Workflow | Fichier | Déclenchement | Rôle |
+| --- | --- | --- | --- |
+| **CI** | [`ci.yml`](./.github/workflows/ci.yml) | PR + push `develop`/`main` | Lint Go, tests + couverture, build, analyse Flutter |
+| **CD** | [`cd.yml`](./.github/workflows/cd.yml) | Fin de CI verte sur `main` | Build & push GHCR, déploiement VPS, release-please |
+| **Security** | [`security.yml`](./.github/workflows/security.yml) | Push `develop`/`main` + cron lundi | Scan Trivy (SARIF) + analyse statique gosec |
+| **Check hardcoded** | [`check-hardcoded.yml`](./.github/workflows/check-hardcoded.yml) | PR + push `develop`/`main` | Bloque tout secret ou valeur codée en dur (gitleaks + grep) |
+| **Lint PR title** | [`lint-pr-title.yml`](./.github/workflows/lint-pr-title.yml) | Ouverture/édition de PR | Valide le titre de PR contre les Conventional Commits |
+| **Load Test** | [`loadtest.yml`](./.github/workflows/loadtest.yml) | Cron lundi 05h00 UTC + manuel | Test de charge HLS 50 auditeurs, rapport en artefact |
+
 ## Documentation API
 
 L'API expose sa documentation OpenAPI via Swagger UI :
@@ -122,7 +257,39 @@ Le projet suit la méthodologie [**12-Factor App**](https://12factor.net/fr/conf
 | `POSTGRES_USER` | Alias compose pour `DB_USER` (init du conteneur Postgres) | — | **oui (compose)** | `streampulse` |
 | `POSTGRES_PASSWORD` | Alias compose pour `DB_PASSWORD` | — | **oui (compose)** | `<mot de passe fort>` |
 | `POSTGRES_DB` | Alias compose pour `DB_NAME` | — | **oui (compose)** | `streampulse_db` |
+| `DATABASE_URL` | DSN PostgreSQL complète. Utilisée par le **migrator** au démarrage, et en **fallback** du pool si les `DB_*` ne sont pas résolues | — | **oui (compose)** | `pgx5://user:pwd@postgres:5432/streampulse_db?sslmode=disable` |
 | `GRAFANA_ADMIN_PASSWORD` | Mot de passe admin Grafana | — | **oui (compose)** | `<mot de passe fort>` |
+
+**Email (réinitialisation de mot de passe, alertes)** — laisser `SMTP_HOST` vide affiche les
+tokens dans les logs (mode dev) ; en local, `mailpit` sert de relay de test (UI sur
+`http://localhost:8025`).
+
+| Variable | Description | Défaut | Requis | Exemple |
+| --- | --- | --- | --- | --- |
+| `SMTP_HOST` | Serveur SMTP. **Vide = mode log stdout** (aucun email envoyé) | — | non | `mailpit` (dev) / `smtp-relay.brevo.com` |
+| `SMTP_PORT` | Port SMTP (STARTTLS) | — (`587` dans `.env.example`) | non | `1025` (mailpit) / `587` |
+| `SMTP_USERNAME` | Utilisateur du relay SMTP | — | non | `postmaster@streampulse.com` |
+| `SMTP_PASSWORD` | Mot de passe du relay SMTP | — | non | `<mot de passe smtp>` |
+| `SMTP_FROM` | Adresse expéditeur des emails | — (`noreply@streampulse.com` dans `.env.example`) | non | `noreply@streampulse.com` |
+| `APP_BASE_URL` | Schéma d'URL des liens contenus dans les emails — **deep link** vers l'app Flutter | — (`streampulse://app` dans `.env.example`) | non | `streampulse://app` |
+
+**Réseau, streaming et stockage**
+
+| Variable | Description | Défaut | Requis | Exemple |
+| --- | --- | --- | --- | --- |
+| `CORS_ALLOWED_ORIGINS` | Origines CORS autorisées, séparées par des virgules. En dev, `localhost` / `127.0.0.1` sont autorisés d'office quel que soit le port | — | non | `https://app.streampulse.com` |
+| `STREAM_INGEST_BASE_URL` | Préfixe de l'URL d'ingest renvoyée au diffuseur : `{base}/api/streams/ingest/{stream_key}` ([ADR 013](./docs/adr/013-domaine-streaming.md)) | `http://localhost:8080` | non | `https://api.streampulse.win` |
+| `STORAGE_PATH` | Répertoire racine des fichiers audio uploadés, **hors répertoire servi** ([ADR 032](./docs/adr/032-domaine-track-upload-audio.md)) | `./data/tracks` | non | `/data/tracks` (volume Docker) |
+| `HLS_MAX_CONCURRENT` | Nombre max de requêtes HLS servies simultanément aux auditeurs. `0` = illimité ([ADR 016](./docs/adr/016-scalabilite-test-de-charge-et-limiteur-hls.md)) | `256` | non | `256` |
+| `TRUST_PROXY_HEADERS` | Lire `X-Forwarded-For` pour identifier les auditeurs (comptage d'audience). **`true` uniquement derrière un reverse proxy** — sinon l'en-tête est falsifiable, et sans proxy le compteur sature à 1 ([ADR 025](./docs/adr/025-statistiques-daudience-en-temps-reel.md)) | `false` | non | `true` (prod) |
+
+**Observabilité**
+
+| Variable | Description | Défaut | Requis | Exemple |
+| --- | --- | --- | --- | --- |
+| `LOG_LEVEL` | Niveau minimal des logs JSON : `trace`, `debug`, `info`, `warn`, `error` ([ADR 018](./docs/adr/018-logs-structures-zerolog-collecte-loki-alloy.md)) | `info` | non | `info` |
+| `LOG_PRETTY` | Sortie console lisible — réservée au `go run` local. **Jamais en conteneur** : la collecte Loki attend du JSON | `false` | non | `true` (dev natif) |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Endpoint OTLP/HTTP de Tempo pour les traces. **Vide = tracing désactivé** ([ADR 020](./docs/adr/020-traces-opentelemetry-otlp-tempo.md)) | — | non | `http://tempo:4318` |
 
 ### Implémentation
 
@@ -183,6 +350,62 @@ docs(readme): documenter le workflow Git
 
 Les **titres de PR** sont validés automatiquement via GitHub Actions. Voir [CONTRIBUTING.md](./CONTRIBUTING.md) pour le détail.
 
+## Équipe et répartition des tâches
+
+Projet réalisé par **3 développeurs**. Chacun a porté ses fonctionnalités de bout en bout —
+backend, mobile, documentation et ADR — plutôt qu'une séparation stricte par couche technique.
+
+| Contributeur | GitHub | Périmètre principal |
+| --- | --- | --- |
+| **Antony Lignac** | [@LignacAntony](https://github.com/LignacAntony) | Backend Go, infrastructure, observabilité, streaming, administration |
+| **Thierry Maignan** | [@thierrymgn](https://github.com/thierrymgn) | Moteur HLS, lecteur audio mobile, authentification, CI/CD |
+| **Baptiste Ballesteros** | [@Oceloott](https://github.com/Oceloott) | Bibliothèque, playlists, favoris, profil utilisateur |
+
+### Détail par domaine
+
+**Antony Lignac** — *fondations du projet et de l'infra*
+
+- Initialisation du dépôt et configuration 12-Factor via Viper ([#88](https://github.com/LignacAntony/streampulse/pull/88), [#101](https://github.com/LignacAntony/streampulse/pull/101))
+- Domaine **streaming** : création/configuration d'un flux, démarrage et arrêt du direct, rotation de la clé de diffusion, transcodage à la volée des formats d'ingest ([#128](https://github.com/LignacAntony/streampulse/pull/128), [#257](https://github.com/LignacAntony/streampulse/pull/257), [#279](https://github.com/LignacAntony/streampulse/pull/279), [#281](https://github.com/LignacAntony/streampulse/pull/281))
+- **Observabilité complète** : logs structurés zerolog + Loki/Alloy, métriques Prometheus + node_exporter, traces OpenTelemetry vers Tempo, dashboards et alertes Grafana provisionnés ([#265](https://github.com/LignacAntony/streampulse/pull/265), [#268](https://github.com/LignacAntony/streampulse/pull/268), [#269](https://github.com/LignacAntony/streampulse/pull/269), [#271](https://github.com/LignacAntony/streampulse/pull/271), [#272](https://github.com/LignacAntony/streampulse/pull/272))
+- **Administration** : tableau de bord utilisateurs, supervision et interruption des flux, journal d'audit ([#264](https://github.com/LignacAntony/streampulse/pull/264), [#267](https://github.com/LignacAntony/streampulse/pull/267))
+- Scalabilité : test de charge 50 auditeurs et limiteur HLS ([#261](https://github.com/LignacAntony/streampulse/pull/261))
+- Mobile : capture micro et push AAC, tableau de bord diffuseur, file d'attente de lecture, modes aléatoire/répétition, barre de progression ([#274](https://github.com/LignacAntony/streampulse/pull/274), [#278](https://github.com/LignacAntony/streampulse/pull/278), [#287](https://github.com/LignacAntony/streampulse/pull/287), [#289](https://github.com/LignacAntony/streampulse/pull/289), [#292](https://github.com/LignacAntony/streampulse/pull/292))
+- OpenAPI comme source de vérité + client Dart généré ([#126](https://github.com/LignacAntony/streampulse/pull/126))
+
+**Thierry Maignan** — *chaîne audio et pipeline*
+
+- **Moteur HLS** : segmentation ffmpeg et génération du manifeste, lecture publique sans authentification ([#259](https://github.com/LignacAntony/streampulse/pull/259), [#263](https://github.com/LignacAntony/streampulse/pull/263))
+- **Lecteur audio mobile** : play/pause/volume, lecture en arrière-plan avec contrôles système, gestion des interruptions (appel, casque débranché) ([#273](https://github.com/LignacAntony/streampulse/pull/273), [#282](https://github.com/LignacAntony/streampulse/pull/282), [#286](https://github.com/LignacAntony/streampulse/pull/286))
+- **Infrastructure Docker** : stack LGTM et pipeline CI/CD GitHub Actions + GHCR ([#89](https://github.com/LignacAntony/streampulse/pull/89), [#90](https://github.com/LignacAntony/streampulse/pull/90))
+- Réinitialisation de mot de passe, demande de rôle diffuseur, suppression de compte RGPD ([#120](https://github.com/LignacAntony/streampulse/pull/120), [#129](https://github.com/LignacAntony/streampulse/pull/129), [#130](https://github.com/LignacAntony/streampulse/pull/130))
+- Durcissement sécurité : correction des alertes gosec, timeouts du serveur HTTP ([#93](https://github.com/LignacAntony/streampulse/pull/93), [#288](https://github.com/LignacAntony/streampulse/pull/288))
+
+**Baptiste Ballesteros** — *bibliothèque et expérience utilisateur*
+
+- **Authentification JWT** : access + refresh token avec rotation (backend et mobile) ([#119](https://github.com/LignacAntony/streampulse/pull/119), [#121](https://github.com/LignacAntony/streampulse/pull/121))
+- **Playlists** : création et gestion ([#276](https://github.com/LignacAntony/streampulse/pull/276))
+- **Upload de pistes** dans la bibliothèque, avec quota et validation MIME ([#284](https://github.com/LignacAntony/streampulse/pull/284))
+- **Découverte des flux** en direct et **favoris** ([#256](https://github.com/LignacAntony/streampulse/pull/256), [#266](https://github.com/LignacAntony/streampulse/pull/266))
+- Gestion du profil utilisateur ([#127](https://github.com/LignacAntony/streampulse/pull/127))
+- Initialisation de la base PostgreSQL ([#95](https://github.com/LignacAntony/streampulse/pull/95))
+
+### Statistiques de contribution
+
+Un fichier [`.mailmap`](./.mailmap) fusionne les identités git multiples (chaque contributeur
+ayant committé sous plusieurs emails), afin que les statistiques reflètent la réalité :
+
+```bash
+git shortlog -sne --all
+```
+
+Les [`CODEOWNERS`](./.github/CODEOWNERS) reprennent cette répartition : toute PR touchant un
+périmètre y demande automatiquement la review de son responsable.
+
 ## Contribuer
 
 Lire [CONTRIBUTING.md](./CONTRIBUTING.md) avant d'ouvrir une PR.
+
+## Licence
+
+Ce projet est distribué sous licence **MIT** — voir [LICENSE](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # StreamPulse
 
-> Plateforme StreamPulse — backend Go, application Flutter, déploiement conteneurisé.
+> Plateforme StreamPulse : backend Go, application Flutter, déploiement conteneurisé.
 
 > 🇬🇧 **English version: [README.en.md](README.en.md)** — see the
 > [bilingual scope](docs/README.md#périmètre-bilingue).
@@ -98,20 +98,20 @@ cd mobile && flutter run
 ## Architecture
 
 Vue d'ensemble, schéma des composants, flux d'une requête et chaîne d'observabilité :
-**[docs/architecture.md](./docs/architecture.md)** — *point de départ recommandé*.
+**[docs/architecture.md](./docs/architecture.md)** (*point de départ recommandé*).
 
 | Couche | Principe |
 | --- | --- |
 | **Backend Go** | `net/http` + `http.ServeMux`, **sans framework**. Un package par domaine métier (`auth`, `streaming`, `playlist`, `track`, `admin`…), découpé en `handler` / `service` / `repository` ([ADR 008](./docs/adr/008-architecture-handler-service-repository.md)). Accès SQL typé généré par [sqlc](./docs/adr/007-sqlc-generation-code-sql.md). |
 | **Mobile Flutter** | **Clean Architecture** (`domain` / `data` / `presentation`) + `provider` pour l'état ([ADR 005](./docs/adr/005-architecture-flutter-clean.md)). Le client HTTP est **généré** depuis la spec OpenAPI. |
 | **Contrat HTTP** | La spec OpenAPI est la **source de vérité** ([ADR 012](./docs/adr/012-openapi-source-de-verite.md)) : le client Dart en est dérivé, jamais écrit à la main. |
-| **Observabilité** | Stack LGTM — Loki (logs), Grafana (dashboards + alertes), Tempo (traces), Prometheus (métriques) ([ADR 001](./docs/adr/001-choix-stack-observabilite.md)). |
+| **Observabilité** | Stack LGTM : Loki (logs), Grafana (dashboards + alertes), Tempo (traces), Prometheus (métriques) ([ADR 001](./docs/adr/001-choix-stack-observabilite.md)). |
 
 Toutes les décisions d'architecture significatives sont consignées sous forme d'**ADR**
-(*Architecture Decision Records*) — 38 à ce jour, chacune reliée à son ticket Linear :
+(*Architecture Decision Records*), 38 à ce jour, chacune reliée à son ticket Linear :
 
-- **[Index complet de la documentation](./docs/README.md)** — ordre de lecture recommandé
-- **[Index des ADR](./docs/adr/)** — une décision par fichier, numérotée
+- **[Index complet de la documentation](./docs/README.md)** : ordre de lecture recommandé
+- **[Index des ADR](./docs/adr/)** : une décision par fichier, numérotée
 
 Le code applique les **principes SOLID** de bout en bout : interfaces étroites côté handler Go
 (ISP), injection systématique des dépendances (DIP), entités du domaine sans dépendance infra.
@@ -123,27 +123,27 @@ Le projet compte **40 fichiers de tests Go** et **36 fichiers de tests Flutter**
 en miroir de `mobile/lib/`).
 
 ```bash
-# Backend Go — tous les tests, avec détecteur de data race
+# Backend Go : tous les tests, avec détecteur de data race
 cd backend && go test -race ./...
 ```
 
 ```bash
-# Backend Go — couverture (même commande qu'en CI)
+# Backend Go : couverture (même commande qu'en CI)
 cd backend && go test -race -coverprofile=coverage.txt ./... && go tool cover -func=coverage.txt
 ```
 
 ```bash
-# Backend Go — un seul package
+# Backend Go : un seul package
 cd backend && go test ./internal/streaming/...
 ```
 
 ```bash
-# Mobile Flutter — tests unitaires et widgets
+# Mobile Flutter : tests unitaires et widgets
 cd mobile && flutter test
 ```
 
 ```bash
-# Test de charge HLS — 50 auditeurs simultanés (STR-90, requiert ffmpeg)
+# Test de charge HLS : 50 auditeurs simultanés (STR-90, requiert ffmpeg)
 make loadtest
 ```
 
@@ -153,7 +153,7 @@ permettent de substituer des fakes (ex. `fake_audio_playback_service.dart`).
 
 ### Couverture actuelle (backend Go)
 
-**48,8 %** des instructions sur l'ensemble du module — **54,4 %** en excluant les packages
+**48,8 %** des instructions sur l'ensemble du module, et **54,4 %** en excluant les packages
 `internal/*/db` générés par sqlc, qui ne sont pas censés être testés directement.
 
 | Package | Couverture | | Package | Couverture |
@@ -187,16 +187,16 @@ L'API est déployée en continu sur un **VPS Hetzner**, derrière **Caddy** (HTT
 
 | | |
 | --- | --- |
-| **API de production** | **<https://api.streampulse.win>** — [health](https://api.streampulse.win/health) |
-| **Déclencheur** | **Fin de la CI sur `main`** (`workflow_run`), uniquement si elle est verte — un push ne déploie donc jamais des tests rouges. Aussi déclenchable à la main (`workflow_dispatch`) |
+| **API de production** | **<https://api.streampulse.win>** ([health](https://api.streampulse.win/health)) |
+| **Déclencheur** | **Fin de la CI sur `main`** (`workflow_run`), uniquement si elle est verte : un push ne déploie donc jamais des tests rouges. Aussi déclenchable à la main (`workflow_dispatch`) |
 | **Pipeline** | Build de l'image Docker multi-stage → push sur **GHCR** → déploiement SSH sur le VPS |
 | **Releases** | Automatiques via **release-please** : les Conventional Commits déterminent la version semver, le tag et le [CHANGELOG](./CHANGELOG.md) |
 
 > `/metrics` et les endpoints Swagger ne sont **pas exposés en production** ; le port de l'API
 > est bindé sur `127.0.0.1` et tout transite par Caddy.
 
-**Procédures détaillées** — secrets GitHub à configurer, mise à jour manuelle du compose et des
-configs d'infra, vérifications post-déploiement, troubleshooting :
+**Procédures détaillées** (secrets GitHub à configurer, mise à jour manuelle du compose et des
+configs d'infra, vérifications post-déploiement, troubleshooting) :
 **[docs/infrastructure.md](./docs/infrastructure.md)**.
 
 Les **6 workflows** GitHub Actions du projet :
@@ -238,7 +238,7 @@ Le projet suit la méthodologie [**12-Factor App**](https://12factor.net/fr/conf
 
 1. Copier le template : `cp .env.example .env`
 2. Renseigner les valeurs sensibles (`JWT_SECRET`, mots de passe…)
-3. **Ne jamais committer** `.env` — il est dans `.gitignore` et un check CI (gitleaks + grep) bloque tout secret hardcodé
+3. **Ne jamais committer** `.env` : il est dans `.gitignore` et un check CI (gitleaks + grep) bloque tout secret hardcodé
 
 ### Variables disponibles
 
@@ -246,50 +246,50 @@ Le projet suit la méthodologie [**12-Factor App**](https://12factor.net/fr/conf
 | --- | --- | --- | --- | --- |
 | `GO_ENV` | Environnement d'exécution (`development`, `production`, `test`) | `development` | non | `production` |
 | `API_PORT` | Port d'écoute HTTP de l'API Go | `8080` | non | `8080` |
-| `JWT_SECRET` | Clé de signature des JWT — **min. 32 caractères** | — | **oui** | `<chaîne aléatoire ≥ 32 chars>` |
+| `JWT_SECRET` | Clé de signature des JWT, **min. 32 caractères** | aucun | **oui** | `<chaîne aléatoire ≥ 32 chars>` |
 | `DB_HOST` | Hôte PostgreSQL | `localhost` | non | `postgres` (en compose) |
 | `DB_PORT` | Port PostgreSQL | `5432` | non | `5432` |
-| `DB_USER` | Utilisateur PostgreSQL | — | **oui** | `streampulse` |
-| `DB_PASSWORD` | Mot de passe PostgreSQL | — | **oui** | `<mot de passe fort>` |
-| `DB_NAME` | Nom de la base PostgreSQL | — | **oui** | `streampulse_db` |
-| `INGEST_RECONNECT_GRACE_SECONDS` | Délai sans audio avant l'arrêt automatique d'un live (doit dépasser 30 s, le backoff mobile max — refusé au démarrage sinon) | `45` | non | `45` |
+| `DB_USER` | Utilisateur PostgreSQL | aucun | **oui** | `streampulse` |
+| `DB_PASSWORD` | Mot de passe PostgreSQL | aucun | **oui** | `<mot de passe fort>` |
+| `DB_NAME` | Nom de la base PostgreSQL | aucun | **oui** | `streampulse_db` |
+| `INGEST_RECONNECT_GRACE_SECONDS` | Délai sans audio avant l'arrêt automatique d'un live (doit dépasser 30 s, le backoff mobile max, sinon l'API refuse de démarrer) | `45` | non | `45` |
 | `INGEST_STOP_TIMEOUT_SECONDS` | Timeout d'une tentative d'arrêt automatique en base | `10` | non | `10` |
-| `POSTGRES_USER` | Alias compose pour `DB_USER` (init du conteneur Postgres) | — | **oui (compose)** | `streampulse` |
-| `POSTGRES_PASSWORD` | Alias compose pour `DB_PASSWORD` | — | **oui (compose)** | `<mot de passe fort>` |
-| `POSTGRES_DB` | Alias compose pour `DB_NAME` | — | **oui (compose)** | `streampulse_db` |
-| `DATABASE_URL` | DSN PostgreSQL complète. Utilisée par le **migrator** au démarrage, et en **fallback** du pool si les `DB_*` ne sont pas résolues | — | **oui (compose)** | `pgx5://user:pwd@postgres:5432/streampulse_db?sslmode=disable` |
-| `GRAFANA_ADMIN_PASSWORD` | Mot de passe admin Grafana | — | **oui (compose)** | `<mot de passe fort>` |
+| `POSTGRES_USER` | Alias compose pour `DB_USER` (init du conteneur Postgres) | aucun | **oui (compose)** | `streampulse` |
+| `POSTGRES_PASSWORD` | Alias compose pour `DB_PASSWORD` | aucun | **oui (compose)** | `<mot de passe fort>` |
+| `POSTGRES_DB` | Alias compose pour `DB_NAME` | aucun | **oui (compose)** | `streampulse_db` |
+| `DATABASE_URL` | DSN PostgreSQL complète. Utilisée par le **migrator** au démarrage, et en **fallback** du pool si les `DB_*` ne sont pas résolues | aucun | **oui (compose)** | `pgx5://user:pwd@postgres:5432/streampulse_db?sslmode=disable` |
+| `GRAFANA_ADMIN_PASSWORD` | Mot de passe admin Grafana | aucun | **oui (compose)** | `<mot de passe fort>` |
 
-**Email (réinitialisation de mot de passe, alertes)** — laisser `SMTP_HOST` vide affiche les
+**Email (réinitialisation de mot de passe, alertes)** : laisser `SMTP_HOST` vide affiche les
 tokens dans les logs (mode dev) ; en local, `mailpit` sert de relay de test (UI sur
 `http://localhost:8025`).
 
 | Variable | Description | Défaut | Requis | Exemple |
 | --- | --- | --- | --- | --- |
-| `SMTP_HOST` | Serveur SMTP. **Vide = mode log stdout** (aucun email envoyé) | — | non | `mailpit` (dev) / `smtp-relay.brevo.com` |
-| `SMTP_PORT` | Port SMTP (STARTTLS) | — (`587` dans `.env.example`) | non | `1025` (mailpit) / `587` |
-| `SMTP_USERNAME` | Utilisateur du relay SMTP | — | non | `postmaster@streampulse.com` |
-| `SMTP_PASSWORD` | Mot de passe du relay SMTP | — | non | `<mot de passe smtp>` |
-| `SMTP_FROM` | Adresse expéditeur des emails | — (`noreply@streampulse.com` dans `.env.example`) | non | `noreply@streampulse.com` |
-| `APP_BASE_URL` | Schéma d'URL des liens contenus dans les emails — **deep link** vers l'app Flutter | — (`streampulse://app` dans `.env.example`) | non | `streampulse://app` |
+| `SMTP_HOST` | Serveur SMTP. **Vide = mode log stdout** (aucun email envoyé) | aucun | non | `mailpit` (dev) / `smtp-relay.brevo.com` |
+| `SMTP_PORT` | Port SMTP (STARTTLS) | aucun (`587` dans `.env.example`) | non | `1025` (mailpit) / `587` |
+| `SMTP_USERNAME` | Utilisateur du relay SMTP | aucun | non | `postmaster@streampulse.com` |
+| `SMTP_PASSWORD` | Mot de passe du relay SMTP | aucun | non | `<mot de passe smtp>` |
+| `SMTP_FROM` | Adresse expéditeur des emails | aucun (`noreply@streampulse.com` dans `.env.example`) | non | `noreply@streampulse.com` |
+| `APP_BASE_URL` | Schéma d'URL des liens contenus dans les emails, **deep link** vers l'app Flutter | aucun (`streampulse://app` dans `.env.example`) | non | `streampulse://app` |
 
 **Réseau, streaming et stockage**
 
 | Variable | Description | Défaut | Requis | Exemple |
 | --- | --- | --- | --- | --- |
-| `CORS_ALLOWED_ORIGINS` | Origines CORS autorisées, séparées par des virgules. En dev, `localhost` / `127.0.0.1` sont autorisés d'office quel que soit le port | — | non | `https://app.streampulse.com` |
+| `CORS_ALLOWED_ORIGINS` | Origines CORS autorisées, séparées par des virgules. En dev, `localhost` / `127.0.0.1` sont autorisés d'office quel que soit le port | aucun | non | `https://app.streampulse.com` |
 | `STREAM_INGEST_BASE_URL` | Préfixe de l'URL d'ingest renvoyée au diffuseur : `{base}/api/streams/ingest/{stream_key}` ([ADR 013](./docs/adr/013-domaine-streaming.md)) | `http://localhost:8080` | non | `https://api.streampulse.win` |
 | `STORAGE_PATH` | Répertoire racine des fichiers audio uploadés, **hors répertoire servi** ([ADR 032](./docs/adr/032-domaine-track-upload-audio.md)) | `./data/tracks` | non | `/data/tracks` (volume Docker) |
 | `HLS_MAX_CONCURRENT` | Nombre max de requêtes HLS servies simultanément aux auditeurs. `0` = illimité ([ADR 016](./docs/adr/016-scalabilite-test-de-charge-et-limiteur-hls.md)) | `256` | non | `256` |
-| `TRUST_PROXY_HEADERS` | Lire `X-Forwarded-For` pour identifier les auditeurs (comptage d'audience). **`true` uniquement derrière un reverse proxy** — sinon l'en-tête est falsifiable, et sans proxy le compteur sature à 1 ([ADR 025](./docs/adr/025-statistiques-daudience-en-temps-reel.md)) | `false` | non | `true` (prod) |
+| `TRUST_PROXY_HEADERS` | Lire `X-Forwarded-For` pour identifier les auditeurs (comptage d'audience). **`true` uniquement derrière un reverse proxy** : sinon l'en-tête est falsifiable, et sans proxy le compteur sature à 1 ([ADR 025](./docs/adr/025-statistiques-daudience-en-temps-reel.md)) | `false` | non | `true` (prod) |
 
 **Observabilité**
 
 | Variable | Description | Défaut | Requis | Exemple |
 | --- | --- | --- | --- | --- |
 | `LOG_LEVEL` | Niveau minimal des logs JSON : `trace`, `debug`, `info`, `warn`, `error` ([ADR 018](./docs/adr/018-logs-structures-zerolog-collecte-loki-alloy.md)) | `info` | non | `info` |
-| `LOG_PRETTY` | Sortie console lisible — réservée au `go run` local. **Jamais en conteneur** : la collecte Loki attend du JSON | `false` | non | `true` (dev natif) |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | Endpoint OTLP/HTTP de Tempo pour les traces. **Vide = tracing désactivé** ([ADR 020](./docs/adr/020-traces-opentelemetry-otlp-tempo.md)) | — | non | `http://tempo:4318` |
+| `LOG_PRETTY` | Sortie console lisible, réservée au `go run` local. **Jamais en conteneur** : la collecte Loki attend du JSON | `false` | non | `true` (dev natif) |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Endpoint OTLP/HTTP de Tempo pour les traces. **Vide = tracing désactivé** ([ADR 020](./docs/adr/020-traces-opentelemetry-otlp-tempo.md)) | aucun | non | `http://tempo:4318` |
 
 ### Implémentation
 
@@ -313,7 +313,7 @@ Le repository suit un modèle **Git Flow simplifié** :
 
 | Branche | Rôle |
 | --- | --- |
-| `main` | Code de production. Protégée — merge uniquement via PR approuvée. |
+| `main` | Code de production. Protégée : merge uniquement via PR approuvée. |
 | `develop` | Branche d'intégration. Toutes les features y sont mergées. |
 | `feature/<ticket>-<slug>` | Branches de feature, partent de `develop`. |
 | `fix/<ticket>-<slug>` | Branches de correctifs. |
@@ -352,8 +352,8 @@ Les **titres de PR** sont validés automatiquement via GitHub Actions. Voir [CON
 
 ## Équipe et répartition des tâches
 
-Projet réalisé par **3 développeurs**. Chacun a porté ses fonctionnalités de bout en bout —
-backend, mobile, documentation et ADR — plutôt qu'une séparation stricte par couche technique.
+Projet réalisé par **3 développeurs**. Chacun a porté ses fonctionnalités de bout en bout
+(backend, mobile, documentation et ADR) plutôt qu'une séparation stricte par couche technique.
 
 | Contributeur | GitHub | Périmètre principal |
 | --- | --- | --- |
@@ -363,7 +363,7 @@ backend, mobile, documentation et ADR — plutôt qu'une séparation stricte par
 
 ### Détail par domaine
 
-**Antony Lignac** — *fondations du projet et de l'infra*
+**Antony Lignac** : *fondations du projet et de l'infra*
 
 - Initialisation du dépôt et configuration 12-Factor via Viper ([#88](https://github.com/LignacAntony/streampulse/pull/88), [#101](https://github.com/LignacAntony/streampulse/pull/101))
 - Domaine **streaming** : création/configuration d'un flux, démarrage et arrêt du direct, rotation de la clé de diffusion, transcodage à la volée des formats d'ingest ([#128](https://github.com/LignacAntony/streampulse/pull/128), [#257](https://github.com/LignacAntony/streampulse/pull/257), [#279](https://github.com/LignacAntony/streampulse/pull/279), [#281](https://github.com/LignacAntony/streampulse/pull/281))
@@ -373,7 +373,7 @@ backend, mobile, documentation et ADR — plutôt qu'une séparation stricte par
 - Mobile : capture micro et push AAC, tableau de bord diffuseur, file d'attente de lecture, modes aléatoire/répétition, barre de progression ([#274](https://github.com/LignacAntony/streampulse/pull/274), [#278](https://github.com/LignacAntony/streampulse/pull/278), [#287](https://github.com/LignacAntony/streampulse/pull/287), [#289](https://github.com/LignacAntony/streampulse/pull/289), [#292](https://github.com/LignacAntony/streampulse/pull/292))
 - OpenAPI comme source de vérité + client Dart généré ([#126](https://github.com/LignacAntony/streampulse/pull/126))
 
-**Thierry Maignan** — *chaîne audio et pipeline*
+**Thierry Maignan** : *chaîne audio et pipeline*
 
 - **Moteur HLS** : segmentation ffmpeg et génération du manifeste, lecture publique sans authentification ([#259](https://github.com/LignacAntony/streampulse/pull/259), [#263](https://github.com/LignacAntony/streampulse/pull/263))
 - **Lecteur audio mobile** : play/pause/volume, lecture en arrière-plan avec contrôles système, gestion des interruptions (appel, casque débranché) ([#273](https://github.com/LignacAntony/streampulse/pull/273), [#282](https://github.com/LignacAntony/streampulse/pull/282), [#286](https://github.com/LignacAntony/streampulse/pull/286))
@@ -381,7 +381,7 @@ backend, mobile, documentation et ADR — plutôt qu'une séparation stricte par
 - Réinitialisation de mot de passe, demande de rôle diffuseur, suppression de compte RGPD ([#120](https://github.com/LignacAntony/streampulse/pull/120), [#129](https://github.com/LignacAntony/streampulse/pull/129), [#130](https://github.com/LignacAntony/streampulse/pull/130))
 - Durcissement sécurité : correction des alertes gosec, timeouts du serveur HTTP ([#93](https://github.com/LignacAntony/streampulse/pull/93), [#288](https://github.com/LignacAntony/streampulse/pull/288))
 
-**Baptiste Ballesteros** — *bibliothèque et expérience utilisateur*
+**Baptiste Ballesteros** : *bibliothèque et expérience utilisateur*
 
 - **Authentification JWT** : access + refresh token avec rotation (backend et mobile) ([#119](https://github.com/LignacAntony/streampulse/pull/119), [#121](https://github.com/LignacAntony/streampulse/pull/121))
 - **Playlists** : création et gestion ([#276](https://github.com/LignacAntony/streampulse/pull/276))
@@ -408,4 +408,4 @@ Lire [CONTRIBUTING.md](./CONTRIBUTING.md) avant d'ouvrir une PR.
 
 ## Licence
 
-Ce projet est distribué sous licence **MIT** — voir [LICENSE](./LICENSE).
+Ce projet est distribué sous licence **MIT**, voir [LICENSE](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -162,14 +162,14 @@ permettent de substituer des fakes (ex. `fake_audio_playback_service.dart`).
 Le sujet demande **80 % minimum** en test unitaire, sur un périmètre déclaré. Une **porte de CI
 échoue sous 80 %** sur ce périmètre (handlers, services, repositories, middlewares, configuration,
 observabilité) : la couverture ne peut plus se dégrader sous le seuil sans bloquer la PR. Le
-relevé courant est de **81,05 %** sur ce périmètre (**63,6 %** brut, tout inclus), tenu à jour
-dans le document de couverture lié ci-dessous.
+relevé courant, au-dessus du seuil, est tenu à jour dans le document de couverture lié ci-dessous
+(il bouge à chaque merge, d'où l'absence de décimale figée ici).
 
 Quatre familles sont exclues du calcul, chacune pour une raison assumée et appliquée par un
 script (pas par convention orale) : le code généré par sqlc (`internal/*/db`), la racine de
 composition `cmd/api` (câblage des routes, qui demande un test de bout en bout encore à écrire),
-les enveloppes minces de `internal/infrastructure` (exercées via les tests d'intégration) et le
-socle de test `internal/testsupport`.
+les enveloppes minces de `internal/infrastructure` (enveloppes de pilotes tiers, non testées à ce
+jour) et le socle de test `internal/testsupport`.
 
 Deux familles de tests, **toutes deux rejouées en CI à chaque PR** :
 
@@ -376,8 +376,8 @@ Projet réalisé par **3 développeurs**. Chacun a porté ses fonctionnalités d
 | Contributeur | GitHub | Périmètre principal |
 | --- | --- | --- |
 | **Antony Lignac** | [@LignacAntony](https://github.com/LignacAntony) | Backend Go, infrastructure, observabilité, streaming, administration |
-| **Thierry Maignan** | [@thierrymgn](https://github.com/thierrymgn) | Moteur HLS, lecteur audio mobile, authentification, CI/CD |
-| **Baptiste Ballesteros** | [@Oceloott](https://github.com/Oceloott) | Bibliothèque, playlists, favoris, profil utilisateur |
+| **Thierry Maignan** | [@thierrymgn](https://github.com/thierrymgn) | Moteur HLS, lecteur audio mobile, parcours de compte (mot de passe, rôles, RGPD), CI/CD |
+| **Baptiste Ballesteros** | [@Oceloott](https://github.com/Oceloott) | Authentification JWT, bibliothèque, playlists, favoris, profil utilisateur |
 
 ### Détail par domaine
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Vue d'ensemble, schéma des composants, flux d'une requête et chaîne d'observa
 | **Observabilité** | Stack LGTM : Loki (logs), Grafana (dashboards + alertes), Tempo (traces), Prometheus (métriques) ([ADR 001](./docs/adr/001-choix-stack-observabilite.md)). |
 
 Toutes les décisions d'architecture significatives sont consignées sous forme d'**ADR**
-(*Architecture Decision Records*), 38 à ce jour, chacune reliée à son ticket Linear :
+(*Architecture Decision Records*), 44 à ce jour, chacune reliée à son ticket Linear :
 
 - **[Index complet de la documentation](./docs/README.md)** : ordre de lecture recommandé
 - **[Index des ADR](./docs/adr/)** : une décision par fichier, numérotée
@@ -118,7 +118,7 @@ Le code applique les **principes SOLID** de bout en bout : interfaces étroites 
 
 ## Tests
 
-Le projet compte **40 fichiers de tests Go** et **36 fichiers de tests Flutter**. Les tests sont
+Le projet compte **51 fichiers de tests Go** et **51 fichiers de tests Flutter**. Les tests sont
 **colocalisés avec le code** qu'ils couvrent (`*_test.go` à côté du package, `mobile/test/`
 en miroir de `mobile/lib/`).
 
@@ -147,34 +147,48 @@ cd mobile && flutter test
 make loadtest
 ```
 
+```bash
+# Preuves de performance (STR-243, voir docs/performance-mobile.md)
+make loadtest-cpu               # coût CPU de N flux simultanés (~15 min, sans -race)
+make frame-budget DEVICE=<id>   # relevé de fluidité 60 FPS sur appareil réel
+```
+
 **Conventions** : tests Go en **stdlib uniquement** (pas de testify), stubs légers pour les
 handlers et `fakeRepo` en mémoire pour les services ; côté Flutter, les abstractions du domaine
 permettent de substituer des fakes (ex. `fake_audio_playback_service.dart`).
 
-### Couverture actuelle (backend Go)
+### Couverture des tests
 
-**48,8 %** des instructions sur l'ensemble du module, et **54,4 %** en excluant les packages
-`internal/*/db` générés par sqlc, qui ne sont pas censés être testés directement.
+Le sujet demande **80 % minimum** en test unitaire, sur un périmètre déclaré. Une **porte de CI
+échoue sous 80 %** sur ce périmètre (handlers, services, repositories, middlewares, configuration,
+observabilité) : la couverture ne peut plus se dégrader sous le seuil sans bloquer la PR. Le
+relevé courant est de **81,05 %** sur ce périmètre (**63,6 %** brut, tout inclus), tenu à jour
+dans le document de couverture lié ci-dessous.
 
-| Package | Couverture | | Package | Couverture |
-| --- | --- | --- | --- | --- |
-| `observability` | 94,1 % | | `streaming` | 65,6 % |
-| `shared/httpmw` | 94,0 % | | `auth` | 62,7 % |
-| `config` | 81,3 % | | `track` | 57,4 % |
-| `shared/httpjson` | 75,8 % | | `profiles` | 54,0 % |
-| `openapi` | 73,3 % | | `admin` | 52,4 % |
-| | | | `broadcaster` | 44,8 % |
-| | | | `shared/apperror` | 40,9 % |
-| | | | `playlist` | 40,0 % |
+Quatre familles sont exclues du calcul, chacune pour une raison assumée et appliquée par un
+script (pas par convention orale) : le code généré par sqlc (`internal/*/db`), la racine de
+composition `cmd/api` (câblage des routes, qui demande un test de bout en bout encore à écrire),
+les enveloppes minces de `internal/infrastructure` (exercées via les tests d'intégration) et le
+socle de test `internal/testsupport`.
 
-> Chiffres obtenus avec `go test -coverprofile` sur le module complet. Les packages
-> `infrastructure/*` (migrator, seeder, pool) et `cmd/api` sont à 0 % : ils sont couverts par
-> les tests d'intégration sous build tag `integration`, exclus de `go test ./...`.
+Deux familles de tests, **toutes deux rejouées en CI à chaque PR** :
+
+- **unitaires** (`go test ./...`) : handlers contre des stubs, services contre des dépôts en
+  mémoire, fonctions pures ; aucune dépendance externe ;
+- **d'intégration** (`go test -tags integration ./...`) : repositories contre un vrai
+  PostgreSQL, pour vérifier les règles qui vivent dans le **schéma** (unicité, cascades,
+  contraintes différées) et qu'un dépôt en mémoire laisserait passer.
+
+Côté Flutter, la couverture est à **~68 %**, sans seuil gardé (le sujet ne l'exige que pour le Go).
+
+> Périmètre chiffré, exclusions justifiées et procédure de rejeu (`make coverage` /
+> `make coverage-gate`) : **[docs/couverture-de-tests.md](./docs/couverture-de-tests.md)**.
 
 ### Intégration continue
 
-La **CI rejoue lint → tests → build à chaque PR** (et sur `develop` / `main`) et publie
-`coverage.txt` en artefact téléchargeable depuis l'onglet *Actions*.
+La **CI rejoue à chaque PR** (et sur `develop` / `main`) : lint Go, **tests unitaires et
+d'intégration avec la porte de couverture**, build du binaire, puis analyse et tests Flutter.
+Le profil `coverage.txt` est publié en artefact téléchargeable depuis l'onglet *Actions*.
 
 Le **test de charge ne tourne pas sur les PR** : le harnais vivant sous *build tag*, la CI
 garantit seulement qu'il **compile** (`go vet -tags loadtest`). Son exécution réelle est un
@@ -252,12 +266,12 @@ Le projet suit la méthodologie [**12-Factor App**](https://12factor.net/fr/conf
 | `DB_USER` | Utilisateur PostgreSQL | aucun | **oui** | `streampulse` |
 | `DB_PASSWORD` | Mot de passe PostgreSQL | aucun | **oui** | `<mot de passe fort>` |
 | `DB_NAME` | Nom de la base PostgreSQL | aucun | **oui** | `streampulse_db` |
+| `DB_SSLMODE` | Mode TLS de la connexion PostgreSQL. `disable` convient au réseau interne Docker ; une base managée exigera `require` ou `verify-full` | `disable` | non | `disable` |
 | `INGEST_RECONNECT_GRACE_SECONDS` | Délai sans audio avant l'arrêt automatique d'un live (doit dépasser 30 s, le backoff mobile max, sinon l'API refuse de démarrer) | `45` | non | `45` |
 | `INGEST_STOP_TIMEOUT_SECONDS` | Timeout d'une tentative d'arrêt automatique en base | `10` | non | `10` |
 | `POSTGRES_USER` | Alias compose pour `DB_USER` (init du conteneur Postgres) | aucun | **oui (compose)** | `streampulse` |
 | `POSTGRES_PASSWORD` | Alias compose pour `DB_PASSWORD` | aucun | **oui (compose)** | `<mot de passe fort>` |
 | `POSTGRES_DB` | Alias compose pour `DB_NAME` | aucun | **oui (compose)** | `streampulse_db` |
-| `DATABASE_URL` | DSN PostgreSQL complète. Utilisée par le **migrator** au démarrage, et en **fallback** du pool si les `DB_*` ne sont pas résolues | aucun | **oui (compose)** | `pgx5://user:pwd@postgres:5432/streampulse_db?sslmode=disable` |
 | `GRAFANA_ADMIN_PASSWORD` | Mot de passe admin Grafana | aucun | **oui (compose)** | `<mot de passe fort>` |
 
 **Email (réinitialisation de mot de passe, alertes)** : laisser `SMTP_HOST` vide affiche les
@@ -272,11 +286,15 @@ tokens dans les logs (mode dev) ; en local, `mailpit` sert de relay de test (UI 
 | `SMTP_PASSWORD` | Mot de passe du relay SMTP | aucun | non | `<mot de passe smtp>` |
 | `SMTP_FROM` | Adresse expéditeur des emails | aucun (`noreply@streampulse.com` dans `.env.example`) | non | `noreply@streampulse.com` |
 | `APP_BASE_URL` | Schéma d'URL des liens contenus dans les emails, **deep link** vers l'app Flutter | aucun (`streampulse://app` dans `.env.example`) | non | `streampulse://app` |
+| `ALERT_EMAIL_TO` | Destinataire des alertes Grafana (consommé par **Grafana**, pas par l'API). Défaut `.invalid` non délivrable en dev ; **obligatoire en prod** (STR-244, [ADR 041](./docs/adr/041-metriques-metier-debit-departs-et-resume-admin.md)) | `alertes@streampulse.invalid` | **oui (prod)** | `equipe@streampulse.com` |
 
-**Réseau, streaming et stockage**
+**Serveur HTTP, réseau, streaming et stockage**
 
 | Variable | Description | Défaut | Requis | Exemple |
 | --- | --- | --- | --- | --- |
+| `HTTP_READ_TIMEOUT_SECONDS` | Timeout de lecture du serveur HTTP, en secondes. Les chemins longs (ingest audio, SSE) gèrent leurs propres échéances | `5` | non | `5` |
+| `HTTP_WRITE_TIMEOUT_SECONDS` | Timeout d'écriture du serveur HTTP, en secondes | `10` | non | `10` |
+| `HTTP_IDLE_TIMEOUT_SECONDS` | Timeout d'inactivité des connexions keep-alive, en secondes | `120` | non | `120` |
 | `CORS_ALLOWED_ORIGINS` | Origines CORS autorisées, séparées par des virgules. En dev, `localhost` / `127.0.0.1` sont autorisés d'office quel que soit le port | aucun | non | `https://app.streampulse.com` |
 | `STREAM_INGEST_BASE_URL` | Préfixe de l'URL d'ingest renvoyée au diffuseur : `{base}/api/streams/ingest/{stream_key}` ([ADR 013](./docs/adr/013-domaine-streaming.md)) | `http://localhost:8080` | non | `https://api.streampulse.win` |
 | `STORAGE_PATH` | Répertoire racine des fichiers audio uploadés, **hors répertoire servi** ([ADR 032](./docs/adr/032-domaine-track-upload-audio.md)) | `./data/tracks` | non | `/data/tracks` (volume Docker) |

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -44,7 +44,7 @@ Aucune valeur secrète ne doit être committée dans le dépôt.
 | `POSTGRES_USER` | postgres | Utilisateur PostgreSQL (init du volume) | `streampulse` | Oui |
 | `POSTGRES_PASSWORD` | postgres | Mot de passe PostgreSQL (init du volume) | `changeme` | **Oui — à changer** |
 | `POSTGRES_DB` | postgres | Nom de la base de données (init du volume) | `streampulse_db` | Oui |
-| `DATABASE_URL` | api | DSN complète, lue par le migrator au démarrage et en fallback du pool | — | Oui |
+| `DATABASE_URL` | api | DSN complète, lue par le migrator au démarrage et en fallback du pool | aucun | Oui |
 | `GRAFANA_ADMIN_PASSWORD` | grafana | Mot de passe admin Grafana | `changeme` | **Oui — à changer** |
 | `API_PORT` | api / hôte | Port exposé de l'API Go sur l'hôte | `8080` | Non |
 
@@ -58,19 +58,19 @@ caractères → l'API refuse de démarrer.
 |---|---|---|---|
 | `GO_ENV` | Environnement (`development` / `production` / `test`) | `development` | Non |
 | `API_PORT` | Port d'écoute HTTP de l'API | `8080` | Non |
-| `JWT_SECRET` | Clé de signature des JWT — **min. 32 caractères** | — | **Oui** |
+| `JWT_SECRET` | Clé de signature des JWT, **min. 32 caractères** | aucun | **Oui** |
 | `DB_HOST` | Hôte PostgreSQL (`postgres` en compose, `localhost` en dev natif) | `localhost` | Non |
 | `DB_PORT` | Port PostgreSQL | `5432` | Non |
-| `DB_USER` | Utilisateur PostgreSQL | — | **Oui** |
-| `DB_PASSWORD` | Mot de passe PostgreSQL | — | **Oui** |
-| `DB_NAME` | Nom de la base PostgreSQL | — | **Oui** |
+| `DB_USER` | Utilisateur PostgreSQL | aucun | **Oui** |
+| `DB_PASSWORD` | Mot de passe PostgreSQL | aucun | **Oui** |
+| `DB_NAME` | Nom de la base PostgreSQL | aucun | **Oui** |
 | `INGEST_RECONNECT_GRACE_SECONDS` | Délai sans audio avant l'arrêt automatique d'un live (doit dépasser 30 s, le backoff mobile max — refusé au démarrage sinon) | `45` | Non |
 | `INGEST_STOP_TIMEOUT_SECONDS` | Timeout d'une tentative d'arrêt automatique en base | `10` | Non |
-| `CORS_ALLOWED_ORIGINS` | Origines CORS autorisées, séparées par des virgules. En développement, `localhost` / `127.0.0.1` sont autorisés d'office quel que soit le port — cette variable sert surtout en production | — | Non |
+| `CORS_ALLOWED_ORIGINS` | Origines CORS autorisées, séparées par des virgules. En développement, `localhost` / `127.0.0.1` sont autorisés d'office quel que soit le port ; cette variable sert surtout en production | aucun | Non |
 | `STREAM_INGEST_BASE_URL` | Préfixe de l'URL d'ingest renvoyée au diffuseur : `{base}/api/streams/ingest/{stream_key}` (cf. [ADR 013](./adr/013-domaine-streaming.md)) | `http://localhost:8080` | Non |
 | `STORAGE_PATH` | Répertoire racine des fichiers audio uploadés, hors répertoire servi. Monté sur le volume `track_storage` en compose (cf. [ADR 032](./adr/032-domaine-track-upload-audio.md)) | `./data/tracks` | Non |
 | `HLS_MAX_CONCURRENT` | Nombre max de requêtes HLS (playlist + segments) servies simultanément aux auditeurs. `0` = illimité (cf. [ADR 016](./adr/016-scalabilite-test-de-charge-et-limiteur-hls.md)) | `256` | Non |
-| `TRUST_PROXY_HEADERS` | Autorise la lecture de `X-Forwarded-For` pour identifier les auditeurs. **`true` uniquement derrière un reverse proxy** qui réécrit l'en-tête — sinon il est falsifiable, et sans proxy tous les auditeurs partagent l'adresse du proxy (compteur saturé à 1). Cf. [ADR 025](./adr/025-statistiques-daudience-en-temps-reel.md) | `false` | Non |
+| `TRUST_PROXY_HEADERS` | Autorise la lecture de `X-Forwarded-For` pour identifier les auditeurs. **`true` uniquement derrière un reverse proxy** qui réécrit l'en-tête ; sinon il est falsifiable, et sans proxy tous les auditeurs partagent l'adresse du proxy (compteur saturé à 1). Cf. [ADR 025](./adr/025-statistiques-daudience-en-temps-reel.md) | `false` | Non |
 | `LOG_PRETTY` | Sortie console lisible, réservée au `go run` local. **Ne jamais activer en conteneur** : la collecte Loki attend du JSON | `false` | Non |
 
 #### Variables SMTP (emails transactionnels)
@@ -81,12 +81,12 @@ aucun email n'est envoyé, les tokens apparaissent dans les logs de l'API. En lo
 
 | Variable | Description | Valeur par défaut | Obligatoire |
 |---|---|---|---|
-| `SMTP_HOST` | Serveur SMTP. Vide = mode log stdout | — | Non |
-| `SMTP_PORT` | Port SMTP (STARTTLS). `1025` avec mailpit, `587` sur un relay externe | — (`587` dans `.env.example`) | Non |
-| `SMTP_USERNAME` | Utilisateur du relay SMTP (vide avec mailpit) | — | Non |
-| `SMTP_PASSWORD` | Mot de passe du relay SMTP (vide avec mailpit) | — | Non |
-| `SMTP_FROM` | Adresse expéditeur des emails | — (`noreply@streampulse.com` dans `.env.example`) | Non |
-| `APP_BASE_URL` | Schéma d'URL des liens contenus dans les emails — deep link vers l'app Flutter | — (`streampulse://app` dans `.env.example`) | Non |
+| `SMTP_HOST` | Serveur SMTP. Vide = mode log stdout | aucun | Non |
+| `SMTP_PORT` | Port SMTP (STARTTLS). `1025` avec mailpit, `587` sur un relay externe | aucun (`587` dans `.env.example`) | Non |
+| `SMTP_USERNAME` | Utilisateur du relay SMTP (vide avec mailpit) | aucun | Non |
+| `SMTP_PASSWORD` | Mot de passe du relay SMTP (vide avec mailpit) | aucun | Non |
+| `SMTP_FROM` | Adresse expéditeur des emails | aucun (`noreply@streampulse.com` dans `.env.example`) | Non |
+| `APP_BASE_URL` | Schéma d'URL des liens contenus dans les emails, deep link vers l'app Flutter | aucun (`streampulse://app` dans `.env.example`) | Non |
 
 > ⚠️ Ces variables n'ont **pas de valeur par défaut dans le code** : elles sont déclarées sans
 > `def:` dans `envKeys` ([`backend/internal/config/config.go`](../backend/internal/config/config.go)).

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -44,6 +44,7 @@ Aucune valeur secrète ne doit être committée dans le dépôt.
 | `POSTGRES_USER` | postgres | Utilisateur PostgreSQL (init du volume) | `streampulse` | Oui |
 | `POSTGRES_PASSWORD` | postgres | Mot de passe PostgreSQL (init du volume) | `changeme` | **Oui — à changer** |
 | `POSTGRES_DB` | postgres | Nom de la base de données (init du volume) | `streampulse_db` | Oui |
+| `DATABASE_URL` | api | DSN complète, lue par le migrator au démarrage et en fallback du pool | — | Oui |
 | `GRAFANA_ADMIN_PASSWORD` | grafana | Mot de passe admin Grafana | `changeme` | **Oui — à changer** |
 | `API_PORT` | api / hôte | Port exposé de l'API Go sur l'hôte | `8080` | Non |
 
@@ -65,6 +66,32 @@ caractères → l'API refuse de démarrer.
 | `DB_NAME` | Nom de la base PostgreSQL | — | **Oui** |
 | `INGEST_RECONNECT_GRACE_SECONDS` | Délai sans audio avant l'arrêt automatique d'un live (doit dépasser 30 s, le backoff mobile max — refusé au démarrage sinon) | `45` | Non |
 | `INGEST_STOP_TIMEOUT_SECONDS` | Timeout d'une tentative d'arrêt automatique en base | `10` | Non |
+| `CORS_ALLOWED_ORIGINS` | Origines CORS autorisées, séparées par des virgules. En développement, `localhost` / `127.0.0.1` sont autorisés d'office quel que soit le port — cette variable sert surtout en production | — | Non |
+| `STREAM_INGEST_BASE_URL` | Préfixe de l'URL d'ingest renvoyée au diffuseur : `{base}/api/streams/ingest/{stream_key}` (cf. [ADR 013](./adr/013-domaine-streaming.md)) | `http://localhost:8080` | Non |
+| `STORAGE_PATH` | Répertoire racine des fichiers audio uploadés, hors répertoire servi. Monté sur le volume `track_storage` en compose (cf. [ADR 032](./adr/032-domaine-track-upload-audio.md)) | `./data/tracks` | Non |
+| `HLS_MAX_CONCURRENT` | Nombre max de requêtes HLS (playlist + segments) servies simultanément aux auditeurs. `0` = illimité (cf. [ADR 016](./adr/016-scalabilite-test-de-charge-et-limiteur-hls.md)) | `256` | Non |
+| `TRUST_PROXY_HEADERS` | Autorise la lecture de `X-Forwarded-For` pour identifier les auditeurs. **`true` uniquement derrière un reverse proxy** qui réécrit l'en-tête — sinon il est falsifiable, et sans proxy tous les auditeurs partagent l'adresse du proxy (compteur saturé à 1). Cf. [ADR 025](./adr/025-statistiques-daudience-en-temps-reel.md) | `false` | Non |
+| `LOG_PRETTY` | Sortie console lisible, réservée au `go run` local. **Ne jamais activer en conteneur** : la collecte Loki attend du JSON | `false` | Non |
+
+#### Variables SMTP (emails transactionnels)
+
+Utilisées pour la réinitialisation de mot de passe. **`SMTP_HOST` vide = mode log stdout** :
+aucun email n'est envoyé, les tokens apparaissent dans les logs de l'API. En local, le service
+`mailpit` sert de relay de test (interface web sur `http://localhost:8025`).
+
+| Variable | Description | Valeur par défaut | Obligatoire |
+|---|---|---|---|
+| `SMTP_HOST` | Serveur SMTP. Vide = mode log stdout | — | Non |
+| `SMTP_PORT` | Port SMTP (STARTTLS). `1025` avec mailpit, `587` sur un relay externe | — (`587` dans `.env.example`) | Non |
+| `SMTP_USERNAME` | Utilisateur du relay SMTP (vide avec mailpit) | — | Non |
+| `SMTP_PASSWORD` | Mot de passe du relay SMTP (vide avec mailpit) | — | Non |
+| `SMTP_FROM` | Adresse expéditeur des emails | — (`noreply@streampulse.com` dans `.env.example`) | Non |
+| `APP_BASE_URL` | Schéma d'URL des liens contenus dans les emails — deep link vers l'app Flutter | — (`streampulse://app` dans `.env.example`) | Non |
+
+> ⚠️ Ces variables n'ont **pas de valeur par défaut dans le code** : elles sont déclarées sans
+> `def:` dans `envKeys` ([`backend/internal/config/config.go`](../backend/internal/config/config.go)).
+> Les valeurs indiquées entre parenthèses proviennent du `.env.example` et ne s'appliquent donc
+> que si ce fichier a été copié.
 
 > **Note :** en compose, le service `api` reçoit `DB_HOST=postgres` (nom du service Docker),
 > tandis qu'en dev natif (hors compose) `DB_HOST=localhost`. Les deux cas sont couverts par
@@ -314,9 +341,15 @@ le déploiement et les scans de sécurité.
 
 | Workflow | Fichier | Déclenchement | Rôle |
 |---|---|---|---|
-| **CI** | `.github/workflows/ci.yml` | `push` / `pull_request` sur `develop` et `main` | Lint Go (golangci-lint), tests avec couverture, vérification de compilation |
-| **CD** | `.github/workflows/cd.yml` | `push` sur `main` uniquement + `workflow_dispatch` | Build image Docker multi-stage, push sur GHCR, déploiement SSH sur le VPS |
+| **CI** | `.github/workflows/ci.yml` | `push` / `pull_request` sur `develop` et `main` | Lint Go (golangci-lint), tests avec couverture, vérification de compilation, analyse Flutter |
+| **CD** | `.github/workflows/cd.yml` | **Fin de la CI sur `main`** (`workflow_run`, uniquement si verte) + `workflow_dispatch` | Build image Docker multi-stage, push sur GHCR, déploiement SSH sur le VPS |
 | **Security** | `.github/workflows/security.yml` | `push` sur `develop` et `main` + cron lundi 06h00 UTC | Scan de vulnérabilités Trivy (SARIF → Code Scanning), analyse statique gosec |
+| **Check hardcoded** | `.github/workflows/check-hardcoded.yml` | `push` / `pull_request` sur `develop` et `main` | Bloque tout secret ou valeur codée en dur (gitleaks + grep) |
+| **Lint PR title** | `.github/workflows/lint-pr-title.yml` | Ouverture / édition d'une PR | Valide le titre contre les Conventional Commits |
+| **Load Test** | `.github/workflows/loadtest.yml` | Cron lundi 05h00 UTC + `workflow_dispatch` | Test de charge HLS 50 auditeurs (STR-90), rapport en artefact |
+
+> **Le CD n'est plus déclenché par le `push`** mais par la conclusion de la CI (STR-241) :
+> les deux workflows démarraient sinon en parallèle, et des tests rouges déployaient quand même.
 
 ### Secrets GitHub à configurer
 

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -44,8 +44,8 @@ Aucune valeur secrète ne doit être committée dans le dépôt.
 | `POSTGRES_USER` | postgres | Utilisateur PostgreSQL (init du volume) | `streampulse` | Oui |
 | `POSTGRES_PASSWORD` | postgres | Mot de passe PostgreSQL (init du volume) | `changeme` | **Oui — à changer** |
 | `POSTGRES_DB` | postgres | Nom de la base de données (init du volume) | `streampulse_db` | Oui |
-| `DATABASE_URL` | api | DSN complète, lue par le migrator au démarrage et en fallback du pool | aucun | Oui |
 | `GRAFANA_ADMIN_PASSWORD` | grafana | Mot de passe admin Grafana | `changeme` | **Oui — à changer** |
+| `ALERT_EMAIL_TO` | grafana | Destinataire des alertes Grafana. Défaut `.invalid` non délivrable en dev ; **obligatoire en prod** (cf. [ADR 041](./adr/041-metriques-metier-debit-departs-et-resume-admin.md)) | `alertes@streampulse.invalid` | **Oui (prod)** |
 | `API_PORT` | api / hôte | Port exposé de l'API Go sur l'hôte | `8080` | Non |
 
 ### Variables consommées par l'API Go
@@ -64,6 +64,10 @@ caractères → l'API refuse de démarrer.
 | `DB_USER` | Utilisateur PostgreSQL | aucun | **Oui** |
 | `DB_PASSWORD` | Mot de passe PostgreSQL | aucun | **Oui** |
 | `DB_NAME` | Nom de la base PostgreSQL | aucun | **Oui** |
+| `DB_SSLMODE` | Mode TLS de la connexion PostgreSQL (`disable` en interne Docker, `require` / `verify-full` sur une base managée) | `disable` | Non |
+| `HTTP_READ_TIMEOUT_SECONDS` | Timeout de lecture du serveur HTTP (les chemins longs, ingest et SSE, gèrent leurs propres échéances) | `5` | Non |
+| `HTTP_WRITE_TIMEOUT_SECONDS` | Timeout d'écriture du serveur HTTP | `10` | Non |
+| `HTTP_IDLE_TIMEOUT_SECONDS` | Timeout d'inactivité des connexions keep-alive | `120` | Non |
 | `INGEST_RECONNECT_GRACE_SECONDS` | Délai sans audio avant l'arrêt automatique d'un live (doit dépasser 30 s, le backoff mobile max — refusé au démarrage sinon) | `45` | Non |
 | `INGEST_STOP_TIMEOUT_SECONDS` | Timeout d'une tentative d'arrêt automatique en base | `10` | Non |
 | `CORS_ALLOWED_ORIGINS` | Origines CORS autorisées, séparées par des virgules. En développement, `localhost` / `127.0.0.1` sont autorisés d'office quel que soit le port ; cette variable sert surtout en production | aucun | Non |


### PR DESCRIPTION
## Contexte

Le sujet exige, dans « Rendus attendus — Commun » : *« Repository GitHub (commits signés, README
complet, répartition des tâches) »*.

Les commits signés sont déjà acquis (ruleset `required_signatures` actif). Les **deux autres
éléments manquaient** : le README n'avait ni section architecture, ni tests, ni déploiement, ni
équipe — et **aucun lien vers `docs/`**, laissant les 38 ADR et `docs/architecture.md` orphelins
depuis le point d'entrée du dépôt.

Closes #311 · [STR-245](https://linear.app/streampulse/issue/STR-245/completer-le-readme-et-documenter-la-repartition-des-taches)

## Ce que fait cette PR

### Nouveaux fichiers

| Fichier | Rôle |
| --- | --- |
| `.mailmap` | Fusionne les identités git multiples. `git shortlog -sne --all` affichait **6 entrées** pour 3 humains (deux contributeurs committaient sous deux emails) ; il en affiche désormais **3** : 166 / 101 / 35 commits. |
| `LICENSE` | MIT, avec les trois contributeurs comme titulaires. |
| `.github/CODEOWNERS` | Review automatique par périmètre, aligné sur la répartition écrite. Tous les chemins déclarés existent (un motif pointant vers un chemin absent serait silencieusement ignoré par GitHub). |

### README.md

- **Fonctionnalités** — ce que fait le produit, par domaine
- **Architecture** — liens vers `docs/architecture.md`, `docs/README.md` et l'index des ADR ; principes par couche
- **Tests** — commandes, emplacement des tests, et **couverture réelle mesurée**
- **Déploiement** — URL de production, déclencheur réel du CD, tableau des 6 workflows, lien vers `docs/infrastructure.md`
- **Équipe et répartition des tâches** — les 3 contributeurs, leur périmètre, avec **liens vers leurs PR principales**
- **Licence**
- Correction de l'entrée vide `- [](#)` dans le sommaire ; le sommaire couvre désormais les 15 sections, dans l'ordre
- **14 variables d'environnement** manquantes documentées

### docs/infrastructure.md

- **11 variables** manquantes documentées — la règle que le projet s'était donnée (`CONTRIBUTING.md:175`) était en défaut ; ces variables n'étaient exhaustivement décrites que dans `CLAUDE.md`, qui n'est pas un livrable
- Ligne CD du tableau des workflows corrigée (voir ci-dessous)

## Couverture des tests

Mesurée, pas estimée : **48,8 %** des instructions sur le module Go complet, **54,4 %** en
excluant les packages `internal/*/db` générés par sqlc. Le détail par package figure dans le
README. Les packages `infrastructure/*` et `cmd/api` sont à 0 % car couverts par les tests
d'intégration sous build tag `integration`, exclus de `go test ./...`.

## Inexactitudes corrigées au passage

Une relecture des affirmations du README contre le code a fait apparaître quatre erreurs
factuelles, dont deux dans du contenu que je venais d'écrire :

1. **Le test de charge n'est pas rejoué par la CI de PR.** Le harnais vivant sous build tag, la
   CI garantit seulement qu'il **compile** (`go vet -tags loadtest`). Son exécution est un
   workflow distinct, hebdomadaire. Écrire l'inverse aurait recréé exactement le trou de
   STR-241, où le harnais est resté 3,5 semaines non compilable sans que rien n'échoue.
2. **Le CD n'est plus déclenché par le `push` sur `main`** mais par la conclusion de la CI
   (`workflow_run`, uniquement si verte) — c'est précisément la bascule opérée par #314.
   `docs/infrastructure.md` affirmait encore l'ancien comportement : **corrigé**, la ligne
   contredisait `cd.yml` dans le document que le README désigne comme référence de déploiement.
3. **Le tableau des workflows en listait 3 sur 6** — `check-hardcoded.yml`, `lint-pr-title.yml`
   et `loadtest.yml` manquaient, alors que le README mentionne lui-même le check gitleaks
   ailleurs. Complété.
4. Quelques **valeurs par défaut** documentées provenaient du `.env.example` et non du code :
   `SMTP_PORT`, `SMTP_FROM` et `APP_BASE_URL` n'ont **aucun défaut** dans `envKeys`
   (`config.go`), et `STORAGE_PATH` vaut `./data/tracks` et non `/data/tracks`. Distinction
   explicitée dans les deux documents.

## Répartition des tâches — méthode

La répartition est **dérivée du journal des PR mergées**, pas d'une estimation. Les 20 numéros de
PR cités ont été vérifiés un à un contre l'auteur réel via `gh`.

Elle diffère de l'hypothèse initiale de la carte sur un point : le découpage n'est pas
« Antony = backend / Thierry = mobile ». Antony a porté une part substantielle du mobile (file
d'attente #287, shuffle/repeat #289, barre de progression #292, capture micro #278) et Thierry
une part du backend (moteur HLS #259, lecture publique #263). `CODEOWNERS` reflète ce
recouvrement plutôt qu'une séparation par couche.

## Vérifications

- [x] Les **29 variables** de `.env.example` sont documentées dans le README **et** dans `docs/infrastructure.md` — vérifié programmatiquement, zéro manquante
- [x] Tous les liens relatifs des deux fichiers pointent vers un chemin existant
- [x] Le sommaire correspond exactement aux 15 titres de section
- [x] Les 20 PR citées correspondent à leur auteur réel
- [x] Comptages vérifiés : 38 ADR, 40 fichiers de tests Go, 36 fichiers de tests Flutter
- [x] Tous les chemins de `CODEOWNERS` existent
- [x] `go test ./...` passe intégralement (chiffres de couverture ci-dessus)

## Hors périmètre

Le tableau des services de `docs/infrastructure.md` est obsolète indépendamment de cette carte :
il liste 6 des 9 services de `docker-compose.yml` (manquent `mailpit`, `node_exporter`, `alloy`,
plus `caddy` en prod), décrit encore l'API comme un « stub de démarrage », et porte une note
périmée annonçant l'authentification JWT « en US-02-02 ». Volontairement laissé de côté pour ne
pas élargir ce diff — à traiter dans un ticket dédié.
