### PR TITLE
docs: constituer le dossier de conception (user stories, UML, schéma BDD)

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,256 @@
+# Schéma de base de données — StreamPulse
+
+> Version : 1.2.0 — dernière révision : 2026-08-19
+
+Modèle physique de la base PostgreSQL, dérivé des **19 migrations** de `backend/migrations/`.
+Ce document est la référence. L'ADR d'initialisation de la base de données décrit la décision
+d'origine et ne portait que sur les six premières tables — elle est indexée dans
+[`docs/README.md`](README.md) (son numéro change avec la renumérotation des ADR en cours, d'où
+l'absence de lien direct ici).
+
+Le schéma compte aujourd'hui **12 tables**.
+
+---
+
+## Diagramme entité-association
+
+```mermaid
+erDiagram
+    users ||--o{ streams : "diffuse"
+    users ||--o{ tracks : "possède"
+    users ||--o{ playlists : "possède"
+    users ||--o{ queue_items : "met en file"
+    users ||--o{ refresh_tokens : "authentifie"
+    users ||--o{ password_reset_tokens : "réinitialise"
+    users ||--|| profiles : "décrit par"
+    users ||--o{ broadcaster_requests : "demande"
+    users ||--o{ favorites : "met en favori"
+    users ||--o{ audit_logs : "agit"
+    streams ||--o{ favorites : "est en favori de"
+    playlists ||--o{ playlist_tracks : "contient"
+    tracks ||--o{ playlist_tracks : "figure dans"
+    tracks ||--o{ queue_items : "est en file"
+
+    users {
+        uuid id PK
+        text email UK
+        text username UK
+        text password_hash
+        text role "anonymous|user|broadcaster|admin"
+        boolean is_active
+        timestamptz created_at
+        timestamptz updated_at
+    }
+    profiles {
+        uuid id PK
+        uuid user_id FK,UK
+        text pseudo
+        text bio
+        text avatar_url
+        text theme "system|light|dark"
+        boolean notifications_enabled
+        text audio_quality "low|normal|high"
+    }
+    streams {
+        uuid id PK
+        uuid user_id FK
+        text title
+        text description
+        text category
+        text status "idle|live|ended"
+        text stream_key UK
+        boolean is_public
+        timestamptz started_at
+        timestamptz ended_at
+        timestamptz archived_at
+    }
+    tracks {
+        uuid id PK
+        uuid user_id FK
+        text title
+        text artist
+        integer duration_s "CHECK > 0"
+        text file_path
+        text mime_type "audio/mpeg|aac|ogg"
+        bigint file_size "CHECK > 0"
+    }
+    playlists {
+        uuid id PK
+        uuid user_id FK
+        text name
+        text description
+        boolean is_public
+    }
+    playlist_tracks {
+        uuid playlist_id PK,FK
+        uuid track_id PK,FK
+        integer position "CHECK >= 0"
+        timestamptz added_at
+    }
+    queue_items {
+        uuid id PK
+        uuid user_id FK
+        uuid track_id FK
+        integer position "CHECK >= 0"
+        timestamptz added_at
+    }
+    favorites {
+        uuid user_id PK,FK
+        uuid stream_id PK,FK
+        timestamptz created_at
+    }
+    refresh_tokens {
+        uuid id PK
+        uuid user_id FK
+        text token_hash UK
+        timestamptz expires_at
+    }
+    password_reset_tokens {
+        uuid id PK
+        uuid user_id FK
+        text token_hash UK
+        timestamptz expires_at
+        timestamptz used_at
+    }
+    broadcaster_requests {
+        uuid id PK
+        uuid user_id FK
+        text status "pending|approved|rejected"
+        text message
+        uuid reviewed_by FK
+        text review_note
+    }
+    audit_logs {
+        uuid id PK
+        uuid actor_id FK "ON DELETE SET NULL"
+        text action
+        text target_type
+        uuid target_id
+        timestamptz created_at
+    }
+```
+
+**Équivalent textuel** — `users` est au centre : tout ce qu'un utilisateur produit
+(flux, pistes, playlists, file d'attente) ou qui l'authentifie (jetons de rafraîchissement et
+de réinitialisation) en dépend, et disparaît avec lui. `profiles` est une extension un-à-un
+créée automatiquement par déclencheur. `playlist_tracks` et `favorites` sont des tables
+d'association à clé primaire composite. `audit_logs` est le seul lien qui **survit** à la
+suppression de son auteur.
+
+---
+
+## Dictionnaire de données
+
+### `users` — comptes
+
+| Colonne | Type | Contrainte | Sens |
+|---|---|---|---|
+| `id` | UUID | PK, `gen_random_uuid()` | Identifiant |
+| `email` | TEXT | NOT NULL, UNIQUE | Identifiant de connexion |
+| `username` | TEXT | NOT NULL, UNIQUE | Pseudonyme public |
+| `password_hash` | TEXT | NOT NULL | bcrypt. Jamais le mot de passe |
+| `role` | TEXT | CHECK `anonymous\|user\|broadcaster\|admin` | Hiérarchie d'autorisation |
+| `is_active` | BOOLEAN | NOT NULL, `true` | Désactivation par un admin, sans suppression |
+
+### `profiles` — préférences et identité publique
+
+Créée automatiquement à l'inscription par le déclencheur `trg_create_profile_for_user`
+(migration `000011`) : aucun code applicatif n'a à s'en soucier, et un compte ne peut pas
+exister sans profil.
+
+| Colonne | Type | Contrainte | Sens |
+|---|---|---|---|
+| `user_id` | UUID | NOT NULL, **UNIQUE**, FK cascade | Relation un-à-un |
+| `bio` | TEXT | NOT NULL, `''` | Jamais NULL — simplifie l'affichage |
+| `theme` | TEXT | CHECK `system\|light\|dark` | Préférence d'affichage |
+| `audio_quality` | TEXT | CHECK `low\|normal\|high` | Préférence de lecture |
+
+### `streams` — flux de diffusion
+
+| Colonne | Type | Contrainte | Sens |
+|---|---|---|---|
+| `status` | TEXT | CHECK `idle\|live\|ended` | `ended` est terminal |
+| `stream_key` | TEXT | NOT NULL, UNIQUE | **Secret de type bearer** : authentifie l'ingest à lui seul, sans JWT |
+| `is_public` | BOOLEAN | NOT NULL, `true` | Un flux privé renvoie 404 à un tiers, jamais 403 |
+| `archived_at` | TIMESTAMPTZ | NULL | Suppression douce |
+
+### `tracks` — bibliothèque audio
+
+| Colonne | Type | Contrainte | Sens |
+|---|---|---|---|
+| `duration_s` | INTEGER | CHECK > 0 | **Déclarée par le client**, non extraite du fichier |
+| `file_path` | TEXT | NOT NULL | Chemin sous `STORAGE_PATH`, hors répertoire servi |
+| `mime_type` | TEXT | CHECK `audio/mpeg\|aac\|ogg` | Valeur **sniffée** côté serveur, jamais déclarée |
+| `file_size` | BIGINT | CHECK > 0 | Alimente le quota de 500 Mo par compte |
+
+### `playlist_tracks` — composition d'une playlist
+
+| Colonne | Type | Contrainte |
+|---|---|---|
+| `playlist_id`, `track_id` | UUID | **PK composite**, FK cascade |
+| `position` | INTEGER | CHECK ≥ 0, `UNIQUE (playlist_id, position)` **DEFERRABLE** |
+
+### `audit_logs` — journal de modération
+
+| Colonne | Type | Contrainte | Sens |
+|---|---|---|---|
+| `actor_id` | UUID | FK **ON DELETE SET NULL** | La trace survit à la suppression du compte, **sans** l'identité |
+| `target_type`, `target_id` | TEXT, UUID | NOT NULL | Cible polymorphe, sans FK |
+
+---
+
+## Contraintes non évidentes
+
+Quatre décisions du schéma ne se lisent pas dans le diagramme et gouvernent le comportement de
+l'application.
+
+**`uq_playlist_tracks_position` est `DEFERRABLE INITIALLY DEFERRED`** (`000019`). Réordonner une
+playlist réécrit toutes les positions dans une transaction, et ses états intermédiaires
+contiennent forcément des doublons — déplacer la piste 3 en position 0 avant d'avoir décalé les
+autres. La contrainte n'est vérifiée qu'au COMMIT. Conséquence pour le code : toute mutation de
+pistes passe par une transaction, et un `INSERT … ON CONFLICT` doit **nommer ses colonnes**
+(`ON CONFLICT (playlist_id, track_id)`) — une contrainte différée ne peut pas servir d'arbitre,
+et un `ON CONFLICT DO NOTHING` nu échoue en SQLSTATE 55000.
+
+**`streams_one_live_per_user`** (`000016`) est un index unique **partiel** :
+`ON streams (user_id) WHERE status = 'live' AND archived_at IS NULL`. C'est la base, et non
+l'application, qui garantit qu'un diffuseur n'a qu'un seul direct à la fois. Deux requêtes
+concurrentes de démarrage ne peuvent pas passer toutes les deux.
+
+**`broadcaster_requests_one_pending`** suit le même principe : un index unique partiel
+`WHERE status = 'pending'` empêche un utilisateur d'empiler les demandes, tout en conservant
+l'historique de ses demandes traitées.
+
+**`idx_streams_public_live`** est un index partiel de couverture pour la découverte publique :
+`WHERE is_public AND status = 'live' AND archived_at IS NULL`, trié par `started_at DESC`. La
+requête la plus fréquente de l'application ne parcourt donc jamais les flux terminés.
+
+---
+
+## Suppression d'un compte
+
+`DELETE FROM users` propage en cascade sur **neuf** tables : `streams`, `tracks`, `playlists`,
+`queue_items`, `refresh_tokens`, `password_reset_tokens`, `profiles`, `broadcaster_requests`,
+`favorites` — et de proche en proche sur `playlist_tracks`.
+
+Deux exceptions délibérées :
+
+- `audit_logs.actor_id` passe à `NULL` : la trace de modération subsiste **sans** l'identité de
+  son auteur. C'est ce qui concilie la traçabilité et le droit à l'effacement.
+- `broadcaster_requests.reviewed_by` passe aussi à `NULL` : supprimer un administrateur
+  n'efface pas les demandes qu'il a traitées.
+
+Les **fichiers audio** ne sont pas couverts par la cascade SQL : ils vivent sur un volume. Leur
+suppression est enchaînée applicativement, et seulement si le `DELETE` a réussi — pour ne
+jamais laisser de ligne orpheline. Voir `track.Service.PurgeUserTracks`.
+
+---
+
+## Notes de version du schéma
+
+- La migration **`000012` n'existe pas** : saut de numéro dans la série, sans conséquence —
+  `golang-migrate` ordonne par numéro et ne réclame pas de continuité.
+- La contrainte `uq_streams_user_title` a été **retirée** en `000015` : deux flux d'un même
+  diffuseur peuvent porter le même titre, il n'y a donc pas de 409 sur ce motif.
+- `queue_items` est créée (`000005`) mais **inutilisée par l'application** : la file d'attente
+  est gérée côté Flutter (ADR 034). Le type sqlc généré existe, aucun appel ne le référence.

--- a/docs/diagrammes.md
+++ b/docs/diagrammes.md
@@ -1,0 +1,254 @@
+# Diagrammes — StreamPulse
+
+> Version : 1.2.0 — dernière révision : 2026-08-19
+
+Vues standardisées du système, en notation UML rendue par Mermaid — GitHub les affiche
+nativement, sans outil ni image à régénérer.
+
+**Chaque diagramme est suivi d'un équivalent textuel.** Un diagramme reste une image pour un
+lecteur d'écran ; la description qui l'accompagne porte la même information sous forme lisible.
+
+Le schéma de données a son propre document : [`database.md`](database.md).
+
+---
+
+## 1. Cas d'utilisation — les quatre rôles
+
+```mermaid
+graph LR
+    anonyme(("Anonyme"))
+    user(("Utilisateur"))
+    diffuseur(("Diffuseur"))
+    admin(("Administrateur"))
+
+    anonyme --> UC1["Découvrir les flux en direct"]
+    anonyme --> UC2["Écouter un flux public"]
+    anonyme --> UC3["S'inscrire / se connecter"]
+
+    user --> UC1
+    user --> UC2
+    user --> UC4["Mettre un flux en favori"]
+    user --> UC5["Téléverser une piste"]
+    user --> UC6["Gérer ses playlists"]
+    user --> UC7["Écouter une playlist"]
+    user --> UC8["Gérer son profil"]
+    user --> UC9["Demander le rôle diffuseur"]
+    user --> UC10["Supprimer son compte"]
+
+    diffuseur --> UC11["Créer un flux"]
+    diffuseur --> UC12["Démarrer / arrêter un direct"]
+    diffuseur --> UC13["Diffuser depuis le micro"]
+    diffuseur --> UC14["Consulter son audience"]
+    diffuseur --> UC15["Faire tourner sa clé de diffusion"]
+
+    admin --> UC16["Gérer les comptes"]
+    admin --> UC17["Superviser les flux actifs"]
+    admin --> UC18["Interrompre un flux"]
+    admin --> UC19["Traiter les demandes de rôle"]
+
+    user -.hérite de.-> anonyme
+    diffuseur -.hérite de.-> user
+    admin -.hérite de.-> diffuseur
+```
+
+**Équivalent textuel** — Quatre rôles hiérarchisés : chacun hérite des capacités du précédent,
+dans l'ordre anonyme → utilisateur → diffuseur → administrateur. L'anonyme découvre et écoute
+les flux publics, et peut s'inscrire. L'utilisateur y ajoute les favoris, la bibliothèque, les
+playlists, son profil, la demande de rôle et la suppression de compte. Le diffuseur y ajoute la
+création de flux, le démarrage et l'arrêt d'un direct, la diffusion depuis le micro, la
+consultation de son audience et la rotation de sa clé. L'administrateur y ajoute la gestion des
+comptes, la supervision et l'interruption des flux, et le traitement des demandes de rôle.
+
+La hiérarchie est appliquée par `auth.RequireRole` : un rang supérieur satisfait toujours
+l'exigence d'un rang inférieur.
+
+---
+
+## 2. Séquence — authentification et rotation du jeton
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant M as Application mobile
+    participant A as API Go
+    participant DB as PostgreSQL
+
+    M->>A: POST /api/auth/login (email, mot de passe)
+    A->>DB: SELECT user WHERE email
+    DB-->>A: utilisateur + password_hash
+    A->>A: bcrypt.CompareHashAndPassword
+    A->>A: signer un access token HS256 (15 min, claims sub + role)
+    A->>DB: INSERT refresh_tokens (SHA-256 du jeton, 7 jours)
+    A-->>M: access token + refresh token
+    M->>M: stocker dans le coffre sécurisé de l'OS
+
+    Note over M,A: 15 minutes plus tard
+
+    M->>A: GET /api/playlists (Bearer access token)
+    A-->>M: 401 — jeton expiré
+    M->>A: POST /api/auth/refresh (refresh token)
+    A->>DB: SELECT par hash, vérifier l'expiration
+    A->>DB: DELETE l'ancien, INSERT le nouveau
+    Note right of A: rotation : un refresh consommé<br/>ne peut plus resservir
+    A-->>M: nouvelle paire de jetons
+    M->>A: rejouer GET /api/playlists
+    A-->>M: 200
+```
+
+**Équivalent textuel** — À la connexion, l'API vérifie le mot de passe avec bcrypt, signe un
+access token HS256 valable 15 minutes portant l'identifiant et le rôle, et enregistre en base le
+**haché SHA-256** d'un refresh token valable 7 jours. Le mobile range les deux dans le coffre
+sécurisé de l'OS. Quand l'access token expire, l'API répond 401 ; le client échange alors son
+refresh token contre une nouvelle paire. L'ancien refresh est supprimé au passage : un jeton
+consommé ne peut plus resservir. Le client rejoue enfin sa requête initiale.
+
+Côté mobile, ce cycle est sérialisé : N requêtes reçues en 401 simultanément ne déclenchent
+qu'un seul rafraîchissement.
+
+---
+
+## 3. Séquence — de l'ingest à l'oreille de l'auditeur
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant D as Diffuseur (mobile)
+    participant A as API Go
+    participant F as ffmpeg
+    participant FS as Répertoire de session
+    participant L as Auditeur (mobile)
+
+    D->>A: PATCH /api/streams/{id}/start (Bearer JWT)
+    A->>A: statut idle → live, créer la session (context annulable)
+    A-->>D: 200 + stream_source_url
+
+    D->>A: POST /api/streams/ingest/{stream_key}
+    Note right of A: auth par la clé seule,<br/>sans JWT
+    A->>F: écrire l'audio sur stdin
+    F->>FS: segments .ts (~10 s) + manifeste .m3u8 glissant
+
+    par Le diffuseur continue de pousser
+        loop en continu
+            D->>A: octets audio
+            A->>F: relais vers stdin
+        end
+    and L'auditeur lit indépendamment
+        L->>A: GET /api/streams/{id}/playlist.m3u8
+        A->>FS: lire le manifeste
+        A-->>L: 200 (ou 409 si pas encore prêt)
+        loop toutes les ~10 s
+            L->>A: GET /api/streams/{id}/segments/{segment}.ts
+            A-->>L: 200 — segment audio
+        end
+    end
+
+    D->>A: PATCH /api/streams/{id}/stop
+    A->>F: fermer stdin, puis tuer le process
+    A->>FS: supprimer le répertoire
+    A->>A: statut live → ended, annuler le context
+    A-->>L: événement SSE « ended »
+```
+
+**Équivalent textuel** — Le diffuseur démarre son flux avec son JWT : le statut passe de `idle`
+à `live` et une session annulable est créée en mémoire. Il pousse ensuite l'audio sur la route
+d'ingest, authentifiée par la seule clé de diffusion — sans JWT, puisqu'un logiciel de
+diffusion tiers ne sait pas en présenter un. L'API relaie ces octets vers l'entrée standard d'un
+ffmpeg, qui écrit des segments d'environ dix secondes et un manifeste glissant dans le
+répertoire de travail de la session.
+
+En parallèle, l'auditeur récupère le manifeste puis les segments, en boucle. Le fan-out d'un
+diffuseur vers N auditeurs se fait donc **par fichiers**, pas par un canal mémoire : chaque
+lecteur lit indépendamment.
+
+À l'arrêt, l'API ferme l'entrée de ffmpeg pour lui laisser finaliser son dernier segment, tue le
+process, supprime le répertoire, annule le context de session et notifie les auditeurs abonnés
+par un événement SSE `ended`.
+
+---
+
+## 4. Composants et flux de déploiement
+
+```mermaid
+graph TB
+    subgraph clients["Clients"]
+        mobile["Application Flutter<br/>iOS · Android"]
+    end
+
+    subgraph vps["VPS — réseau streampulse-net"]
+        caddy["Caddy<br/>TLS Let's Encrypt<br/>seul port public"]
+
+        subgraph app["Application"]
+            api["API Go<br/>net/http · 127.0.0.1:8080"]
+            pg[("PostgreSQL 16")]
+            vol[/"Volume track_storage"/]
+        end
+
+        subgraph obs["Observabilité"]
+            prom["Prometheus"]
+            loki["Loki"]
+            tempo["Tempo"]
+            alloy["Alloy"]
+            grafana["Grafana"]
+        end
+    end
+
+    mobile -->|HTTPS| caddy
+    caddy -->|HTTP interne| api
+    api --> pg
+    api --> vol
+    prom -->|scrape /metrics| api
+    alloy -->|logs JSON| loki
+    api -.->|stdout| alloy
+    api -->|OTLP| tempo
+    grafana --> prom
+    grafana --> loki
+    grafana --> tempo
+```
+
+**Équivalent textuel** — L'application Flutter joint le VPS en HTTPS. **Caddy est le seul point
+d'entrée public** : il termine le TLS avec un certificat Let's Encrypt renouvelé
+automatiquement, et relaie en HTTP sur le réseau interne vers l'API Go, qui n'écoute que sur la
+boucle locale.
+
+L'API parle à PostgreSQL et écrit les fichiers audio sur un volume nommé, hors de tout
+répertoire servi.
+
+Trois flux d'observabilité en partent : Prometheus vient chercher les métriques sur `/metrics`
+en scrape interne, Alloy collecte la sortie standard de l'API et l'expédie à Loki, et l'API
+pousse ses traces à Tempo en OTLP. Grafana lit les trois sources et sert les tableaux de bord
+comme les alertes.
+
+⚠️ **Cette vue décrit la cible.** Au 2026-08-19, Prometheus et Grafana sont encore publiés sur
+toutes les interfaces du VPS, et le blocage de `/metrics` par Caddy n'est pas déployé — les
+correctifs sont écrits mais attendent une synchronisation manuelle de l'infrastructure. Voir
+STR-240.
+
+---
+
+## 5. États d'un flux
+
+```mermaid
+stateDiagram-v2
+    [*] --> idle : création du flux
+    idle --> live : PATCH /start (propriétaire, aucun autre direct)
+    live --> ended : PATCH /stop
+    live --> ended : bail d'ingest expiré (aucun audio pendant N s)
+    live --> ended : mort du segmenteur
+    ended --> [*]
+
+    idle --> archived : DELETE (suppression douce)
+    live --> archived : DELETE
+    ended --> archived : DELETE
+    archived --> [*]
+```
+
+**Équivalent textuel** — Un flux naît `idle` à sa création. Il passe `live` sur demande de son
+propriétaire, à condition qu'aucun autre de ses flux ne soit déjà en direct — une contrainte
+garantie par un index unique partiel en base, pas seulement par le code.
+
+Trois chemins mènent à `ended` : l'arrêt explicite par le diffuseur, l'expiration du bail
+d'ingest lorsque plus aucun audio n'arrive, et la mort du segmenteur. `ended` est **terminal** :
+un flux terminé ne redémarre pas.
+
+La suppression est douce et orthogonale : elle renseigne `archived_at` depuis n'importe quel
+état, sans effacer la ligne.

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -1,0 +1,585 @@
+# User stories — StreamPulse
+
+> Version : 1.2.0 — dernière révision : 2026-08-19
+
+Export des user stories du projet, jusqu'ici visibles uniquement dans Linear. Un système
+externe n'est ni versionné, ni archivable, ni consultable par un jury : ce document les rend
+lisibles depuis le dépôt.
+
+Chaque story reprend **son énoncé et ses critères d'acceptation d'origine**, tels qu'ils ont
+été rédigés avant l'implémentation — pas une reconstruction après coup. La colonne de
+traçabilité relie chacune à la PR qui l'a livrée.
+
+Les scénarios de vérification correspondants vivent dans `docs/cahier-de-recette.md`, livré par
+une PR distincte encore ouverte au moment de la rédaction.
+
+---
+
+## Convention
+
+| Élément | Signification |
+|---|---|
+| **Identifiant** | `US-<épopée>-<rang>`. Le ticket Linear (`STR-NNN`) est l'identifiant technique |
+| **Estimation** | En points, telle que posée au cadrage. Non réévaluée depuis |
+| **Statut** | État réel dans Linear au 2026-08-19 |
+
+⚠️ **Six épopées fondatrices n'ont pas de numéro d'US.** Elles ont été créées avant l'adoption
+de la convention `US-XX-YY`, et portent un titre libre. Les dépendances des stories ultérieures
+les désignent pourtant par un numéro (`US-01-02`, `US-02-02`, `US-03-02`…). La correspondance
+est donnée plus bas comme **proposition à confirmer par l'équipe** : elle est déduite du sens
+des dépendances, pas d'une décision écrite.
+
+Le tableau des dépendances ci-dessous reproduit ce que Linear contient, y compris ces renvois
+à des numéros non attribués.
+
+---
+
+## 1. Infrastructure & Setup
+
+### STR-5 — Configuration du repository Git · ✅ Done
+
+En tant que développeur, je veux un repository Git bien structuré avec branches develop/main
+afin d'organiser le travail collaboratif et de protéger la branche de production.
+
+### STR-11 — Mise en place de Docker Compose · ✅ Done
+
+En tant que développeur, je veux un environnement Docker Compose fonctionnel afin de démarrer
+l'ensemble des services (API, BDD, observabilité) d'une seule commande.
+
+- **Given** : Docker et Docker Compose installés
+- **When** : j'exécute `docker-compose up`
+- **Then** : les services go-api, postgres, prometheus, grafana, loki et tempo démarrent sans
+  erreur et sont interconnectés sur un réseau interne.
+
+### STR-17 — Pipeline CI/CD GitHub Actions · ✅ Done
+
+En tant que tech lead, je veux un pipeline CI/CD automatisé afin que chaque push sur main
+déclenche automatiquement build, tests et déploiement sans intervention manuelle.
+
+- **Given** : un commit pushé sur main
+- **When** : le pipeline se déclenche
+- **Then** : le build Go réussit, les tests unitaires passent, l'image Docker est construite et
+  le déploiement sur le VPS s'effectue — le tout en moins de 5 minutes.
+
+### STR-23 — Configuration 12-Factor App · ✅ Done
+
+En tant que développeur, je veux que toute la configuration soit externalisée via variables
+d'environnement afin de respecter la méthodologie 12-Factor App et d'éviter tout hardcoding.
+
+- **Given** : un fichier `.env.example` documenté
+- **When** : je lance l'application avec des variables d'environnement injectées
+- **Then** : l'application démarre correctement — aucune valeur de configuration (JWT secret,
+  URL BDD, ports) n'est codée en dur dans le code source.
+
+### STR-28 — Initialisation de la base de données PostgreSQL · ✅ Done
+
+En tant que développeur backend, je veux un schéma PostgreSQL versionné afin de garantir la
+reproductibilité des migrations et la cohérence de la base entre les environnements.
+
+- **Given** : un conteneur PostgreSQL vide
+- **When** : j'exécute les migrations
+- **Then** : toutes les tables (users, streams, tracks, playlists, queue_items) sont créées avec
+  les contraintes d'intégrité et les index appropriés.
+
+> ⚠️ Le schéma livré compte **12 tables**, pas cinq : l'énoncé date du cadrage initial. Voir
+> [`database.md`](database.md).
+
+### US-01-06 (STR-92) — Initialisation du projet Flutter mobile · ✅ Done · 4 pts
+
+En tant que développeur Flutter, je veux un projet mobile structuré avec la Clean Architecture
+et toutes les dépendances configurées, afin que l'équipe puisse commencer à développer les
+features sans configuration préalable.
+
+- **Given** : le développeur clone le repo et se place dans `mobile/`
+- **When** : il exécute `flutter pub get` puis `flutter analyze`
+- **Then** : le projet compile et l'analyse ne remonte aucune issue.
+
+---
+
+## 2. Authentification & Gestion des Rôles
+
+### STR-33 — Inscription d'un nouvel utilisateur · ✅ Done
+
+En tant que visiteur, je veux créer un compte avec mon email et un mot de passe afin d'accéder
+aux fonctionnalités personnalisées de la plateforme.
+
+- **Given** : un visiteur sur l'écran d'inscription
+- **When** : il soumet un email valide, un pseudonyme unique et un mot de passe ≥ 8 caractères
+- **Then** : le compte est créé, le mot de passe est haché avec bcrypt (coût ≥ 12), une
+  confirmation est affichée et l'utilisateur peut se connecter immédiatement.
+
+### STR-38 — Connexion sécurisée avec JWT · ✅ Done
+
+En tant qu'utilisateur inscrit, je veux me connecter avec mon email et mot de passe afin
+d'obtenir un token JWT pour accéder aux ressources protégées.
+
+- **Given** : un utilisateur inscrit
+- **When** : il saisit ses identifiants corrects
+- **Then** : l'API retourne un access token JWT (exp. 15 min) et un refresh token (exp. 7 jours)
+  — le token contient le rôle de l'utilisateur dans ses claims.
+
+### STR-44 — Gestion du profil utilisateur · ✅ Done
+
+En tant qu'utilisateur connecté, je veux consulter et modifier mes informations personnelles
+afin de maintenir mon profil à jour.
+
+- **Given** : un utilisateur connecté sur son profil
+- **When** : il modifie son pseudo ou son avatar et valide
+- **Then** : les modifications sont sauvegardées, l'UI est mise à jour et une confirmation est
+  affichée.
+
+### STR-49 — Demande et activation du rôle Diffuseur · ✅ Done
+
+En tant qu'utilisateur standard, je veux demander le rôle Diffuseur depuis mon profil afin de
+pouvoir créer et gérer des flux live.
+
+- **Given** : un utilisateur au rôle User standard
+- **When** : il soumet une demande de rôle Diffuseur
+- **Then** : sa demande est en attente, un admin peut l'approuver depuis le tableau de bord —
+  après approbation, l'utilisateur obtient le rôle Diffuseur et peut créer des flux.
+
+### STR-54 — Réinitialisation du mot de passe · ✅ Done
+
+En tant qu'utilisateur ayant oublié son mot de passe, je veux recevoir un lien de
+réinitialisation par email afin de récupérer l'accès à mon compte.
+
+- **Given** : un email valide soumis sur l'écran « mot de passe oublié »
+- **When** : l'utilisateur clique sur le lien reçu (valide 1 h)
+- **Then** : il peut définir un nouveau mot de passe — l'ancien token est invalidé après usage.
+
+### STR-59 — Suppression de compte (conformité RGPD) · ✅ Done
+
+En tant qu'utilisateur connecté, je veux pouvoir supprimer définitivement mon compte et toutes
+mes données afin d'exercer mon droit à l'effacement (RGPD art. 17).
+
+- **Given** : un utilisateur authentifié qui confirme la suppression
+- **When** : il valide la suppression (double confirmation)
+- **Then** : toutes ses données personnelles (email, pseudo, historique, playlists, fichiers
+  audio) sont supprimées de la base de données et du stockage.
+
+---
+
+## 3. Moteur de Streaming Live (Backend Go)
+
+### STR-64 — Création et configuration d'un flux live · ✅ Done
+
+En tant que diffuseur, je veux créer un nouveau flux live avec un titre, une description et une
+visibilité afin de le préparer avant de commencer la diffusion.
+
+- **Given** : un diffuseur authentifié
+- **When** : il crée un flux (titre, description, public/privé)
+- **Then** : le flux est persisté en base avec le statut « inactif », un identifiant unique est
+  généré et le diffuseur obtient l'URL de stream source.
+
+### STR-70 — Moteur HLS : segmentation et génération du manifeste · ✅ Done
+
+En tant que backend, je veux segmenter le flux audio entrant en fichiers `.ts` de ~10 secondes
+et générer un manifeste `.m3u8` mis à jour en continu afin de permettre la lecture HLS par les
+clients.
+
+- **Given** : un diffuseur envoie un flux audio AAC via HTTP multipart
+- **When** : le backend reçoit le flux
+- **Then** : des segments `.ts` sont générés toutes les 10 secondes, le manifeste `.m3u8` est mis
+  à jour avec les nouveaux segments, et un auditeur peut récupérer le manifeste et démarrer la
+  lecture.
+
+### STR-77 — Démarrage et arrêt du flux (diffuseur) · ✅ Done
+
+En tant que **diffuseur**, je veux **démarrer** puis **arrêter** mon flux en direct afin de
+passer un flux préparé (`idle`) en diffusion (`live`), puis le terminer proprement (`ended`) en
+prévenant les auditeurs.
+
+- **Given** : un diffuseur authentifié, propriétaire d'un flux `idle`, sans autre flux déjà en direct
+- **When** : il démarre le flux (`PATCH /api/streams/{id}/start`)
+- **Then** : le statut passe à `live`, `started_at` est renseigné, une session de diffusion est
+  enregistrée en mémoire (goroutine annulable), et le flux devient visible dans la liste des directs.
+
+- **Given** : un diffuseur propriétaire d'un flux `live`
+- **When** : il arrête le flux (`PATCH /api/streams/{id}/stop`)
+- **Then** : le statut passe à `ended`, `ended_at` est renseigné, la goroutine de session est
+  libérée (aucune fuite), et les auditeurs abonnés reçoivent un événement `ended` en temps réel (SSE).
+
+Critères complémentaires :
+
+- **Un seul flux `live` à la fois par diffuseur** : un `start` est refusé (409) si le diffuseur
+  a déjà un flux en direct, ou si le flux n'est pas `idle`.
+- **Owner-only** : seul le propriétaire (rôle `broadcaster`) peut `start`/`stop` (404 sinon) ;
+  `stop` sur un flux non-`live` → 409 ; `ended` est terminal.
+- **Notification temps réel** : `GET /api/streams/{id}/events` expose un flux SSE.
+- **Concurrence propre** : chaque session est annulée via `context.Context` au `stop` et à
+  l'arrêt du serveur ; absence de fuite de goroutines vérifiée par test.
+
+### STR-87 — Scalabilité : gestion de N auditeurs simultanés · ✅ Done
+
+En tant que système, je veux supporter au moins 50 auditeurs simultanés sur un même flux afin
+de prouver la scalabilité du moteur de streaming Go.
+
+- **Given** : un flux HLS actif
+- **When** : 50 clients HTTP simulent la récupération du manifeste et des segments
+- **Then** : la latence p95 reste < 300 ms, la consommation mémoire est < 2 Mo/connexion et
+  aucune goroutine leak n'est détectée via pprof.
+
+---
+
+## 4. Expérience Auditeur Mobile (Flutter)
+
+### US-04-01 (STR-107) — Découverte et liste des flux actifs · ✅ Done · 2 pts
+
+En tant qu'auditeur (ou anonyme), je veux voir la liste des flux en direct afin de rejoindre
+facilement une émission qui m'intéresse.
+
+- **Given** : des flux publics actifs existent
+- **When** : j'ouvre l'écran d'accueil
+- **Then** : la liste des flux actifs s'affiche avec titre, nombre d'auditeurs et durée de
+  diffusion — elle se rafraîchit automatiquement toutes les 10 secondes.
+
+*Dépendances : US-03-01, US-02-02*
+
+### US-04-02 (STR-108) — Lecteur audio HLS (play/pause/volume) · ✅ Done · 4 pts
+
+En tant qu'auditeur, je veux écouter un flux live HLS avec des contrôles de lecture afin de
+profiter d'une expérience audio fluide.
+
+- **Given** : un flux actif rejoint
+- **When** : le lecteur s'ouvre
+- **Then** : la lecture démarre automatiquement en < 3 secondes, les contrôles play/pause et le
+  réglage de volume sont fonctionnels, le titre du flux est affiché et le taux de rebuffering
+  est < 2 %.
+
+*Dépendances : US-03-02, US-04-01*
+
+> ⚠️ Le **réglage de volume in-app n'est pas livré** : le volume est délégué aux boutons
+> matériels. Ce critère du sujet reste ouvert, suivi dans STR-244.
+
+### US-04-03 (STR-109) — Lecture audio en arrière-plan · ✅ Done · 3 pts
+
+En tant qu'auditeur, je veux que la lecture continue quand je quitte l'application afin de
+pouvoir utiliser mon téléphone librement pendant l'écoute.
+
+- **Given** : un flux en cours d'écoute
+- **When** : l'utilisateur appuie sur le bouton Home
+- **Then** : la lecture continue sans interruption et les contrôles apparaissent dans la barre
+  de notification et sur l'écran de verrouillage (iOS et Android).
+
+*Dépendances : US-04-02*
+
+### US-04-04 (STR-110) — Gestion des interruptions · ✅ Done · 2 pts
+
+En tant qu'auditeur, je veux que la lecture se mette en pause lors d'un appel entrant et
+reprenne automatiquement ensuite afin de ne pas manquer de contenu.
+
+- **Given** : un flux en lecture en arrière-plan
+- **When** : un appel téléphonique entrant est reçu
+- **Then** : la lecture se met en pause automatiquement — et quand l'appel se termine, la
+  lecture reprend depuis le point courant du flux live.
+
+*Dépendances : US-04-03*
+
+### US-04-05 (STR-111) — Ajout d'un flux aux favoris · ✅ Done · 1 pt
+
+En tant qu'utilisateur connecté, je veux ajouter un flux à mes favoris afin de le retrouver
+facilement lors de sa prochaine diffusion.
+
+- **Given** : un utilisateur connecté sur la page d'un flux
+- **When** : il appuie sur l'icône favoris
+- **Then** : le flux est ajouté à sa liste de favoris, l'icône change d'état — et le flux
+  apparaît dans son onglet Favoris.
+
+*Dépendances : US-04-01, US-02-02*
+
+---
+
+## 5. Bibliothèque Audio à la Demande
+
+### US-05-01 (STR-130) — Upload d'une piste audio · ✅ Done · 3 pts
+
+En tant que diffuseur ou utilisateur, je veux uploader un fichier audio (MP3/AAC/OGG) afin de
+l'ajouter à ma bibliothèque personnelle.
+
+- **Given** : un utilisateur connecté
+- **When** : il sélectionne un fichier audio ≤ 50 Mo au format MP3/AAC/OGG
+- **Then** : le fichier est uploadé, son MIME type est validé côté serveur, il est stocké hors
+  répertoire web et référencé en base avec ses métadonnées (titre, durée, taille).
+
+*Dépendances : US-02-02, US-01-05*
+
+### US-05-02 (STR-131) — Création et gestion de playlists · ✅ Done · 2 pts
+
+En tant qu'utilisateur connecté, je veux créer, renommer et supprimer mes playlists afin
+d'organiser ma bibliothèque musicale personnelle.
+
+- **Given** : un utilisateur connecté
+- **When** : il crée une playlist avec un nom
+- **Then** : la playlist est créée vide et apparaît dans sa liste — il peut la renommer ou la
+  supprimer à tout moment, avec confirmation avant suppression.
+
+*Dépendances : US-02-02, US-01-05*
+
+### US-05-03 (STR-132) — Ajout et réorganisation de pistes · ✅ Done · 3 pts
+
+En tant qu'utilisateur, je veux ajouter, supprimer et réorganiser les pistes d'une playlist afin
+de construire une file d'écoute personnalisée.
+
+- **Given** : une playlist existante
+- **When** : l'utilisateur ajoute une piste ou change son ordre par drag-and-drop
+- **Then** : la modification est persistée, la playlist affiche le nouvel ordre et la file
+  d'attente (queue) est mise à jour.
+
+*Dépendances : US-05-01, US-05-02*
+
+### US-05-04 (STR-133) — Lecture d'une playlist avec file d'attente · ✅ Done · 3 pts
+
+En tant qu'utilisateur, je veux lire ma playlist avec passage automatique à la piste suivante
+afin de profiter d'une écoute continue sans intervention.
+
+- **Given** : une playlist avec 3+ pistes
+- **When** : l'utilisateur lance la lecture
+- **Then** : les pistes s'enchaînent automatiquement, la file d'attente est visible,
+  l'utilisateur peut sauter à n'importe quelle piste — la lecture continue en arrière-plan.
+
+*Dépendances : US-05-03, US-04-03*
+
+### US-05-05 (STR-134) — Modes Shuffle et Repeat · ✅ Done · 1 pt
+
+En tant qu'utilisateur, je veux activer le mode lecture aléatoire (shuffle) ou la répétition
+(repeat track / repeat playlist) afin de varier mon expérience d'écoute.
+
+- **Given** : une playlist en cours de lecture
+- **When** : l'utilisateur active le shuffle
+- **Then** : l'ordre de lecture devient aléatoire — et avec repeat-one, la piste courante se
+  répète indéfiniment.
+
+*Dépendances : US-05-04*
+
+---
+
+## 6. Tableau de Bord Diffuseur
+
+### US-06-01 (STR-153) — Lancer et arrêter un flux depuis le dashboard · ✅ Done · 4 pts
+
+En tant que diffuseur, je veux lancer et arrêter mon flux depuis une interface simplifiée afin
+de contrôler ma diffusion sans complexité technique.
+
+- **Given** : un diffuseur sur son tableau de bord
+- **When** : il appuie sur « Démarrer la diffusion »
+- **Then** : l'application commence à envoyer le flux audio au backend, le statut du flux passe
+  à « En direct » et le compteur d'auditeurs s'affiche en temps réel.
+
+*Dépendances : US-03-03, US-02-04*
+
+### US-06-02 (STR-154) — Statistiques de diffusion en temps réel · ✅ Done · 2 pts
+
+En tant que diffuseur, je veux voir les statistiques de mon flux en temps réel (auditeurs
+connectés, durée, déconnexions) afin d'évaluer l'audience de ma diffusion.
+
+- **Given** : un flux actif
+- **When** : je consulte mon tableau de bord diffuseur
+- **Then** : le nombre d'auditeurs connectés est affiché et mis à jour toutes les 5 secondes,
+  ainsi que la durée totale de diffusion.
+
+*Dépendances : US-06-01, US-03-02*
+
+> ⚠️ Le comptage d'auditeurs est une **estimation** : HLS est sans connexion persistante. Voir
+> [ADR 025](adr/025-statistiques-daudience-en-temps-reel.md).
+
+---
+
+## 7. Observabilité & Supervision
+
+### US-07-01 (STR-163) — Logs structurés JSON · ✅ Done · 2 pts
+
+En tant que SRE, je veux que tous les logs du backend Go soient émis au format JSON structuré
+afin de permettre leur indexation automatique dans Loki et leur analyse par des outils tiers.
+
+- **Given** : l'application Go en cours d'exécution
+- **When** : une requête HTTP est traitée ou une erreur survient
+- **Then** : un log JSON est émis avec les champs timestamp, level, message, trace_id, service,
+  environment — aucun `fmt.Println()` n'existe en production.
+
+*Dépendances : US-01-02*
+
+### US-07-02 (STR-164) — Instrumentation OpenTelemetry · ✅ Done · 4 pts
+
+En tant que développeur, je veux instrumenter le backend Go avec OpenTelemetry afin de pouvoir
+tracer le cheminement d'une requête de l'app mobile jusqu'à la base de données.
+
+- **Given** : le SDK OTEL Go configuré
+- **When** : une requête arrive sur l'API
+- **Then** : un span est créé pour chaque handler HTTP, les spans de requêtes SQL sont
+  enregistrés, le trace_id est propagé dans les headers — et la trace complète
+  (mobile → API → DB) est visible dans Tempo/Grafana.
+
+*Dépendances : US-07-01, US-01-02*
+
+> ⚠️ **Critère partiellement atteint.** La trace commence au serveur : aucun `traceparent` n'est
+> émis par le client Flutter. Le volet `API → DB` est livré, le volet `mobile →` ne l'est pas.
+> Voir [ADR 020](adr/020-traces-opentelemetry-otlp-tempo.md) et STR-244.
+
+### US-07-03 (STR-165) — Métriques Prometheus + panels API & Infra · ✅ Done · 3 pts
+
+En tant que SRE, je veux exposer des métriques HTTP et infrastructure via Prometheus afin de les
+visualiser dans les panels Grafana API Backend et Infrastructure.
+
+- **Given** : l'application Go démarrée
+- **When** : Prometheus scrape `/metrics` toutes les 15 secondes
+- **Then** : les métriques `http_requests_total`, `http_request_duration_seconds` (p50/p95/p99),
+  `go_goroutines` et `go_memstats_heap_alloc_bytes` sont collectées et visibles dans Grafana.
+
+*Dépendances : US-07-01, US-01-02*
+
+### US-07-04 (STR-166) — Dashboard Grafana Panel Live Streaming · ✅ Done · 3 pts
+
+En tant que SRE, je veux un dashboard dédié au streaming live afin de visualiser en temps réel
+le nombre de flux actifs, les auditeurs connectés, la latence HLS et le taux de rebuffering.
+
+- **Given** : au moins un flux actif et des auditeurs connectés
+- **When** : je consulte le Panel 1 dans Grafana
+- **Then** : les gauges affichent le nombre de flux actifs, d'auditeurs connectés par flux, la
+  latence HLS p95 et le taux d'erreurs sur les segments `.ts` — avec des données réelles, pas
+  des fixtures.
+
+*Dépendances : US-07-03, US-03-02*
+
+### US-07-05 (STR-167) — Panel Logs & Erreurs + Alertes · ✅ Done · 3 pts
+
+En tant que SRE, je veux visualiser les logs en temps réel dans Grafana et configurer des
+alertes sur les seuils critiques afin d'être notifié proactivement des incidents.
+
+- **Given** : les logs JSON indexés dans Loki et les traces dans Tempo
+- **When** : je consulte le Panel 4
+- **Then** : les logs filtrables par niveau (info/warn/error) et par trace_id sont visibles — et
+  une alerte se déclenche si le taux d'erreurs HTTP 5xx dépasse 5 % sur 5 minutes.
+
+*Dépendances : US-07-01, US-07-02, US-07-03*
+
+---
+
+## 8. Tableau de Bord Administrateur
+
+### US-08-01 (STR-191) — Liste, recherche et gestion des utilisateurs · ✅ Done · 3 pts
+
+En tant qu'administrateur, je veux consulter et gérer la liste complète des utilisateurs afin
+d'assurer la supervision de la communauté.
+
+- **Given** : un administrateur connecté sur `/admin`
+- **When** : il recherche un utilisateur par nom ou filtre par rôle
+- **Then** : la liste filtrée s'affiche — il peut activer, désactiver ou supprimer un compte
+  avec confirmation.
+
+*Dépendances : US-02-02, US-02-04*
+
+### US-08-02 (STR-192) — Supervision et interruption des flux actifs · ✅ Done · 2 pts
+
+En tant qu'administrateur, je veux voir tous les flux actifs et pouvoir en interrompre un si
+nécessaire afin de modérer la plateforme.
+
+- **Given** : un administrateur sur le tableau de bord
+- **When** : il sélectionne un flux actif et clique sur « Interrompre »
+- **Then** : le flux est arrêté immédiatement, les auditeurs reçoivent une notification de fin
+  et un log d'audit est enregistré.
+
+*Dépendances : US-03-03, US-08-01*
+
+---
+
+## 9. Fonctionnalités bonus
+
+Le sujet note ces fonctionnalités sur 5 points, en supplément des 15 du socle.
+
+### US-09-01 (STR-200) — Chat en direct entre auditeurs (WebSocket) · ⬜ Backlog · 5 pts
+
+En tant qu'auditeur d'un flux, je veux envoyer et recevoir des messages en temps réel afin
+d'interagir avec la communauté pendant la diffusion.
+
+- **Given** : plusieurs auditeurs connectés au même flux
+- **When** : l'un envoie un message texte
+- **Then** : tous les auditeurs reçoivent le message en < 500 ms via WebSocket — le diffuseur
+  peut supprimer un message ou bannir un utilisateur du chat.
+
+*Dépendances : US-03-02, US-02-02*
+
+### US-09-02 (STR-201) — Mode hors ligne (cache playlists) · 🔵 In Review · 5 pts
+
+En tant qu'utilisateur, je veux rendre une playlist disponible hors connexion afin d'écouter mes
+pistes sans accès internet.
+
+- **Given** : une playlist avec des pistes
+- **When** : l'utilisateur active le mode offline pour cette playlist
+- **Then** : les fichiers audio sont téléchargés et mis en cache localement — la playlist est
+  accessible et lisible sans réseau, avec indication visuelle de l'état hors ligne.
+
+*Dépendances : US-05-04*
+
+### US-09-03 (STR-202) — Déploiement Kubernetes · ⬜ Backlog · 5 pts
+
+En tant que DevOps, je veux déployer StreamPulse sur un cluster Kubernetes avec gestion des
+ressources afin de démontrer une infrastructure cloud-native production-grade.
+
+- **Given** : un cluster K8s disponible (Minikube ou cloud)
+- **When** : j'applique les manifests kubectl
+- **Then** : l'API Go, PostgreSQL et la stack OTEL sont déployés avec des limits/requests de
+  ressources configurés, un HorizontalPodAutoscaler est actif et l'application répond sur son
+  endpoint.
+
+*Dépendances : US-01-03*
+
+### US-09-04 (STR-203) — Algorithme de recommandation simple · ⬜ Backlog · 4 pts
+
+En tant qu'utilisateur, je veux voir des flux et playlists recommandés sur ma page d'accueil
+afin de découvrir du contenu correspondant à mes goûts.
+
+- **Given** : un utilisateur avec un historique d'écoute
+- **When** : il ouvre la page d'accueil
+- **Then** : une section « Recommandé pour vous » affiche 5 flux ou playlists basés sur ses
+  catégories les plus écoutées (collaborative filtering simplifié ou content-based).
+
+*Dépendances : US-04-02, US-05-04*
+
+### US-09-05 (STR-204) — Transcodage à la volée (FFmpeg) · ✅ Done · 4 pts
+
+En tant que système, je veux transcoder les formats audio non-AAC à la volée avec FFmpeg afin
+d'accepter n'importe quel format entrant (MP3, OGG, WAV) pour la diffusion HLS.
+
+- **Given** : un diffuseur qui envoie un flux MP3
+- **When** : le backend reçoit le flux
+- **Then** : FFmpeg transcode le flux en AAC à la volée, le résultat est segmenté en HLS et les
+  auditeurs reçoivent un flux AAC propre — la latence supplémentaire due au transcodage est
+  < 2 secondes.
+
+*Dépendances : US-03-02*
+
+> ⚠️ Ce transcodage porte sur l'**ingest** (normaliser le format entrant), pas sur l'adaptation
+> du débit à la bande passante de l'auditeur. Le sujet, lui, demande le second. Voir
+> [ADR 030](adr/030-transcodage-a-la-volee-des-formats-dingest.md).
+
+---
+
+## Correspondance des épopées sans numéro
+
+⚠️ **Proposition, à confirmer par l'équipe.** Ces correspondances sont déduites du sens des
+dépendances déclarées dans Linear ; aucune décision écrite ne les fixe.
+
+| Numéro cité en dépendance | Épopée probable | Ticket |
+|---|---|---|
+| US-01-02 | Mise en place de Docker Compose | STR-11 |
+| US-01-03 | Pipeline CI/CD GitHub Actions | STR-17 |
+| US-01-05 | Initialisation de la base PostgreSQL | STR-28 |
+| US-01-06 | Initialisation du projet Flutter | STR-92 ✅ *(confirmé par le titre)* |
+| US-02-02 | Connexion sécurisée avec JWT | STR-38 |
+| US-02-04 | Demande et activation du rôle Diffuseur | STR-49 |
+| US-03-01 | Création et configuration d'un flux live | STR-64 |
+| US-03-02 | Moteur HLS : segmentation et manifeste | STR-70 |
+| US-03-03 | Démarrage et arrêt du flux | STR-77 |
+
+Les numéros `US-01-01` et `US-01-04` ne sont cités par aucune dépendance ; ils correspondent
+vraisemblablement à STR-5 (repository Git) et STR-23 (12-Factor), sans qu'on puisse le
+départager.
+
+---
+
+## Ce que ce document ne couvre pas
+
+- Les **sous-tâches** de chaque story (une centaine de tickets `STR-NNN` sans énoncé
+  utilisateur) : elles décrivent des étapes d'implémentation, pas des attentes utilisateur.
+- Les **tickets de correction** ouverts après l'audit de conformité (STR-232 à STR-245) : ils
+  vivent dans un projet Linear distinct et ne sont pas des user stories.


### PR DESCRIPTION
Closes STR-234

Ferme **Ce3.6.1** — « la documentation décrit la solution en incluant des *user stories*, la structure des bases de données, le schéma de sécurité, et utilise un langage qui permet de visualiser les composantes de façon standardisée (UML, BPMN) » — aujourd'hui non acquis. Le volet « schéma de sécurité » relève d'un ticket distinct (STR-235).

Trois documents, 1095 lignes, aucun fichier existant modifié.

## `docs/user-stories.md` — 40 stories rapatriées de Linear

Les user stories étaient citées par vingt ADR mais **définies nulle part dans le dépôt** : elles vivaient dans Linear, un système externe, non versionné, absent de l'archive finale et inaccessible au jury.

Les quarante sont exportées avec leur **énoncé et leurs critères Given/When/Then d'origine**, tels que rédigés au cadrage — pas reconstruits après coup à partir du code. Chacune porte son estimation, ses dépendances et son statut réel.

## `docs/database.md` — 12 tables, pas 6

L'ADR d'initialisation documentait six tables ; dix-neuf migrations en ont produit douze. Le document porte un diagramme entité-association Mermaid et un dictionnaire de données.

L'essentiel est ailleurs : **quatre contraintes gouvernent le comportement applicatif sans se lire dans le schéma**.

- `uq_playlist_tracks_position` est `DEFERRABLE INITIALLY DEFERRED` — un réordonnancement passe forcément par des états intermédiaires en doublon. D'où deux conséquences pour le code : toute mutation de pistes est transactionnelle, et un `INSERT … ON CONFLICT` doit nommer ses colonnes, sous peine de SQLSTATE 55000.
- `streams_one_live_per_user` et `broadcaster_requests_one_pending` sont des **index uniques partiels** : c'est la base, et non le code, qui garantit un seul direct par diffuseur et une seule demande en attente. Deux requêtes concurrentes ne peuvent pas passer toutes les deux.
- `idx_streams_public_live` est un index partiel de couverture : la requête la plus fréquente de l'application ne parcourt jamais les flux terminés.

Une section décrit la suppression d'un compte : cascade sur neuf tables, et deux exceptions délibérées — `audit_logs.actor_id` et `broadcaster_requests.reviewed_by` passent à `NULL`, ce qui concilie la traçabilité et le droit à l'effacement.

## `docs/diagrammes.md` — cinq diagrammes

Zéro diagramme existait dans le dépôt : l'ASCII art de `architecture.md` n'est ni UML ni BPMN.

Cas d'utilisation des quatre rôles · séquence d'authentification avec rotation du jeton · séquence de l'ingest jusqu'à l'auditeur · composants déployés · cycle de vie d'un flux.

En **Mermaid**, rendu nativement par GitHub : rien à régénérer, rien à committer en binaire, et le diff reste lisible.

**Chaque diagramme est suivi d'un équivalent textuel.** Un diagramme reste une image pour un lecteur d'écran, et Ce3.6.4 demande une documentation lisible par les publics en situation de handicap. Ça ne ferme pas ce critère — c'est le périmètre de STR-233 — mais ça évite de creuser le trou en ajoutant six images muettes.

## Trois écarts consignés plutôt que tus

**Six épopées fondatrices n'ont jamais reçu de numéro d'US**, alors que les dépendances des stories ultérieures les désignent par un numéro (`US-01-02`, `US-02-02`, `US-03-02`…). La correspondance est donnée, mais **explicitement marquée comme une proposition à confirmer** : elle est déduite du sens des dépendances, aucune décision écrite ne la fixe. `US-01-01` et `US-01-04` restent indépartageables.

**L'US-04-02 annonce un réglage de volume** qui n'est pas livré — le volume est délégué aux boutons matériels. Noté sur la story elle-même.

**L'US-07-02 annonce une trace `mobile → API → DB`** ; elle s'arrête au serveur, aucun `traceparent` n'étant émis par Flutter. Noté aussi.

## Vérifications

- Les 12 tables des migrations figurent toutes au diagramme ER — contrôle scripté
- 0 lien relatif cassé sur les trois documents
- Les 6 blocs Mermaid ont leurs `subgraph`/`par`/`loop` équilibrés avec leurs `end`
- 40 stories documentées, chacune avec son ticket Linear

⚠️ **Les diagrammes n'ont pas été rendus.** La syntaxe est vérifiée structurellement, pas par le moteur Mermaid. À contrôler visuellement sur GitHub à la relecture — c'est justement ce que le rendu natif rend facile.

## Coordination

Deux liens ont été volontairement laissés en texte plutôt qu'en hyperlien, parce que leurs cibles dépendent de PR encore ouvertes : `docs/cahier-de-recette.md` arrive avec #318, et l'ADR d'initialisation de la base est renumérotée par #319. Les rendre robustes évite un lien mort quel que soit l'ordre de merge — à recâbler une fois les trois fusionnées.
