### PR TITLE
fix(api): rétablir le démarrage en distinguant l'URL de migration

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -115,7 +115,7 @@ func run() error {
 	}()
 
 	// 1. Appliquer les migrations
-	migrator.Run(cfg.DatabaseURL())
+	migrator.Run(cfg.MigrationURL())
 
 	// 2. Seed uniquement en développement (connexion simple, one-shot)
 	if cfg.IsDev() {

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -350,16 +350,30 @@ func (c *Config) DBDSN() string {
 	)
 }
 
-// DatabaseURL rend la même connexion au format URL, attendu par golang-migrate
-// et par pgx.Connect.
+// DatabaseURL rend la connexion au format URL attendu par pgx.
 //
 // Dérivée de DBDSN plutôt que lue dans DATABASE_URL : cette variable était une
 // seconde source de vérité en doublon avec les DB_*, et .env.example y
 // dupliquait le mot de passe en dur — changer POSTGRES_PASSWORD sans la mettre à
 // jour cassait silencieusement les migrations.
-func (c *Config) DatabaseURL() string {
+func (c *Config) DatabaseURL() string { return c.databaseURL("postgres") }
+
+// MigrationURL rend la même connexion pour golang-migrate.
+//
+// Le schéma diffère de DatabaseURL, et ce n'est pas cosmétique : golang-migrate
+// résout son pilote **par le schéma de l'URL**, et le pilote importé par
+// internal/infrastructure/migrator est `database/pgx/v5`, qui s'enregistre sous
+// le seul nom « pgx5 ». Une URL en « postgres:// » le fait échouer au démarrage
+// sur « unknown driver postgres (forgotten import?) ».
+//
+// L'inverse est vrai aussi : pgx.ParseConfig n'accepte que « postgres:// » ou
+// « postgresql:// » et rejette « pgx5:// ». Aucune URL unique ne peut donc
+// servir les deux — d'où deux méthodes plutôt qu'une valeur partagée.
+func (c *Config) MigrationURL() string { return c.databaseURL("pgx5") }
+
+func (c *Config) databaseURL(scheme string) string {
 	u := &url.URL{
-		Scheme:   "postgres",
+		Scheme:   scheme,
 		User:     url.UserPassword(c.DBUser, c.DBPassword),
 		Host:     net.JoinHostPort(c.DBHost, c.DBPort),
 		Path:     "/" + c.DBName,

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -256,6 +256,40 @@ func TestConfig_DBDSN(t *testing.T) {
 	}
 }
 
+// Les deux URL de connexion ne diffèrent que par leur schéma, et ce détail
+// décide si l'API démarre. golang-migrate résout son pilote par le schéma :
+// `database/pgx/v5` ne s'enregistre que sous « pgx5 », et une URL « postgres://
+// » fait échouer le démarrage sur « unknown driver postgres (forgotten
+// import?) ». pgx.ParseConfig, lui, rejette « pgx5:// ».
+//
+// Rien d'autre ne couvre cette contrainte : la CI compile et joue les tests
+// unitaires, elle ne démarre jamais le binaire.
+func TestConfig_URLsDeConnexion(t *testing.T) {
+	cfg := &Config{
+		DBHost:     "db.example.com",
+		DBPort:     "5432",
+		DBUser:     "u",
+		DBPassword: "p",
+		DBName:     "n",
+	}
+
+	const credsEtCible = "://u:p@db.example.com:5432/n?sslmode=disable"
+
+	if got, want := cfg.DatabaseURL(), "postgres"+credsEtCible; got != want {
+		t.Errorf("DatabaseURL() = %q, want %q", got, want)
+	}
+	if got, want := cfg.MigrationURL(), "pgx5"+credsEtCible; got != want {
+		t.Errorf("MigrationURL() = %q, want %q", got, want)
+	}
+
+	// Les deux doivent désigner la même base : seul le schéma change.
+	if strings.TrimPrefix(cfg.DatabaseURL(), "postgres") !=
+		strings.TrimPrefix(cfg.MigrationURL(), "pgx5") {
+		t.Errorf("les deux URL ne pointent pas sur la même base:\n  %s\n  %s",
+			cfg.DatabaseURL(), cfg.MigrationURL())
+	}
+}
+
 func TestConfig_IsDev_IsProd(t *testing.T) {
 	tests := []struct {
 		env      string

--- a/backend/internal/infrastructure/database/database.go
+++ b/backend/internal/infrastructure/database/database.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -13,13 +12,21 @@ import (
 // Connect établit une connexion simple à PostgreSQL (seeder de développement).
 // La DSN vient de la config, dérivée des DB_*. Un timeout de 10 s évite un
 // blocage infini si Postgres est indisponible.
+//
+// databaseURL doit porter un schéma que pgx accepte — « postgres:// » ou
+// « postgresql:// ». C'est ce que rend cfg.DatabaseURL(), seul appelant.
+// L'URL de migration (cfg.MigrationURL(), en « pgx5:// ») ne convient pas ici :
+// ce schéma est un nom de pilote golang-migrate, que pgx rejette.
+//
+// Cette fonction réécrivait auparavant « pgx5:// » en « postgres:// ». La
+// substitution est retirée : depuis la séparation des deux URL, aucun appelant
+// ne peut plus lui passer de « pgx5:// », et la garder laissait croire le
+// contraire.
 func Connect(ctx context.Context, databaseURL string) *pgx.Conn {
-	dbURL := strings.Replace(databaseURL, "pgx5://", "postgres://", 1)
-
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	conn, err := pgx.Connect(ctx, dbURL)
+	conn, err := pgx.Connect(ctx, databaseURL)
 	if err != nil {
 		log.Fatal().Err(err).Msg("connexion base de données")
 	}


### PR DESCRIPTION
Ferme **STR-246**. 🔴 **`develop` est actuellement cassé** : l'API ne démarre plus du tout.

## Le symptôme

```
FTL migrate init error="failed to open database: database driver: unknown driver postgres (forgotten import?)"
exit status 1
```

Reproductible sur `develop` (`391d93f`) avec un simple `go run ./cmd/api`. L'échec survient **avant** l'écoute : le service ne rend jamais `/health`.

## La cause

golang-migrate résout son pilote **par le schéma de l'URL**. Le pilote importé par `internal/infrastructure/migrator` est `database/pgx/v5`, et il s'enregistre sous un seul nom :

```go
// migrate@v4.19.1/database/pgx/v5/pgx.go:28
database.Register("pgx5", &db)
```

`config.DatabaseURL()` émettait `postgres://`. Aucun pilote sous ce nom → échec.

Et le piège est symétrique : `pgx.ParseConfig` n'accepte que `postgres://` ou `postgresql://`, et rejette `pgx5://`. **Aucune URL unique ne peut servir les deux consommateurs.** Or `DatabaseURL()` était passée aux deux :

```go
migrator.Run(cfg.DatabaseURL())              // veut pgx5://
conn := database.Connect(ctx, cfg.DatabaseURL())  // veut postgres://
```

## C'est ma régression, en #316

Avant #316, l'URL venait de `DATABASE_URL`, et `.env.example` en fixait le schéma :

```
DATABASE_URL=pgx5://streampulse:***@postgres:5432/streampulse_db?sslmode=disable
```

Supprimer cette variable était justifié — elle dupliquait le mot de passe et faisait une seconde source de vérité en doublon avec les `DB_*`. Mais **son schéma portait une information fonctionnelle**, et la dérivation l'a perdue en choisissant `postgres` comme s'il s'agissait d'un détail cosmétique.

## Pourquoi personne ne l'a vu

La CI compile et joue les tests unitaires. **Elle ne démarre jamais le binaire.** Aucun test ne couvrait le schéma des URL de connexion, et le seul endroit où l'erreur apparaît est le premier `go run` ou le premier `docker compose up`.

C'est le trou le plus intéressant de cette PR : un défaut qui rend le service totalement inopérant a traversé une CI verte, une revue et un merge.

## Le correctif

| Méthode | Schéma | Consommateur |
|---|---|---|
| `DatabaseURL()` | `postgres://` | `pgx` |
| `MigrationURL()` | `pgx5://` | `golang-migrate` |

Les deux dérivent d'un helper commun : seul le schéma change, la cible reste identique. `TestConfig_URLsDeConnexion` verrouille les deux valeurs **et** vérifie que le reste de l'URL est le même — sinon on pourrait corriger un schéma en faisant diverger la base.

## Vérification — démarrage réel, pas seulement compilation

PostgreSQL local, `go run ./cmd/api` :

```
GET /health → {"status":"ok"}
```

- **13 tables** créées
- `schema_migrations` en **version 19**, `dirty = false`
- Seed appliqué : `admin@`, `broadcaster@`, `user1@`, `user2@streampulse.dev`

Plus : `go test ./...` sans échec, `golangci-lint run` **0 issue**.

## Ce que ça devrait déclencher ensuite

Rien ici ne garantit qu'une prochaine régression de démarrage soit vue. Un job de fumée en CI — lancer l'API contre un PostgreSQL de service et interroger `/health` — coûterait une trentaine de lignes et aurait attrapé celle-ci. Hors périmètre de ce correctif, mais ça mérite son ticket.

## À merger en priorité

Les autres PR en cours (#318, #319, #320, #321) partent d'un `develop` où l'API ne démarre pas. Aucune n'est affectée dans son contenu, mais tout test manuel sur `develop` échouera tant que celle-ci n'est pas passée.