### PR TITLE
feat(mobile): régler le volume dans l'application et afficher le temps d'écoute

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -474,6 +474,30 @@ Voir [ADR 034](docs/adr/034-lecture-dune-playlist-avec-file-dattente.md).
   dans le **lecteur**, `duration_s` de la base ne servant que de valeur d'attente (déclaré par le
   client à l'upload, il peut mentir). Le serveur ne coûte rien : `Range` déjà géré (ADR 034 §1).
 
+### Contrôle du volume et temps d'écoute (STR-245, ADR 042)
+
+- **Le volume vit sur `PlaybackTransport`** (`volume` / `volumeStream` / `setVolume`),
+  pas sur un contrôleur : un glissement émet des dizaines de valeurs par seconde. Le
+  curseur `VolumeSlider` (`core/widgets/`) s'abonne **directement** au flux — même règle
+  que `queue_progress.dart`. Sur le transport et non sur une interface dérivée : le même
+  curseur sert le direct et la file d'attente.
+- `VolumeLevel` (`core/audio/`, objet **pur**) : le réglage de l'auditeur est la source de
+  vérité, l'atténuation (ducking, ADR 033) est un **facteur** qui en dérive. ⚠️ L'ancien
+  schéma capturait `player.volume` avant d'atténuer : un réglage fait **pendant**
+  l'interruption était écrasé à sa levée. `volumeStream` publie le réglage, jamais le
+  niveau effectif — sinon le curseur sauterait à chaque notification.
+- Persistance : `VolumeStore` → `shared_preferences`, **pas** `SecureStorage` (une seule
+  responsabilité : les jetons). Appliqué **avant le premier rendu** dans `main()`, sinon
+  la lecture démarre au défaut puis saute — ça s'entend. `onChanged` applique,
+  `onChangeEnd` enregistre.
+- `ListeningClock` + `ListeningTime` : un direct n'a pas de barre de progression (pas de
+  fin connue) mais un **temps d'écoute**. ⚠️ Ne pas utiliser `positionStream` : le
+  contrôleur recharge l'URL à chaque reprise (STR-118), la position repartirait de zéro à
+  chaque coupure réseau. L'horloge est pilotée par l'**état de lecture** et se met en
+  pause pendant une reconnexion.
+- La source de temps du widget est **injectable** : `tester.pump(Duration)` n'avance que
+  l'horloge simulée de Flutter, un `DateTime.now()` en dur rendrait le widget invérifiable.
+
 ### Modes shuffle et repeat (US-05-05)
 
 Voir [ADR 035](docs/adr/035-modes-shuffle-et-repeat.md).
@@ -707,7 +731,7 @@ xcrun simctl openurl booted \
 | `docs/adr/037-initialisation-base-de-donnees.md` | Décision : schéma, migrations et seed PostgreSQL |
 
 **Règle :** toute nouvelle décision d'architecture significative → nouvel ADR dans `docs/adr/`
-avec le numéro suivant (prochain : `040-...`). Référencer le ticket Linear correspondant.
+avec le numéro suivant (prochain : `043-...`). Référencer le ticket Linear correspondant.
 Un numéro n'est **jamais** réutilisé, et une ADR remplacée passe en `Superseded by NNN` plutôt
 que d'être réécrite. Chaque ADR porte un bloc **Date / Statut / Ticket** et une section
 **« Alternatives écartées »**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -474,7 +474,7 @@ Voir [ADR 034](docs/adr/034-lecture-dune-playlist-avec-file-dattente.md).
   dans le **lecteur**, `duration_s` de la base ne servant que de valeur d'attente (déclaré par le
   client à l'upload, il peut mentir). Le serveur ne coûte rien : `Range` déjà géré (ADR 034 §1).
 
-### Contrôle du volume et temps d'écoute (STR-245, ADR 042)
+### Contrôle du volume et temps d'écoute (STR-244, ADR 042)
 
 - **Le volume vit sur `PlaybackTransport`** (`volume` / `volumeStream` / `setVolume`),
   pas sur un contrôleur : un glissement émet des dizaines de valeurs par seconde. Le

--- a/docs/README.md
+++ b/docs/README.md
@@ -163,13 +163,14 @@ Chaque décision est tracée avec son contexte, les **alternatives écartées** 
 | 037 | [037-initialisation-base-de-donnees.md](adr/037-initialisation-base-de-donnees.md) | Initialisation de la base de données : schéma, migrations et seed *(ex-ADR 003)* |
 | 038 | [038-gestion-profil-utilisateur.md](adr/038-gestion-profil-utilisateur.md) | Gestion du profil utilisateur (table `profiles` dédiée) *(ex-ADR 012)* |
 | 039 | [039-supervision-admin-des-flux-et-journal-daudit.md](adr/039-supervision-admin-des-flux-et-journal-daudit.md) | Supervision admin des flux actifs et journal d'audit *(ex-ADR 018)* |
+| 042 | [042-controle-du-volume-et-temps-decoute.md](adr/042-controle-du-volume-et-temps-decoute.md) | Contrôle du volume dans l'application et temps d'écoute d'un direct |
 
 ---
 
 ## Convention ADR
 
 - Toute nouvelle décision d'architecture significative → nouvel ADR dans `docs/adr/`,
-  avec **le numéro suivant** (prochain : `040-...`). Le numéro est un **identifiant**,
+  avec **le numéro suivant** (prochain : `043-...`). Le numéro est un **identifiant**,
   attribué dans l'ordre d'enregistrement — il ne suit pas nécessairement l'ordre chronologique
   des décisions (cf. 037/038/039, renumérotées après collision).
 - Un numéro n'est **jamais réutilisé** : une ADR remplacée passe en statut

--- a/docs/adr/042-controle-du-volume-et-temps-decoute.md
+++ b/docs/adr/042-controle-du-volume-et-temps-decoute.md
@@ -2,7 +2,7 @@
 
 **Date** : 2026-08-21
 **Statut** : Accepté
-**Ticket** : [STR-245](https://linear.app/streampulse/issue/STR-245)
+**Ticket** : [STR-244](https://linear.app/streampulse/issue/STR-244/completer-le-lecteur-linterface-et-les-metriques-manquantes-du-bareme)
 
 ---
 

--- a/docs/adr/042-controle-du-volume-et-temps-decoute.md
+++ b/docs/adr/042-controle-du-volume-et-temps-decoute.md
@@ -1,0 +1,189 @@
+# ADR 042 — Contrôle du volume dans l'application et temps d'écoute d'un direct
+
+**Date** : 2026-08-21
+**Statut** : Accepté
+**Ticket** : [STR-245](https://linear.app/streampulse/issue/STR-245)
+
+---
+
+## Contexte
+
+Le sujet énumère quatre éléments du « Lecteur Audio Avancé » : gestion du
+streaming, **barre de progression**, **contrôle du volume**, lecture en arrière-plan.
+Deux étaient acquis, deux manquaient.
+
+Le code documentait d'ailleurs l'absence du volume comme un choix
+(`audio_player_controller.dart` : « le volume est délégué au système, boutons
+matériels — pas de contrôle in-app »). L'arbitrage se défend en général : les
+boutons matériels existent, et un second réglage peut dérouter. Mais le sujet le
+liste nommément, et l'argument « le système le fait » ne tient qu'à moitié —
+baisser le volume système baisse aussi les notifications et les appels, alors
+qu'un auditeur veut souvent baisser *la radio*, pas son téléphone.
+
+---
+
+## 1. Le volume appartient au transport, pas au contrôleur
+
+`PlaybackTransport` gagne `volume`, `volumeStream` et `setVolume`. Le curseur
+s'y abonne **directement** ; il ne passe pas par `AudioPlayerController` ni par
+`PlaylistQueueController`.
+
+C'est la règle déjà posée pour la position de lecture (STR-230,
+`queue_progress.dart`) : un glissement émet des dizaines de valeurs par seconde,
+et les faire transiter par le `notifyListeners` d'un contrôleur app-level
+reconstruirait tout l'arbre sous lui à cette cadence.
+
+Le placer sur le **transport** et non sur l'une des deux interfaces dérivées a
+une seconde conséquence, utile : le même curseur sert le direct et la file
+d'attente. Le volume ne dépend pas de ce qu'on écoute.
+
+`app_providers.dart` expose donc un `Provider<PlaybackTransport>` pointant sur
+le même objet que les deux autres — le curseur dépend de l'interface la plus
+étroite qui porte ce dont il a besoin (principe I).
+
+---
+
+## 2. Le réglage de l'auditeur est la source de vérité, l'atténuation en dérive
+
+L'atténuation d'une interruption transitoire (ducking, [ADR 033](033-gestion-des-interruptions-audio.md))
+et le réglage de l'auditeur sont deux choses différentes. Le lecteur n'en connaît
+qu'une : son volume courant.
+
+La version précédente **capturait** `player.volume` juste avant d'atténuer, pour
+le restaurer ensuite. C'était correct tant que personne ne pouvait régler le
+volume. Depuis qu'un curseur existe, ce schéma a un défaut net : un réglage fait
+**pendant** l'interruption est écrasé à la restauration — l'auditeur baisse le
+son pendant sa notification, et le son remonte tout seul quand elle se termine.
+
+[`VolumeLevel`](../../mobile/lib/core/audio/volume_level.dart) inverse la
+dépendance : le réglage est conservé, l'atténuation est un **facteur** appliqué
+par-dessus, et le niveau envoyé au lecteur en dérive.
+
+| | Réglage auditeur | Envoyé au lecteur |
+| -- | -- | -- |
+| Normal | 0,8 | 0,8 |
+| Atténué | 0,8 | 0,32 |
+| Réglé pendant l'atténuation | 0,3 | 0,12 |
+| Atténuation levée | 0,3 | **0,3** |
+
+Un **facteur** et non un niveau absolu : atténuer à 0,4 en dur *remonterait* le
+son de quelqu'un qui écoute à 0,2.
+
+`volumeStream` publie le **réglage**, jamais le niveau effectif : sinon le
+curseur sauterait à chaque notification reçue, ce qui se lit comme un bug.
+
+Objet **pur**, comme `InterruptionPolicy` et `PlaybackOrder` : c'est la seule
+règle non triviale de tout ce ticket, et elle se vérifie sans lecteur.
+
+---
+
+## 3. Persistance dans `shared_preferences`, pas dans `SecureStorage`
+
+`SecureStorage` n'a qu'une responsabilité — les jetons JWT — et un niveau sonore
+n'est ni un secret ni quelque chose qu'on veut chiffrer. Le mélanger y aurait
+élargi la seule classe du projet dont la surface doit rester close.
+
+Une abstraction `VolumeStore` sépare le contrat de l'implémentation (principe D),
+ce qui permet aux tests de tourner sans plugin de plateforme.
+
+**Le réglage s'applique en continu, ne s'enregistre qu'une fois** : `onChanged`
+applique (l'auditeur doit entendre pendant qu'il glisse), `onChangeEnd`
+enregistre. Écrire à chaque tick userait le magasin pour un résultat identique.
+
+Le niveau est restauré **avant le premier rendu**, dans `main()`. Le retrouver
+après coup ferait démarrer la lecture au volume par défaut puis sauter — et cela
+s'entend. La restauration est best-effort, comme la configuration de la session
+audio : un magasin indisponible ne doit pas empêcher l'application de démarrer.
+
+---
+
+## 4. Un direct n'a pas de barre de progression, il a un temps d'écoute
+
+Le sujet demande une barre de progression. Un direct n'a pas de fin connue :
+il n'y a pas de fraction à remplir, et une barre qui n'avance jamais serait un
+mensonge visuel. Ce que l'auditeur peut vouloir savoir, c'est depuis combien de
+temps il écoute.
+
+### Pourquoi pas `positionStream`
+
+`just_audio` expose une position sur un flux HLS, et l'afficher aurait coûté une
+ligne. Mais cette position est relative à la **source chargée**, et le contrôleur
+recharge l'URL à chaque reprise après erreur (reconnexion bornée, STR-118). Une
+coupure réseau de deux secondes remettrait donc le compteur à zéro, sous un
+libellé qui promet « depuis le début de l'écoute ».
+
+[`ListeningClock`](../../mobile/lib/core/audio/listening_clock.dart) est pilotée
+par l'**état de lecture** et non par la source : elle traverse les rechargements.
+C'est la seule façon de tenir la promesse du libellé.
+
+Elle se met en pause **pendant une reconnexion** : c'est précisément le moment
+où l'auditeur n'entend rien, et laisser courir un compteur sur du silence
+surestimerait ce qu'il a réellement écouté.
+
+Objet pur là encore : l'appelant fournit l'instant, ce qui rend le comportement
+vérifiable sans attendre. Le widget qui l'affiche reçoit sa source de temps en
+paramètre injectable — `tester.pump(Duration)` n'avance que l'horloge simulée de
+Flutter, un `DateTime.now()` en dur aurait rendu tout le fichier invérifiable.
+
+Le tic bat **une fois par seconde et localement au widget** : rien au-dessus ne
+se reconstruit, et il s'arrête dès que l'horloge est suspendue.
+
+---
+
+## Conséquences
+
+**Positives**
+
+- Le volume se règle dans l'application, indépendamment du volume système.
+- Un réglage fait pendant une interruption survit à celle-ci.
+- Le niveau est retrouvé d'une session à l'autre.
+- Un direct affiche un temps d'écoute qui résiste aux reconnexions.
+- Aucun flux haute fréquence n'a été ajouté à un `ChangeNotifier` app-level.
+
+**Négatives, assumées**
+
+- Une dépendance de plus (`shared_preferences`), pour un seul réglage
+  aujourd'hui.
+- Le curseur n'est pas exposé aux commandes système (notification, écran
+  verrouillé) : `audio_service` ne relit pas cet état, il dériverait.
+- Le temps d'écoute compte le temps de **lecture**, pas le temps passé sur
+  l'écran : mettre en pause le fige. C'est voulu, mais quelqu'un peut s'attendre
+  à l'inverse.
+- Deux widgets tests de plus dépendent des providers `PlaybackTransport` et
+  `VolumeStore` — trois harnais existants ont dû les fournir.
+
+---
+
+## Alternatives écartées
+
+**Garder « le volume est délégué au système ».** L'arbitrage d'origine, et il se
+défend. Écarté parce que le sujet nomme le contrôle du volume comme un critère,
+et parce que baisser le volume système baisse aussi les notifications.
+
+**Faire passer le volume par un `ChangeNotifier` app-level.** Le plus court à
+écrire. Écarté pour la raison déjà donnée en STR-230 : un flux qui émet des
+dizaines de fois par seconde reconstruirait tout l'arbre sous le contrôleur.
+
+**Capturer le volume avant d'atténuer** (schéma d'origine). Écarté : un réglage
+fait pendant l'interruption serait écrasé à sa levée.
+
+**Afficher `positionStream` sur le direct.** Une ligne. Écarté : la position se
+remet à zéro à chaque rechargement de source, donc à chaque reconnexion.
+
+**Un chronomètre du temps passé sur l'écran plutôt que du temps de lecture.**
+Écarté : l'écran plein n'est pas l'écoute — la lecture survit à la navigation
+(ADR 031), et le mini-player continue ailleurs.
+
+**Stocker le volume dans `SecureStorage`.** Aucune dépendance à ajouter.
+Écarté : cette classe n'a qu'une responsabilité, et un volume n'est pas un
+secret.
+
+---
+
+## Références
+
+- [ADR 023 — Lecteur audio HLS mobile](023-lecteur-audio-hls-mobile.md)
+- [ADR 031 — Lecture audio en arrière-plan](031-lecture-audio-en-arriere-plan.md)
+- [ADR 033 — Gestion des interruptions audio](033-gestion-des-interruptions-audio.md) — le ducking dont dérive `VolumeLevel`
+- [ADR 034 — Lecture d'une playlist avec file d'attente](034-lecture-dune-playlist-avec-file-dattente.md) — `PlaybackTransport` et ses interfaces dérivées
+- [ADR 036 — State management Flutter](036-state-management-flutter-provider.md) — la règle sur les flux haute fréquence

--- a/docs/en/adr-index.md
+++ b/docs/en/adr-index.md
@@ -174,6 +174,16 @@ the system notification travels the same path as a tap in the app.
 **involuntary** reloads. *Consequence:* a token expiry no longer reshuffles the
 queue every fifteen minutes.
 
+**ADR 042 — In-app volume and live listening time.** *Context:* the brief lists
+a volume control and a progress bar; the code documented the absence of the
+former as a deliberate choice. *Decision:* put volume on `PlaybackTransport` —
+so one slider serves both live and queue — keep the listener's setting as the
+source of truth with ducking as a factor derived from it, and show a live's
+elapsed **listening time** rather than a progress bar. *Consequence:* a volume
+change made during an interruption survives it, and the elapsed counter survives
+a reconnection, where the player's own position would reset because the
+controller reloads the source.
+
 ## Administration
 
 **ADR 017 — Admin dashboard, user management.** *Context:* administration must

--- a/mobile/lib/app/app_providers.dart
+++ b/mobile/lib/app/app_providers.dart
@@ -71,7 +71,7 @@ class StreamPulseApp extends StatelessWidget {
         Provider<QueuePlaybackService>.value(value: queueService),
         // Le volume ne dépend pas de la source : le curseur lit l'interface la
         // plus étroite qui le porte (principe I) et fonctionne donc aussi bien
-        // pendant un direct que pendant une file d'attente (STR-245).
+        // pendant un direct que pendant une file d'attente (STR-244).
         Provider<PlaybackTransport>.value(value: audioService),
         Provider<VolumeStore>(
           create: (_) => const SharedPreferencesVolumeStore(),

--- a/mobile/lib/app/app_providers.dart
+++ b/mobile/lib/app/app_providers.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 
 import '../core/audio/audio_playback_service.dart';
+import '../core/audio/volume_store.dart';
 import '../core/audio/playback_auth.dart';
 import '../core/audio/queue_playback_service.dart';
 import '../core/network/dio_client.dart';
@@ -68,6 +69,13 @@ class StreamPulseApp extends StatelessWidget {
       providers: [
         Provider<AudioPlaybackService>.value(value: audioService),
         Provider<QueuePlaybackService>.value(value: queueService),
+        // Le volume ne dépend pas de la source : le curseur lit l'interface la
+        // plus étroite qui le porte (principe I) et fonctionne donc aussi bien
+        // pendant un direct que pendant une file d'attente (STR-245).
+        Provider<PlaybackTransport>.value(value: audioService),
+        Provider<VolumeStore>(
+          create: (_) => const SharedPreferencesVolumeStore(),
+        ),
         Provider<SecureStorage>(create: (_) => SecureStorage()),
         Provider<DioClient>(
           create: (ctx) => DioClient(ctx.read<SecureStorage>()),
@@ -115,8 +123,9 @@ class StreamPulseApp extends StatelessWidget {
               BroadcasterRemoteDataSource(ctx.read<DioClient>().broadcasterApi),
         ),
         Provider<BroadcasterRepository>(
-          create: (ctx) =>
-              BroadcasterRepositoryImpl(ctx.read<BroadcasterRemoteDataSource>()),
+          create: (ctx) => BroadcasterRepositoryImpl(
+            ctx.read<BroadcasterRemoteDataSource>(),
+          ),
         ),
         ChangeNotifierProvider<BroadcasterController>(
           create: (ctx) =>
@@ -144,8 +153,9 @@ class StreamPulseApp extends StatelessWidget {
         ChangeNotifierProvider<AudioPlayerController>(
           create: (ctx) => AudioPlayerController(
             service: ctx.read<AudioPlaybackService>(),
-            isManifestUnavailable:
-                ctx.read<StreamRepository>().isManifestUnavailable,
+            isManifestUnavailable: ctx
+                .read<StreamRepository>()
+                .isManifestUnavailable,
           ),
         ),
         Provider<OfflineDatabase>(create: (_) => OfflineDatabase()),
@@ -175,8 +185,9 @@ class StreamPulseApp extends StatelessWidget {
               service: ctx.read<QueuePlaybackService>(),
               token: ctx.read<PlaybackAuth>().token,
               stopLive: live.stop,
-              resolveTrackUri:
-                  ctx.read<OfflineCacheRepository>().cachedFilePath,
+              resolveTrackUri: ctx
+                  .read<OfflineCacheRepository>()
+                  .cachedFilePath,
             );
             live.onTakeOver = queue.clear;
             return queue;

--- a/mobile/lib/core/audio/listening_clock.dart
+++ b/mobile/lib/core/audio/listening_clock.dart
@@ -1,4 +1,4 @@
-/// Temps d'écoute cumulé d'un direct (STR-245).
+/// Temps d'écoute cumulé d'un direct (STR-244).
 ///
 /// Un direct n'a pas de durée — il n'a pas de fin connue — mais il a un temps
 /// d'écoute, et c'est cela que l'auditeur veut voir : « ça fait 12 minutes que

--- a/mobile/lib/core/audio/listening_clock.dart
+++ b/mobile/lib/core/audio/listening_clock.dart
@@ -1,0 +1,71 @@
+/// Temps d'écoute cumulé d'un direct (STR-245).
+///
+/// Un direct n'a pas de durée — il n'a pas de fin connue — mais il a un temps
+/// d'écoute, et c'est cela que l'auditeur veut voir : « ça fait 12 minutes que
+/// j'écoute ».
+///
+/// ## Pourquoi pas la position du lecteur
+///
+/// `just_audio` expose bien une `position` sur un flux HLS, et l'utiliser aurait
+/// coûté une ligne. Mais cette position est relative à la **source chargée**, et
+/// le contrôleur recharge l'URL à chaque reprise après erreur (reconnexion
+/// bornée, STR-118). Une coupure réseau de deux secondes remettrait donc le
+/// compteur à zéro, sous un libellé qui promet « depuis le début de l'écoute ».
+///
+/// Cette horloge est pilotée par l'**état de lecture**, pas par la source : elle
+/// traverse les rechargements. C'est la seule façon de tenir la promesse du
+/// libellé.
+///
+/// ## Objet pur
+///
+/// Aucune minuterie, aucun `DateTime.now()` interne, aucune dépendance Flutter —
+/// même parti que [InterruptionPolicy] et [PlaybackOrder] : l'appelant fournit
+/// l'instant, ce qui rend le comportement vérifiable sans attendre.
+class ListeningClock {
+  Duration _accumulated = Duration.zero;
+  DateTime? _startedAt;
+
+  /// Vrai si l'horloge tourne (l'auditeur entend quelque chose).
+  bool get running => _startedAt != null;
+
+  /// Démarre ou reprend le décompte. Idempotent : appelée alors que l'horloge
+  /// tourne déjà, elle ne redémarre pas — sinon chaque événement de lecture
+  /// répété (le lecteur en émet plusieurs pour un même état) décalerait
+  /// l'origine et le temps affiché reculerait.
+  void start(DateTime at) {
+    _startedAt ??= at;
+  }
+
+  /// Suspend le décompte en cumulant la tranche écoulée.
+  ///
+  /// Appelée à la pause **et pendant une reconnexion** : le compteur mesure du
+  /// temps d'écoute, et une reconnexion est précisément le moment où l'auditeur
+  /// n'écoute rien. Le figer est plus honnête que de le laisser courir sur du
+  /// silence.
+  void pause(DateTime at) {
+    final started = _startedAt;
+    if (started == null) return;
+    _accumulated += _nonNegative(at.difference(started));
+    _startedAt = null;
+  }
+
+  /// Repart de zéro. À appeler quand l'écoute change d'objet — autre flux, ou
+  /// arrêt — jamais sur une simple pause.
+  void reset() {
+    _accumulated = Duration.zero;
+    _startedAt = null;
+  }
+
+  /// Temps d'écoute à l'instant [now], tranche en cours comprise.
+  Duration elapsedAt(DateTime now) {
+    final started = _startedAt;
+    if (started == null) return _accumulated;
+    return _accumulated + _nonNegative(now.difference(started));
+  }
+
+  /// Une horloge murale peut reculer (fuseau, synchronisation NTP, changement
+  /// manuel). Un temps d'écoute négatif n'a aucun sens et ferait afficher un
+  /// compteur qui décroît : la tranche est alors comptée pour zéro.
+  static Duration _nonNegative(Duration d) =>
+      d.isNegative ? Duration.zero : d;
+}

--- a/mobile/lib/core/audio/playback_transport.dart
+++ b/mobile/lib/core/audio/playback_transport.dart
@@ -36,6 +36,28 @@ abstract class PlaybackTransport {
 
   bool get playing;
 
+  /// Niveau sonore **choisi par l'auditeur**, dans `[0, 1]` (STR-245).
+  ///
+  /// Ce n'est pas nécessairement le niveau appliqué au lecteur à l'instant t :
+  /// pendant l'atténuation d'une interruption (ducking, ADR 033) le lecteur
+  /// joue plus bas, mais le réglage de l'auditeur, lui, n'a pas changé — et
+  /// c'est celui-là que l'interface doit montrer.
+  double get volume;
+
+  /// Émet le niveau choisi à chaque changement. Comme la position de lecture,
+  /// **à consommer au plus près du widget** qui l'affiche : un glissement de
+  /// curseur émet des dizaines de valeurs par seconde, les faire transiter par
+  /// un `ChangeNotifier` app-level reconstruirait tout l'arbre à cette cadence.
+  Stream<double> get volumeStream;
+
+  /// Règle le niveau sonore de l'application. Valeur hors bornes ramenée dans
+  /// `[0, 1]`.
+  ///
+  /// Ne remplace pas les boutons matériels : ceux-ci pilotent le volume du
+  /// **système**, celui-ci atténue le flux de l'application à l'intérieur.
+  /// L'auditeur peut ainsi baisser StreamPulse sans baisser ses notifications.
+  Future<void> setVolume(double volume);
+
   Future<void> play();
   Future<void> pause();
 

--- a/mobile/lib/core/audio/playback_transport.dart
+++ b/mobile/lib/core/audio/playback_transport.dart
@@ -36,7 +36,7 @@ abstract class PlaybackTransport {
 
   bool get playing;
 
-  /// Niveau sonore **choisi par l'auditeur**, dans `[0, 1]` (STR-245).
+  /// Niveau sonore **choisi par l'auditeur**, dans `[0, 1]` (STR-244).
   ///
   /// Ce n'est pas nécessairement le niveau appliqué au lecteur à l'instant t :
   /// pendant l'atténuation d'une interruption (ducking, ADR 033) le lecteur

--- a/mobile/lib/core/audio/stream_audio_handler.dart
+++ b/mobile/lib/core/audio/stream_audio_handler.dart
@@ -7,6 +7,7 @@ import 'package:just_audio/just_audio.dart';
 import 'audio_playback_service.dart';
 import 'interruption_policy.dart';
 import 'queue_playback_service.dart';
+import 'volume_level.dart';
 
 /// Implémentation de [AudioPlaybackService] et [QueuePlaybackService] via
 /// `audio_service` + `just_audio` (STR-109/US-05-04, cf. ADR 031, 033 et 034).
@@ -29,7 +30,7 @@ class StreamAudioHandler extends BaseAudioHandler
   // `handleInterruptions: false` : c'est [InterruptionPolicy] qui arbitre les
   // appels entrants et le débranchement du casque (STR-110), pas just_audio.
   StreamAudioHandler({AudioPlayer? player})
-      : _player = player ?? AudioPlayer(handleInterruptions: false) {
+    : _player = player ?? AudioPlayer(handleInterruptions: false) {
     // Chaque événement du lecteur → un PlaybackState pour la notification. Les
     // erreurs sont routées vers [playbackErrors] (le contrôleur les gère), et
     // ne cassent pas le flux de la notification. Le handler vit aussi longtemps
@@ -48,22 +49,35 @@ class StreamAudioHandler extends BaseAudioHandler
   final _errors = StreamController<Object>.broadcast();
   final _interruptions = InterruptionPolicy();
 
-  /// Volume appliqué pendant l'atténuation (ducking) d'une interruption
-  /// transitoire (notification).
-  static const double _duckVolume = 0.4;
+  /// Réglage de l'auditeur et atténuation en cours (STR-245). La règle qui les
+  /// combine vit dans [VolumeLevel], objet pur — le handler ne fait que
+  /// l'appliquer au lecteur.
+  VolumeLevel _volumeLevel = const VolumeLevel();
 
-  /// Volume à restaurer après un ducking (capturé juste avant, pour ne pas
-  /// écraser un réglage éventuel plutôt que de remettre 1.0 en dur).
-  double _preDuckVolume = 1;
-
-  /// Vrai entre un `duck` et sa restauration : on ne touche au volume qu'après
-  /// avoir réellement atténué (sinon une reprise écraserait un réglage éventuel).
-  bool _ducked = false;
+  final _volumes = StreamController<double>.broadcast();
 
   /// File d'attente courante, vide en lecture de direct. Sert à choisir les
   /// contrôles de la notification (précédent/suivant n'ont de sens qu'ici) et à
   /// republier le `MediaItem` à chaque changement de piste.
   List<MediaItem> _queueItems = const [];
+
+  @override
+  double get volume => _volumeLevel.user;
+
+  @override
+  Stream<double> get volumeStream => _volumes.stream;
+
+  @override
+  Future<void> setVolume(double volume) async {
+    final next = _volumeLevel.withUser(volume);
+    if (next == _volumeLevel) return;
+    _volumeLevel = next;
+    // Le niveau publié est celui de l'auditeur, le niveau appliqué tient compte
+    // d'une atténuation en cours : régler le volume pendant une notification
+    // doit s'entendre tout de suite, sans annuler l'atténuation.
+    _volumes.add(next.user);
+    await _player.setVolume(next.effective);
+  }
 
   @override
   Stream<PlayerState> get playerStateStream => _player.playerStateStream;
@@ -110,12 +124,12 @@ class StreamAudioHandler extends BaseAudioHandler
   /// pas le même vocabulaire.
   @override
   Future<void> setRepeat(QueueRepeatMode mode) => _player.setLoopMode(
-        const {
-          QueueRepeatMode.off: LoopMode.off,
-          QueueRepeatMode.one: LoopMode.one,
-          QueueRepeatMode.all: LoopMode.all,
-        }[mode]!,
-      );
+    const {
+      QueueRepeatMode.off: LoopMode.off,
+      QueueRepeatMode.one: LoopMode.one,
+      QueueRepeatMode.all: LoopMode.all,
+    }[mode]!,
+  );
 
   @override
   Future<void> loadUri(String url, {required NowPlaying now}) async {
@@ -288,11 +302,11 @@ class StreamAudioHandler extends BaseAudioHandler
   }
 
   MediaItem _toMediaItem(QueueItem item) => MediaItem(
-        id: item.id,
-        title: item.title,
-        artist: item.artist,
-        duration: item.duration,
-      );
+    id: item.id,
+    title: item.title,
+    artist: item.artist,
+    duration: item.duration,
+  );
 
   /// Republie le `MediaItem` de la piste atteinte. Ne fait rien hors file
   /// d'attente : en direct, l'unique `MediaItem` est posé par [loadUri].
@@ -340,9 +354,8 @@ class StreamAudioHandler extends BaseAudioHandler
         // l'application a abandonnée entre-temps (garde `_hasSource`).
         unawaited(play());
       case InterruptionAction.duck:
-        _preDuckVolume = _player.volume; // capture avant d'atténuer
-        _ducked = true;
-        unawaited(_player.setVolume(_duckVolume));
+        _volumeLevel = _volumeLevel.withDucked(true);
+        unawaited(_player.setVolume(_volumeLevel.effective));
       case InterruptionAction.unduck:
         _restoreVolumeIfDucked();
       case InterruptionAction.none:
@@ -350,12 +363,15 @@ class StreamAudioHandler extends BaseAudioHandler
     }
   }
 
-  /// Restaure le volume d'avant l'atténuation **uniquement** si on avait
-  /// effectivement atténué — sinon on ne touche pas à un réglage éventuel.
+  /// Lève l'atténuation en revenant au niveau **choisi par l'auditeur**, et non
+  /// à un niveau capturé avant le duck : si le curseur a bougé entre-temps,
+  /// c'est le nouveau réglage qui doit survivre à l'interruption.
+  ///
+  /// Ne fait rien hors d'un duck, pour ne pas réécrire le volume sans raison.
   void _restoreVolumeIfDucked() {
-    if (!_ducked) return;
-    _ducked = false;
-    unawaited(_player.setVolume(_preDuckVolume));
+    if (!_volumeLevel.ducked) return;
+    _volumeLevel = _volumeLevel.withDucked(false);
+    unawaited(_player.setVolume(_volumeLevel.effective));
   }
 
   /// Mappe un événement just_audio vers l'état `audio_service` qui pilote la
@@ -389,13 +405,14 @@ class StreamAudioHandler extends BaseAudioHandler
       // `?? idle` : une valeur d'enum ajoutée par une future version de
       // just_audio ne doit pas lever dans ce listener (ça tuerait le flux de
       // playbackState → notification figée).
-      processingState: const {
-        ProcessingState.idle: AudioProcessingState.idle,
-        ProcessingState.loading: AudioProcessingState.loading,
-        ProcessingState.buffering: AudioProcessingState.buffering,
-        ProcessingState.ready: AudioProcessingState.ready,
-        ProcessingState.completed: AudioProcessingState.completed,
-      }[_player.processingState] ??
+      processingState:
+          const {
+            ProcessingState.idle: AudioProcessingState.idle,
+            ProcessingState.loading: AudioProcessingState.loading,
+            ProcessingState.buffering: AudioProcessingState.buffering,
+            ProcessingState.ready: AudioProcessingState.ready,
+            ProcessingState.completed: AudioProcessingState.completed,
+          }[_player.processingState] ??
           AudioProcessingState.idle,
       playing: playing,
       updatePosition: _player.position,

--- a/mobile/lib/core/audio/stream_audio_handler.dart
+++ b/mobile/lib/core/audio/stream_audio_handler.dart
@@ -49,7 +49,7 @@ class StreamAudioHandler extends BaseAudioHandler
   final _errors = StreamController<Object>.broadcast();
   final _interruptions = InterruptionPolicy();
 
-  /// Réglage de l'auditeur et atténuation en cours (STR-245). La règle qui les
+  /// Réglage de l'auditeur et atténuation en cours (STR-244). La règle qui les
   /// combine vit dans [VolumeLevel], objet pur — le handler ne fait que
   /// l'appliquer au lecteur.
   VolumeLevel _volumeLevel = const VolumeLevel();

--- a/mobile/lib/core/audio/volume_level.dart
+++ b/mobile/lib/core/audio/volume_level.dart
@@ -1,0 +1,61 @@
+/// Niveau sonore de l'application, en deux valeurs distinctes (STR-245) :
+/// celle que l'auditeur a choisie, et celle réellement envoyée au lecteur.
+///
+/// Les deux divergent pendant l'atténuation d'une interruption transitoire
+/// (ducking, ADR 033) : une notification arrive, le flux baisse, mais le
+/// **réglage** de l'auditeur n'a pas changé — et c'est celui-là que le curseur
+/// doit montrer. Confondre les deux ferait sauter le curseur à chaque
+/// notification reçue, ce qui se lit comme un bug.
+///
+/// ## Ce que cet objet corrige
+///
+/// La version précédente capturait `player.volume` au moment du duck pour le
+/// restaurer après. Cela marchait tant que personne ne pouvait régler le
+/// volume. Depuis qu'un curseur existe, un réglage fait **pendant**
+/// l'interruption était écrasé à la restauration : l'auditeur baissait le son
+/// pendant sa notification, et le son remontait tout seul à la fin.
+///
+/// Ici le réglage est la source de vérité et l'atténuation en dérive, si bien
+/// que le cas ne peut plus se produire.
+///
+/// Objet **pur** et immuable, comme [InterruptionPolicy] et [PlaybackOrder] :
+/// la règle se vérifie sans lecteur ni plateforme.
+class VolumeLevel {
+  const VolumeLevel({this.user = 1, this.ducked = false});
+
+  /// Facteur appliqué pendant une atténuation.
+  ///
+  /// Un **facteur** et non un niveau absolu : atténuer à 0,4 en dur remonterait
+  /// le son de quelqu'un qui écoute à 0,2.
+  static const double duckFactor = 0.4;
+
+  /// Niveau choisi par l'auditeur, dans `[0, 1]`.
+  final double user;
+
+  /// Vrai pendant une atténuation.
+  final bool ducked;
+
+  /// Niveau à envoyer au lecteur.
+  double get effective => ducked ? user * duckFactor : user;
+
+  /// Applique un nouveau réglage. La valeur est ramenée dans `[0, 1]` :
+  /// `just_audio` accepte des valeurs supérieures à 1 (amplification) mais le
+  /// curseur ne les propose pas, et une valeur venue d'un magasin de
+  /// préférences trafiqué ne doit pas saturer le son.
+  VolumeLevel withUser(double value) =>
+      VolumeLevel(user: value.clamp(0.0, 1.0), ducked: ducked);
+
+  /// Entre ou sort de l'atténuation, sans toucher au réglage.
+  VolumeLevel withDucked(bool value) =>
+      VolumeLevel(user: user, ducked: value);
+
+  @override
+  bool operator ==(Object other) =>
+      other is VolumeLevel && other.user == user && other.ducked == ducked;
+
+  @override
+  int get hashCode => Object.hash(user, ducked);
+
+  @override
+  String toString() => 'VolumeLevel(user: $user, ducked: $ducked)';
+}

--- a/mobile/lib/core/audio/volume_level.dart
+++ b/mobile/lib/core/audio/volume_level.dart
@@ -1,4 +1,4 @@
-/// Niveau sonore de l'application, en deux valeurs distinctes (STR-245) :
+/// Niveau sonore de l'application, en deux valeurs distinctes (STR-244) :
 /// celle que l'auditeur a choisie, et celle réellement envoyée au lecteur.
 ///
 /// Les deux divergent pendant l'atténuation d'une interruption transitoire

--- a/mobile/lib/core/audio/volume_store.dart
+++ b/mobile/lib/core/audio/volume_store.dart
@@ -1,6 +1,6 @@
 import 'package:shared_preferences/shared_preferences.dart';
 
-/// Persistance du niveau sonore choisi par l'auditeur (STR-245).
+/// Persistance du niveau sonore choisi par l'auditeur (STR-244).
 ///
 /// Interface séparée de l'implémentation (principe D) pour la même raison que
 /// `AudioPlaybackService` : le noyau audio n'a pas à connaître le magasin, et

--- a/mobile/lib/core/audio/volume_store.dart
+++ b/mobile/lib/core/audio/volume_store.dart
@@ -1,0 +1,56 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Persistance du niveau sonore choisi par l'auditeur (STR-245).
+///
+/// Interface séparée de l'implémentation (principe D) pour la même raison que
+/// `AudioPlaybackService` : le noyau audio n'a pas à connaître le magasin, et
+/// les tests n'ont pas à faire tourner de plugin de plateforme.
+///
+/// Ce n'est **pas** [SecureStorage] : celui-ci n'a qu'une responsabilité, les
+/// jetons JWT, et un niveau sonore n'est ni un secret ni quelque chose qu'on
+/// veut chiffrer.
+abstract class VolumeStore {
+  /// Niveau enregistré dans `[0, 1]`, ou `null` si l'auditeur n'a jamais réglé
+  /// le volume — auquel cas l'appelant garde le défaut du lecteur.
+  Future<double?> read();
+
+  Future<void> write(double volume);
+}
+
+/// Implémentation sur `shared_preferences`.
+class SharedPreferencesVolumeStore implements VolumeStore {
+  const SharedPreferencesVolumeStore();
+
+  static const _key = 'playback_volume';
+
+  @override
+  Future<double?> read() async {
+    final prefs = await SharedPreferences.getInstance();
+    final stored = prefs.getDouble(_key);
+    if (stored == null) return null;
+    // Une valeur hors bornes ne peut venir que d'une écriture d'une autre
+    // version de l'application, ou d'un fichier de préférences trafiqué.
+    // `setVolume` la refuserait : on la ramène plutôt que de laisser
+    // l'application démarrer sur une exception.
+    return stored.clamp(0.0, 1.0);
+  }
+
+  @override
+  Future<void> write(double volume) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setDouble(_key, volume.clamp(0.0, 1.0));
+  }
+}
+
+/// Magasin en mémoire, pour les tests et les plateformes sans plugin.
+class InMemoryVolumeStore implements VolumeStore {
+  InMemoryVolumeStore([this._volume]);
+
+  double? _volume;
+
+  @override
+  Future<double?> read() async => _volume;
+
+  @override
+  Future<void> write(double volume) async => _volume = volume.clamp(0.0, 1.0);
+}

--- a/mobile/lib/core/widgets/volume_slider.dart
+++ b/mobile/lib/core/widgets/volume_slider.dart
@@ -1,0 +1,150 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../audio/playback_transport.dart';
+import '../audio/volume_store.dart';
+
+/// Réglage du niveau sonore de l'application (STR-245).
+///
+/// Le volume appartient au **transport**, pas à une source : le même curseur
+/// sert donc au direct et à la file d'attente, et lit l'interface la plus
+/// étroite qui le porte ([PlaybackTransport], principe I).
+///
+/// ## Pourquoi pas un `ChangeNotifier` app-level
+///
+/// Un glissement émet des dizaines de valeurs par seconde. Les faire transiter
+/// par un contrôleur applicatif reconstruirait tout l'arbre sous lui à cette
+/// cadence — même règle que la position de lecture (`queue_progress.dart`). Ce
+/// widget s'abonne donc directement au flux, une fois, et ne reconstruit que
+/// lui-même.
+///
+/// ## Réglage appliqué en continu, enregistré une fois
+///
+/// `onChanged` applique (l'auditeur doit entendre pendant qu'il glisse),
+/// `onChangeEnd` enregistre. Écrire à chaque tick userait le magasin pour un
+/// résultat identique — seule la valeur relâchée compte.
+///
+/// Ce curseur ne remplace pas les boutons matériels : ceux-ci pilotent le
+/// volume du **système**, celui-ci atténue StreamPulse à l'intérieur. On peut
+/// donc baisser la radio sans baisser ses notifications.
+class VolumeSlider extends StatefulWidget {
+  const VolumeSlider({super.key, this.showLabel = true});
+
+  /// Affiche le pourcentage à droite du curseur. Coupé sur les surfaces
+  /// étroites où la place manque.
+  final bool showLabel;
+
+  @override
+  State<VolumeSlider> createState() => _VolumeSliderState();
+}
+
+class _VolumeSliderState extends State<VolumeSlider> {
+  late final PlaybackTransport _transport;
+  late final VolumeStore _store;
+  StreamSubscription<double>? _subscription;
+
+  double _volume = 1;
+
+  /// Niveau d'avant la coupure, restauré au second appui sur l'icône. Nul tant
+  /// que le son n'a pas été coupé depuis ce widget.
+  double? _beforeMute;
+
+  @override
+  void initState() {
+    super.initState();
+    _transport = context.read<PlaybackTransport>();
+    _store = context.read<VolumeStore>();
+    // Valeur de départ lue directement : le flux n'émet qu'aux changements,
+    // s'y fier seul laisserait le curseur à sa valeur par défaut jusqu'au
+    // premier réglage.
+    _volume = _transport.volume;
+    _subscription = _transport.volumeStream.listen((value) {
+      if (!mounted) return;
+      setState(() => _volume = value);
+    });
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _apply(double value) => _transport.setVolume(value);
+
+  Future<void> _persist(double value) => _store.write(value);
+
+  Future<void> _toggleMute() async {
+    if (_volume > 0) {
+      _beforeMute = _volume;
+      await _apply(0);
+      await _persist(0);
+      return;
+    }
+    // Restaurer à 1 quand rien n'a été mémorisé : l'auditeur a démarré
+    // l'application déjà en sourdine, l'appui doit lui rendre du son plutôt
+    // que de ne rien faire.
+    final restored = _beforeMute ?? 1.0;
+    _beforeMute = null;
+    await _apply(restored);
+    await _persist(restored);
+  }
+
+  IconData get _icon {
+    if (_volume <= 0) return Icons.volume_off;
+    if (_volume < 0.5) return Icons.volume_down;
+    return Icons.volume_up;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    final text = Theme.of(context).textTheme;
+    final percent = (_volume * 100).round();
+
+    return Row(
+      children: [
+        IconButton(
+          key: const Key('volume_mute_toggle'),
+          onPressed: _toggleMute,
+          icon: Icon(_icon, color: colors.onSurfaceVariant),
+          // Un tooltip n'est pas lu par TalkBack/VoiceOver comme un libellé :
+          // il faut les deux (STR-245).
+          tooltip: _volume <= 0 ? 'Rétablir le son' : 'Couper le son',
+        ),
+        Expanded(
+          child: SliderTheme(
+            data: SliderTheme.of(context).copyWith(
+              trackHeight: 2,
+              thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 6),
+              overlayShape: const RoundSliderOverlayShape(overlayRadius: 14),
+            ),
+            child: Slider(
+              key: const Key('volume_slider'),
+              value: _volume.clamp(0.0, 1.0),
+              // Le lecteur d'écran annonce « 42 pour cent » plutôt que « 0.42 ».
+              semanticFormatterCallback: (value) =>
+                  'Volume ${(value * 100).round()} %',
+              onChanged: (value) {
+                setState(() => _volume = value);
+                unawaited(_apply(value));
+              },
+              onChangeEnd: (value) => unawaited(_persist(value)),
+            ),
+          ),
+        ),
+        if (widget.showLabel)
+          SizedBox(
+            width: 40,
+            child: Text(
+              '$percent %',
+              textAlign: TextAlign.end,
+              style: text.bodySmall?.copyWith(color: colors.onSurfaceVariant),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/mobile/lib/core/widgets/volume_slider.dart
+++ b/mobile/lib/core/widgets/volume_slider.dart
@@ -6,7 +6,7 @@ import 'package:provider/provider.dart';
 import '../audio/playback_transport.dart';
 import '../audio/volume_store.dart';
 
-/// Réglage du niveau sonore de l'application (STR-245).
+/// Réglage du niveau sonore de l'application (STR-244).
 ///
 /// Le volume appartient au **transport**, pas à une source : le même curseur
 /// sert donc au direct et à la file d'attente, et lit l'interface la plus
@@ -111,7 +111,7 @@ class _VolumeSliderState extends State<VolumeSlider> {
           onPressed: _toggleMute,
           icon: Icon(_icon, color: colors.onSurfaceVariant),
           // Un tooltip n'est pas lu par TalkBack/VoiceOver comme un libellé :
-          // il faut les deux (STR-245).
+          // il faut les deux (STR-244).
           tooltip: _volume <= 0 ? 'Rétablir le son' : 'Couper le son',
         ),
         Expanded(

--- a/mobile/lib/features/playlists/presentation/widgets/playback_queue_sheet.dart
+++ b/mobile/lib/features/playlists/presentation/widgets/playback_queue_sheet.dart
@@ -5,6 +5,7 @@ import '../providers/playlist_queue_controller.dart';
 import '../track_labels.dart';
 import 'queue_progress.dart';
 import 'queue_track_visuals.dart';
+import '../../../../core/widgets/volume_slider.dart';
 
 /// File d'attente en cours de lecture (US-05-04), en feuille modale.
 ///
@@ -70,6 +71,13 @@ class PlaybackQueueSheet extends StatelessWidget {
           // Avancement manipulable (STR-230) : c'est la surface qui a la place
           // d'accueillir un pouce, contrairement au bandeau.
           const QueueProgressSlider(),
+          // Volume ici pour la même raison que la barre d'avancement : le
+          // bandeau de 60 px n'a pas la place d'un curseur qu'on vise au pouce
+          // (STR-245). Il pilote le même transport que pendant un direct.
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 12),
+            child: VolumeSlider(showLabel: false),
+          ),
           // Les modes vivent ici plutôt que sur le mini-player : celui-ci n'a
           // que 60 px de haut et porte déjà quatre boutons, et c'est la file
           // affichée juste dessous qui rend leur effet lisible.
@@ -132,7 +140,10 @@ class _QueueModeBar extends StatelessWidget {
   Widget build(BuildContext context) {
     final queue = context.watch<PlaylistQueueController>();
 
-    final (IconData repeatIcon, String repeatLabel) = switch (queue.repeatMode) {
+    final (
+      IconData repeatIcon,
+      String repeatLabel,
+    ) = switch (queue.repeatMode) {
       QueueRepeatMode.off => (Icons.repeat, 'Répétition'),
       QueueRepeatMode.all => (Icons.repeat, 'Répéter la file'),
       QueueRepeatMode.one => (Icons.repeat_one, 'Répéter la piste'),
@@ -201,11 +212,7 @@ class _ModeButton extends StatelessWidget {
           foregroundColor: active ? colors.primary : colors.onSurfaceVariant,
         ),
         icon: Icon(icon),
-        label: Text(
-          label,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-        ),
+        label: Text(label, maxLines: 1, overflow: TextOverflow.ellipsis),
       ),
     );
   }

--- a/mobile/lib/features/playlists/presentation/widgets/playback_queue_sheet.dart
+++ b/mobile/lib/features/playlists/presentation/widgets/playback_queue_sheet.dart
@@ -73,7 +73,7 @@ class PlaybackQueueSheet extends StatelessWidget {
           const QueueProgressSlider(),
           // Volume ici pour la même raison que la barre d'avancement : le
           // bandeau de 60 px n'a pas la place d'un curseur qu'on vise au pouce
-          // (STR-245). Il pilote le même transport que pendant un direct.
+          // (STR-244). Il pilote le même transport que pendant un direct.
           const Padding(
             padding: EdgeInsets.symmetric(horizontal: 12),
             child: VolumeSlider(showLabel: false),

--- a/mobile/lib/features/streams/presentation/providers/audio_player_controller.dart
+++ b/mobile/lib/features/streams/presentation/providers/audio_player_controller.dart
@@ -45,7 +45,7 @@ typedef ManifestUnavailableProbe = Future<bool> Function(String streamId);
 /// erreurs (STR-118) par une **reconnexion automatique bornée** (perte réseau)
 /// puis un état d'erreur clair (flux indisponible).
 ///
-/// Le **volume ne passe pas par ce contrôleur** (STR-245) : il vit sur le
+/// Le **volume ne passe pas par ce contrôleur** (STR-244) : il vit sur le
 /// transport, et le curseur s'y abonne directement. Un glissement émet des
 /// dizaines de valeurs par seconde ; les faire transiter par un `notifyListeners`
 /// app-level reconstruirait tout l'arbre sous ce contrôleur à cette cadence.

--- a/mobile/lib/features/streams/presentation/providers/audio_player_controller.dart
+++ b/mobile/lib/features/streams/presentation/providers/audio_player_controller.dart
@@ -41,10 +41,14 @@ typedef ManifestUnavailableProbe = Future<bool> Function(String streamId);
 /// Contrôleur du lecteur audio HLS, **hissé au niveau application** (STR-109,
 /// cf. [ADR 031]). Pilote un [AudioPlaybackService] partagé (service de premier
 /// plan `audio_service`) : la lecture survit à la navigation et à la mise en
-/// arrière-plan. Expose un état applicatif simple + play/pause (le volume est
-/// délégué au système, boutons matériels — pas de contrôle in-app), et gère
-/// les erreurs (STR-118) par une **reconnexion automatique bornée** (perte
-/// réseau) puis un état d'erreur clair (flux indisponible).
+/// arrière-plan. Expose un état applicatif simple + play/pause, et gère les
+/// erreurs (STR-118) par une **reconnexion automatique bornée** (perte réseau)
+/// puis un état d'erreur clair (flux indisponible).
+///
+/// Le **volume ne passe pas par ce contrôleur** (STR-245) : il vit sur le
+/// transport, et le curseur s'y abonne directement. Un glissement émet des
+/// dizaines de valeurs par seconde ; les faire transiter par un `notifyListeners`
+/// app-level reconstruirait tout l'arbre sous ce contrôleur à cette cadence.
 class AudioPlayerController extends PlaybackController {
   AudioPlayerController({
     required AudioPlaybackService service,

--- a/mobile/lib/features/streams/presentation/screens/stream_player_screen.dart
+++ b/mobile/lib/features/streams/presentation/screens/stream_player_screen.dart
@@ -142,7 +142,7 @@ class _StreamPlayerScreenState extends State<StreamPlayerScreen> {
                       const SizedBox(height: 16),
                       // Temps d'écoute plutôt qu'une barre de progression : un
                       // direct n'a pas de fin connue, donc pas de fraction à
-                      // remplir (STR-245).
+                      // remplir (STR-244).
                       ListeningTime(controller: _audio),
                       const SizedBox(height: 16),
                       _statusLine(colors, text),

--- a/mobile/lib/features/streams/presentation/screens/stream_player_screen.dart
+++ b/mobile/lib/features/streams/presentation/screens/stream_player_screen.dart
@@ -7,8 +7,10 @@ import '../../../../core/errors/exceptions.dart';
 import '../../../../core/permissions/notification_permission.dart';
 import '../../../auth/presentation/widgets/auth_toasts.dart';
 import '../../domain/entities/live_stream.dart';
+import '../../../../core/widgets/volume_slider.dart';
 import '../providers/audio_player_controller.dart';
 import '../providers/favorites_controller.dart';
+import '../widgets/listening_time.dart';
 
 /// Lecteur audio HLS plein écran (STR-108/117, cf. ADR 023). L'audio est piloté
 /// par le [AudioPlayerController] **partagé** app-level (STR-109) : la lecture
@@ -66,7 +68,8 @@ class _StreamPlayerScreenState extends State<StreamPlayerScreen> {
     // Arrivée par deep-link : pas de métadonnées → placeholder pour l'update optimiste.
     final isPlaceholder = widget.stream == null;
     final wasFavorited = controller.isFavorited(widget.streamId);
-    final favorite = widget.stream ??
+    final favorite =
+        widget.stream ??
         LiveStream(id: widget.streamId, title: 'Flux', startedAt: null);
     try {
       await controller.toggle(favorite);
@@ -95,8 +98,9 @@ class _StreamPlayerScreenState extends State<StreamPlayerScreen> {
     final subtitle =
         widget.stream?.broadcasterName ?? _audio.nowPlaying?.broadcaster;
     final listeners = widget.stream?.listenerCount;
-    final isFavorited =
-        context.watch<FavoritesController>().isFavorited(widget.streamId);
+    final isFavorited = context.watch<FavoritesController>().isFavorited(
+      widget.streamId,
+    );
 
     return Scaffold(
       body: SafeArea(
@@ -118,25 +122,37 @@ class _StreamPlayerScreenState extends State<StreamPlayerScreen> {
                       Text(
                         title,
                         textAlign: TextAlign.center,
-                        style: text.headlineSmall
-                            ?.copyWith(fontWeight: FontWeight.bold),
+                        style: text.headlineSmall?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
                       ),
                       if (subtitle != null && subtitle.isNotEmpty) ...[
                         const SizedBox(height: 6),
                         Text(
                           subtitle,
-                          style:
-                              text.titleMedium?.copyWith(color: colors.primary),
+                          style: text.titleMedium?.copyWith(
+                            color: colors.primary,
+                          ),
                         ),
                       ],
                       if (listeners != null) ...[
                         const SizedBox(height: 10),
                         _listeners(colors, text, listeners),
                       ],
-                      const SizedBox(height: 24),
+                      const SizedBox(height: 16),
+                      // Temps d'écoute plutôt qu'une barre de progression : un
+                      // direct n'a pas de fin connue, donc pas de fraction à
+                      // remplir (STR-245).
+                      ListeningTime(controller: _audio),
+                      const SizedBox(height: 16),
                       _statusLine(colors, text),
                       const SizedBox(height: 28),
                       _controls(colors, isFavorited),
+                      const SizedBox(height: 20),
+                      // Le curseur s'abonne seul au flux de volume : il est donc
+                      // posé HORS du ListenableBuilder pour ce qui le concerne,
+                      // et n'entraîne aucune reconstruction de l'écran.
+                      const VolumeSlider(),
                       const SizedBox(height: 24),
                     ],
                   ),
@@ -254,8 +270,9 @@ class _StreamPlayerScreenState extends State<StreamPlayerScreen> {
       return _busyLine(colors, text, 'Chargement…');
     }
     if (_audio.hasError || _audio.isEnded) {
-      final msg =
-          _audio.isEnded ? 'Le direct est terminé' : 'Flux indisponible';
+      final msg = _audio.isEnded
+          ? 'Le direct est terminé'
+          : 'Flux indisponible';
       return Text(
         msg,
         textAlign: TextAlign.center,
@@ -275,12 +292,16 @@ class _StreamPlayerScreenState extends State<StreamPlayerScreen> {
         SizedBox(
           width: 14,
           height: 14,
-          child:
-              CircularProgressIndicator(strokeWidth: 2, color: colors.primary),
+          child: CircularProgressIndicator(
+            strokeWidth: 2,
+            color: colors.primary,
+          ),
         ),
         const SizedBox(width: 10),
-        Text(label,
-            style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant)),
+        Text(
+          label,
+          style: text.bodyMedium?.copyWith(color: colors.onSurfaceVariant),
+        ),
       ],
     );
   }
@@ -307,7 +328,10 @@ class _StreamPlayerScreenState extends State<StreamPlayerScreen> {
       icon = SizedBox(
         width: 28,
         height: 28,
-        child: CircularProgressIndicator(strokeWidth: 3, color: colors.onPrimary),
+        child: CircularProgressIndicator(
+          strokeWidth: 3,
+          color: colors.onPrimary,
+        ),
       );
     } else if (_audio.hasError || _audio.isEnded) {
       icon = Icon(Icons.replay, size: 36, color: colors.onPrimary);
@@ -324,11 +348,7 @@ class _StreamPlayerScreenState extends State<StreamPlayerScreen> {
       child: InkWell(
         customBorder: const CircleBorder(),
         onTap: _audio.togglePlayPause,
-        child: SizedBox(
-          width: 76,
-          height: 76,
-          child: Center(child: icon),
-        ),
+        child: SizedBox(width: 76, height: 76, child: Center(child: icon)),
       ),
     );
   }

--- a/mobile/lib/features/streams/presentation/widgets/listening_time.dart
+++ b/mobile/lib/features/streams/presentation/widgets/listening_time.dart
@@ -1,0 +1,146 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../../../../core/audio/listening_clock.dart';
+import '../providers/audio_player_controller.dart';
+
+/// Temps d'écoute d'un direct (STR-245).
+///
+/// Le sujet demande une barre de progression au lecteur. Un direct n'en a pas :
+/// il n'a pas de fin connue, donc pas de fraction à remplir, et une barre qui
+/// n'avance jamais serait un mensonge visuel. Ce qu'il a — et ce que l'auditeur
+/// veut savoir — c'est depuis combien de temps il écoute.
+///
+/// La valeur vient d'une [ListeningClock] pilotée par l'**état de lecture**, et
+/// non de `positionStream`. La raison est dans `listening_clock.dart` : le
+/// contrôleur recharge l'URL à chaque reprise après erreur (STR-118), ce qui
+/// remettrait la position du lecteur à zéro à la moindre coupure réseau.
+///
+/// Le tic est **local à ce widget**. Il bat une fois par seconde, et rien
+/// au-dessus ne se reconstruit — même règle que la position de la file
+/// d'attente (`queue_progress.dart`).
+class ListeningTime extends StatefulWidget {
+  const ListeningTime({super.key, required this.controller, this.now});
+
+  final PlaybackController controller;
+
+  /// Source de l'heure courante. Injectable parce que `tester.pump(Duration)`
+  /// n'avance que l'horloge **simulée** de Flutter : un widget qui appellerait
+  /// `DateTime.now()` en dur ne verrait jamais le temps passer sous test, et
+  /// tout ce fichier serait invérifiable. Même parti que le `controller`
+  /// injectable de `StreamPlayerScreen`.
+  final DateTime Function()? now;
+
+  @override
+  State<ListeningTime> createState() => _ListeningTimeState();
+}
+
+class _ListeningTimeState extends State<ListeningTime> {
+  final _clock = ListeningClock();
+  Timer? _ticker;
+
+  DateTime _now() => (widget.now ?? DateTime.now)();
+
+  /// Flux auquel le décompte se rapporte. Changer de direct redémarre
+  /// l'horloge : sans ce repère, le temps d'écoute d'une radio serait
+  /// attribué à la suivante.
+  String? _streamId;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_onPlaybackChanged);
+    _onPlaybackChanged();
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_onPlaybackChanged);
+    _ticker?.cancel();
+    super.dispose();
+  }
+
+  void _onPlaybackChanged() {
+    final controller = widget.controller;
+    final streamId = controller.nowPlaying?.streamId;
+
+    if (streamId != _streamId) {
+      _streamId = streamId;
+      _clock.reset();
+    }
+
+    // L'horloge ne tourne que pendant une lecture effective. Une reconnexion
+    // n'en est pas une : l'auditeur n'entend rien, et un compteur qui court sur
+    // du silence surestimerait ce qu'il a réellement écouté.
+    if (controller.isPlaying) {
+      _clock.start(_now());
+    } else {
+      // Couvre aussi la fin de flux et l'erreur : dans les deux cas plus rien
+      // ne joue, et le compteur doit s'arrêter là où l'écoute s'est arrêtée.
+      _clock.pause(_now());
+    }
+
+    _syncTicker();
+    if (mounted) setState(() {});
+  }
+
+  /// Le tic ne bat que quand l'horloge tourne : une lecture en pause n'a aucune
+  /// raison de réveiller l'application chaque seconde.
+  void _syncTicker() {
+    if (_clock.running && _ticker == null) {
+      _ticker = Timer.periodic(const Duration(seconds: 1), (_) {
+        if (mounted) setState(() {});
+      });
+    } else if (!_clock.running) {
+      _ticker?.cancel();
+      _ticker = null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    final text = Theme.of(context).textTheme;
+    final elapsed = _clock.elapsedAt(_now());
+
+    // Rien à afficher avant la première seconde écoutée : un « 00:00 » figé
+    // pendant le chargement laisse croire que la lecture est bloquée.
+    if (elapsed == Duration.zero) return const SizedBox.shrink();
+
+    final label = formatListeningTime(elapsed);
+    return Semantics(
+      // Sans libellé, un lecteur d'écran annonce « 12 deux-points 03 », ce qui
+      // ne veut rien dire hors contexte visuel.
+      label: 'Temps d\'écoute : $label',
+      excludeSemantics: true,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.schedule, size: 16, color: colors.onSurfaceVariant),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: text.bodyMedium?.copyWith(
+              color: colors.onSurfaceVariant,
+              // Chiffres à chasse fixe : sans cela, la ligne se décale à chaque
+              // seconde parce que « 1 » est plus étroit que « 8 ».
+              fontFeatures: const [FontFeature.tabularFigures()],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// `mm:ss` en deçà d'une heure, `h:mm:ss` au-delà — une écoute de trois heures
+/// affichée « 180:24 » se lit mal.
+String formatListeningTime(Duration elapsed) {
+  final seconds = elapsed.inSeconds;
+  final s = (seconds % 60).toString().padLeft(2, '0');
+  final m = (seconds ~/ 60) % 60;
+  final h = seconds ~/ 3600;
+  if (h == 0) return '${m.toString().padLeft(2, '0')}:$s';
+  return '$h:${m.toString().padLeft(2, '0')}:$s';
+}

--- a/mobile/lib/features/streams/presentation/widgets/listening_time.dart
+++ b/mobile/lib/features/streams/presentation/widgets/listening_time.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 import '../../../../core/audio/listening_clock.dart';
 import '../providers/audio_player_controller.dart';
 
-/// Temps d'écoute d'un direct (STR-245).
+/// Temps d'écoute d'un direct (STR-244).
 ///
 /// Le sujet demande une barre de progression au lecteur. Un direct n'en a pas :
 /// il n'a pas de fin connue, donc pas de fraction à remplir, et une barre qui

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'app/app.dart';
 import 'app/app_providers.dart';
 import 'core/audio/stream_audio_handler.dart';
+import 'core/audio/volume_store.dart';
 
 // StreamPulseApp pose le MultiProvider racine (injection de dépendances)
 // au-dessus de l'arbre de widgets.
@@ -36,6 +37,21 @@ Future<void> main() async {
   } catch (e) {
     if (kDebugMode) {
       debugPrint('main: configuration de la session audio échouée: $e');
+    }
+  }
+
+  // Niveau sonore de la session précédente (STR-245). Appliqué avant le premier
+  // rendu : le retrouver après coup ferait démarrer la lecture au volume par
+  // défaut puis sauter, ce qui s'entend.
+  //
+  // Best-effort, comme la session audio : un magasin de préférences indisponible
+  // ne doit pas empêcher l'application de démarrer — on repart du défaut.
+  try {
+    final stored = await const SharedPreferencesVolumeStore().read();
+    if (stored != null) await audioHandler.setVolume(stored);
+  } catch (e) {
+    if (kDebugMode) {
+      debugPrint('main: volume enregistré illisible: $e');
     }
   }
 

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -40,7 +40,7 @@ Future<void> main() async {
     }
   }
 
-  // Niveau sonore de la session précédente (STR-245). Appliqué avant le premier
+  // Niveau sonore de la session précédente (STR-244). Appliqué avant le premier
   // rendu : le retrouver après coup ferait démarrer la lecture au volume par
   // défaut puis sauter, ce qui s'entend.
   //

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -928,6 +928,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.27.7"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.5"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: e8d4762b1e2e8578fc4d0fd548cebf24afd24f49719c08974df92834565e2c53
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.23"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   shelf:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -32,6 +32,11 @@ dependencies:
   # Stockage sécurisé (tokens JWT)
   flutter_secure_storage: ^9.0.0
 
+  # Préférences non sensibles — niveau sonore du lecteur (STR-245).
+  # Séparé de flutter_secure_storage à dessein : celui-ci n'a qu'une
+  # responsabilité, les jetons, et un volume n'est pas un secret.
+  shared_preferences: ^2.3.0
+
   # Lecture audio (live HLS + on-demand)
   just_audio: ^0.9.40
   audio_service: ^0.18.12

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   # Stockage sécurisé (tokens JWT)
   flutter_secure_storage: ^9.0.0
 
-  # Préférences non sensibles — niveau sonore du lecteur (STR-245).
+  # Préférences non sensibles — niveau sonore du lecteur (STR-244).
   # Séparé de flutter_secure_storage à dessein : celui-ci n'a qu'une
   # responsabilité, les jetons, et un volume n'est pas un secret.
   shared_preferences: ^2.3.0

--- a/mobile/test/core/audio/interruption_policy_test.dart
+++ b/mobile/test/core/audio/interruption_policy_test.dart
@@ -49,28 +49,31 @@ void main() {
       );
     });
 
-    test('interruption alors qu\'on est déjà en pause → aucune reprise auto', () {
-      final policy = InterruptionPolicy();
+    test(
+      'interruption alors qu\'on est déjà en pause → aucune reprise auto',
+      () {
+        final policy = InterruptionPolicy();
 
-      expect(
-        policy.onInterruption(
-          begin: true,
-          isDuck: false,
-          canResume: false,
-          isPlaying: false,
-        ),
-        InterruptionAction.none,
-      );
-      expect(
-        policy.onInterruption(
-          begin: false,
-          isDuck: false,
-          canResume: true,
-          isPlaying: false,
-        ),
-        InterruptionAction.none,
-      );
-    });
+        expect(
+          policy.onInterruption(
+            begin: true,
+            isDuck: false,
+            canResume: false,
+            isPlaying: false,
+          ),
+          InterruptionAction.none,
+        );
+        expect(
+          policy.onInterruption(
+            begin: false,
+            isDuck: false,
+            canResume: true,
+            isPlaying: false,
+          ),
+          InterruptionAction.none,
+        );
+      },
+    );
 
     test('notification transitoire en lecture → duck puis unduck', () {
       final policy = InterruptionPolicy();
@@ -132,10 +135,7 @@ void main() {
     test('casque débranché en lecture → pause, sans reprise auto ensuite', () {
       final policy = InterruptionPolicy();
 
-      expect(
-        policy.onBecomingNoisy(isPlaying: true),
-        InterruptionAction.pause,
-      );
+      expect(policy.onBecomingNoisy(isPlaying: true), InterruptionAction.pause);
       // Une fin d'interruption ne doit pas relancer le son sur le haut-parleur.
       expect(
         policy.onInterruption(
@@ -151,10 +151,7 @@ void main() {
     test('casque débranché à l\'arrêt → aucune action', () {
       final policy = InterruptionPolicy();
 
-      expect(
-        policy.onBecomingNoisy(isPlaying: false),
-        InterruptionAction.none,
-      );
+      expect(policy.onBecomingNoisy(isPlaying: false), InterruptionAction.none);
     });
   });
 }

--- a/mobile/test/core/audio/listening_clock_test.dart
+++ b/mobile/test/core/audio/listening_clock_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:streampulse/core/audio/listening_clock.dart';
+
+/// Instants fixes : l'horloge ne lit jamais l'heure elle-même, c'est ce qui la
+/// rend vérifiable sans attendre.
+final _t0 = DateTime(2026, 8, 20, 10, 0, 0);
+DateTime _at(int seconds) => _t0.add(Duration(seconds: seconds));
+
+void main() {
+  group('ListeningClock', () {
+    test('ne compte rien avant le premier démarrage', () {
+      final clock = ListeningClock();
+      expect(clock.elapsedAt(_at(60)), Duration.zero);
+      expect(clock.running, isFalse);
+    });
+
+    test('compte le temps écoulé depuis le démarrage', () {
+      final clock = ListeningClock()..start(_t0);
+      expect(clock.elapsedAt(_at(30)), const Duration(seconds: 30));
+      expect(clock.running, isTrue);
+    });
+
+    test('cumule les tranches de part et d\'autre d\'une pause', () {
+      final clock = ListeningClock()..start(_t0);
+      clock.pause(_at(10));
+      // Rien ne s'écoule pendant la pause, même si le temps passe.
+      expect(clock.elapsedAt(_at(100)), const Duration(seconds: 10));
+
+      clock.start(_at(100));
+      expect(clock.elapsedAt(_at(105)), const Duration(seconds: 15));
+    });
+
+    // Le lecteur émet plusieurs événements pour un même état : un `start`
+    // répété qui déplacerait l'origine ferait reculer le temps affiché.
+    test('un démarrage répété ne déplace pas l\'origine', () {
+      final clock = ListeningClock()..start(_t0);
+      clock.start(_at(20));
+      clock.start(_at(40));
+
+      expect(clock.elapsedAt(_at(60)), const Duration(seconds: 60));
+    });
+
+    test('une pause répétée ne cumule pas deux fois', () {
+      final clock = ListeningClock()..start(_t0);
+      clock.pause(_at(10));
+      clock.pause(_at(50));
+
+      expect(clock.elapsedAt(_at(90)), const Duration(seconds: 10));
+    });
+
+    test('reset repart de zéro, y compris pendant une lecture', () {
+      final clock = ListeningClock()..start(_t0);
+      clock.reset();
+
+      expect(clock.elapsedAt(_at(30)), Duration.zero);
+      expect(clock.running, isFalse);
+    });
+
+    // Une horloge murale peut reculer (NTP, fuseau, réglage manuel). Un temps
+    // d'écoute qui décroît serait pire que figé.
+    test('une horloge qui recule ne produit pas de durée négative', () {
+      final clock = ListeningClock()..start(_at(100));
+
+      expect(clock.elapsedAt(_at(40)), Duration.zero);
+
+      clock.pause(_at(40));
+      clock.start(_at(40));
+      expect(clock.elapsedAt(_at(50)), const Duration(seconds: 10));
+    });
+
+    // C'est la raison d'être de cette horloge : le contrôleur recharge l'URL à
+    // chaque reprise après erreur (STR-118), ce qui remettrait la position du
+    // lecteur à zéro. Le temps d'écoute, lui, doit traverser la coupure.
+    test('une reconnexion suspend le décompte sans le perdre', () {
+      final clock = ListeningClock()..start(_t0);
+      clock.pause(_at(120)); // perte réseau
+      clock.start(_at(125)); // flux repris
+
+      expect(clock.elapsedAt(_at(130)), const Duration(seconds: 125));
+    });
+  });
+}

--- a/mobile/test/core/audio/volume_level_test.dart
+++ b/mobile/test/core/audio/volume_level_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:streampulse/core/audio/volume_level.dart';
+
+void main() {
+  group('VolumeLevel', () {
+    test('sans atténuation, le niveau appliqué est celui de l\'auditeur', () {
+      expect(const VolumeLevel(user: 0.6).effective, 0.6);
+    });
+
+    test('l\'atténuation est un facteur, pas un niveau absolu', () {
+      // Atténuer à 0,4 en dur remonterait le son de quelqu'un qui écoute à 0,2.
+      const quiet = VolumeLevel(user: 0.2, ducked: true);
+      expect(quiet.effective, closeTo(0.08, 1e-9));
+      expect(quiet.effective, lessThan(quiet.user));
+    });
+
+    // Le bug que cet objet existe pour empêcher : la version précédente
+    // capturait le volume du lecteur avant d'atténuer et le restaurait après.
+    // Un réglage fait pendant l'interruption était donc écrasé — le son de
+    // l'auditeur remontait tout seul à la fin de sa notification.
+    test('un réglage fait pendant une atténuation survit à sa levée', () {
+      const before = VolumeLevel(user: 0.8);
+
+      final ducked = before.withDucked(true);
+      final adjusted = ducked.withUser(0.3); // l'auditeur baisse pendant
+      final restored = adjusted.withDucked(false);
+
+      expect(restored.user, 0.3);
+      expect(restored.effective, 0.3);
+    });
+
+    test('régler le volume ne lève pas l\'atténuation en cours', () {
+      final level = const VolumeLevel(user: 1).withDucked(true).withUser(0.5);
+
+      expect(level.ducked, isTrue);
+      expect(level.effective, closeTo(0.2, 1e-9));
+    });
+
+    test('les valeurs hors bornes sont ramenées dans [0, 1]', () {
+      // just_audio accepte au-delà de 1 (amplification) ; une valeur venue d'un
+      // magasin de préférences trafiqué ne doit pas saturer le son.
+      expect(const VolumeLevel().withUser(4).user, 1);
+      expect(const VolumeLevel().withUser(-2).user, 0);
+    });
+
+    test('le silence reste silencieux, atténué ou non', () {
+      const muted = VolumeLevel(user: 0);
+      expect(muted.effective, 0);
+      expect(muted.withDucked(true).effective, 0);
+    });
+
+    test('l\'égalité porte sur le réglage ET l\'atténuation', () {
+      expect(const VolumeLevel(user: 0.5), const VolumeLevel(user: 0.5));
+      expect(
+        const VolumeLevel(user: 0.5),
+        isNot(const VolumeLevel(user: 0.5, ducked: true)),
+      );
+    });
+  });
+}

--- a/mobile/test/core/audio/volume_store_test.dart
+++ b/mobile/test/core/audio/volume_store_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:streampulse/core/audio/volume_store.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SharedPreferencesVolumeStore', () {
+    setUp(() => SharedPreferences.setMockInitialValues({}));
+
+    test('rend null tant que rien n\'a été réglé', () async {
+      // null et non 1 : l'appelant garde alors le défaut du lecteur plutôt que
+      // d'écrire un réglage que l'auditeur n'a jamais fait.
+      expect(await const SharedPreferencesVolumeStore().read(), isNull);
+    });
+
+    test('relit ce qui a été écrit', () async {
+      const store = SharedPreferencesVolumeStore();
+      await store.write(0.35);
+      expect(await store.read(), closeTo(0.35, 1e-9));
+    });
+
+    test('les valeurs hors bornes sont ramenées à l\'écriture', () async {
+      const store = SharedPreferencesVolumeStore();
+      await store.write(3);
+      expect(await store.read(), 1);
+    });
+
+    // Un fichier de préférences écrit par une autre version, ou trafiqué :
+    // `setVolume` refuserait la valeur, l'application ne doit pas démarrer sur
+    // une exception pour autant.
+    test(
+      'une valeur hors bornes déjà stockée est ramenée à la lecture',
+      () async {
+        SharedPreferences.setMockInitialValues({'playback_volume': 42.0});
+        expect(await const SharedPreferencesVolumeStore().read(), 1);
+      },
+    );
+  });
+
+  group('InMemoryVolumeStore', () {
+    test('part vide, garde ce qu\'on lui donne, borne les valeurs', () async {
+      final store = InMemoryVolumeStore();
+      expect(await store.read(), isNull);
+
+      await store.write(0.5);
+      expect(await store.read(), 0.5);
+
+      await store.write(-1);
+      expect(await store.read(), 0);
+    });
+
+    test('accepte une valeur initiale', () async {
+      expect(await InMemoryVolumeStore(0.25).read(), 0.25);
+    });
+  });
+}

--- a/mobile/test/core/widgets/volume_slider_test.dart
+++ b/mobile/test/core/widgets/volume_slider_test.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:streampulse/core/audio/playback_transport.dart';
+import 'package:streampulse/core/audio/volume_store.dart';
+import 'package:streampulse/core/widgets/volume_slider.dart';
+
+import '../../support/fake_audio_playback_service.dart';
+
+const _sliderKey = Key('volume_slider');
+const _muteKey = Key('volume_mute_toggle');
+
+Future<({FakeAudioPlaybackService transport, InMemoryVolumeStore store})> _pump(
+  WidgetTester tester, {
+  double initial = 1,
+}) async {
+  final transport = FakeAudioPlaybackService();
+  await transport.setVolume(initial);
+  final store = InMemoryVolumeStore();
+  addTearDown(transport.dispose);
+
+  await tester.pumpWidget(
+    MultiProvider(
+      providers: [
+        Provider<PlaybackTransport>.value(value: transport),
+        Provider<VolumeStore>.value(value: store),
+      ],
+      child: const MaterialApp(home: Scaffold(body: VolumeSlider())),
+    ),
+  );
+  return (transport: transport, store: store);
+}
+
+/// Glisse la poignée jusqu'à l'extrémité gauche du curseur (volume nul).
+Future<void> _dragToStart(WidgetTester tester) async {
+  final box = tester.getRect(find.byKey(_sliderKey));
+  await tester.dragFrom(box.center, Offset(-box.width, 0));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets(
+    'le curseur part du niveau courant du transport, pas d\'un défaut',
+    (tester) async {
+      // Le flux n'émet qu'aux changements : s'y fier seul laisserait le curseur à
+      // 1 alors que la session précédente avait été restaurée à 0,3.
+      await _pump(tester, initial: 0.3);
+
+      final slider = tester.widget<Slider>(find.byKey(_sliderKey));
+      expect(slider.value, closeTo(0.3, 1e-9));
+      expect(find.text('30 %'), findsOneWidget);
+    },
+  );
+
+  testWidgets('glisser applique le volume immédiatement', (tester) async {
+    final ctx = await _pump(tester);
+
+    await _dragToStart(tester);
+
+    expect(ctx.transport.volume, 0);
+  });
+
+  // Un glissement émet des dizaines de valeurs : écrire à chaque tick userait
+  // le magasin pour un résultat identique. Seule la valeur relâchée compte.
+  testWidgets('le magasin n\'est écrit qu\'au relâchement', (tester) async {
+    final ctx = await _pump(tester);
+
+    // onChanged sans onChangeEnd : le transport bouge, le magasin non.
+    final slider = tester.widget<Slider>(find.byKey(_sliderKey));
+    slider.onChanged!(0.5);
+    await tester.pump();
+    expect(ctx.transport.volume, 0.5);
+    expect(await ctx.store.read(), isNull);
+
+    slider.onChangeEnd!(0.5);
+    await tester.pump();
+    expect(await ctx.store.read(), 0.5);
+  });
+
+  testWidgets('le transport pilote le curseur, pas l\'inverse', (tester) async {
+    final ctx = await _pump(tester);
+
+    // Un réglage venu d'ailleurs (restauration au démarrage) doit se voir.
+    await ctx.transport.setVolume(0.25);
+    await tester.pump();
+
+    expect(
+      tester.widget<Slider>(find.byKey(_sliderKey)).value,
+      closeTo(0.25, 1e-9),
+    );
+  });
+
+  testWidgets('l\'icône suit le niveau', (tester) async {
+    final ctx = await _pump(tester, initial: 1);
+    expect(find.byIcon(Icons.volume_up), findsOneWidget);
+
+    await ctx.transport.setVolume(0.2);
+    await tester.pump();
+    expect(find.byIcon(Icons.volume_down), findsOneWidget);
+
+    await ctx.transport.setVolume(0);
+    await tester.pump();
+    expect(find.byIcon(Icons.volume_off), findsOneWidget);
+  });
+
+  testWidgets('couper puis rétablir revient au niveau d\'avant', (
+    tester,
+  ) async {
+    final ctx = await _pump(tester, initial: 0.7);
+
+    await tester.tap(find.byKey(_muteKey));
+    await tester.pumpAndSettle();
+    expect(ctx.transport.volume, 0);
+
+    await tester.tap(find.byKey(_muteKey));
+    await tester.pumpAndSettle();
+    expect(ctx.transport.volume, closeTo(0.7, 1e-9));
+    expect(await ctx.store.read(), closeTo(0.7, 1e-9));
+  });
+
+  // L'auditeur a fermé l'application en sourdine : l'appui doit lui rendre du
+  // son, pas ne rien faire.
+  testWidgets('rétablir sans niveau mémorisé remonte à 100 %', (tester) async {
+    final ctx = await _pump(tester, initial: 0);
+
+    await tester.tap(find.byKey(_muteKey));
+    await tester.pumpAndSettle();
+
+    expect(ctx.transport.volume, 1);
+  });
+
+  testWidgets('le curseur est annoncé en pourcentage au lecteur d\'écran', (
+    tester,
+  ) async {
+    await _pump(tester, initial: 0.42);
+
+    final slider = tester.widget<Slider>(find.byKey(_sliderKey));
+    expect(slider.semanticFormatterCallback!(0.42), 'Volume 42 %');
+  });
+}

--- a/mobile/test/features/playlists/presentation/widgets/queue_ui_test.dart
+++ b/mobile/test/features/playlists/presentation/widgets/queue_ui_test.dart
@@ -21,7 +21,7 @@ final _tracks = [
 ];
 
 /// [service] sert aussi de [PlaybackTransport] : c'est le même objet qui porte
-/// la file et le volume en production (STR-245), le fake doit donc l'être aussi.
+/// la file et le volume en production (STR-244), le fake doit donc l'être aussi.
 Widget _host(
   PlaylistQueueController controller,
   Widget child, {

--- a/mobile/test/features/playlists/presentation/widgets/queue_ui_test.dart
+++ b/mobile/test/features/playlists/presentation/widgets/queue_ui_test.dart
@@ -3,18 +3,16 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:just_audio/just_audio.dart' show PlayerState, ProcessingState;
 import 'package:provider/provider.dart';
 
+import 'package:streampulse/core/audio/playback_transport.dart';
+import 'package:streampulse/core/audio/volume_store.dart';
 import 'package:streampulse/features/playlists/domain/entities/track.dart';
 import 'package:streampulse/features/playlists/presentation/providers/playlist_queue_controller.dart';
 import 'package:streampulse/features/playlists/presentation/widgets/queue_mini_player.dart';
 
 import '../../../../support/fake_queue_playback_service.dart';
 
-Track _track(String id, String title) => Track(
-      id: id,
-      title: title,
-      artist: 'Neon Lights',
-      durationS: 214,
-    );
+Track _track(String id, String title) =>
+    Track(id: id, title: title, artist: 'Neon Lights', durationS: 214);
 
 final _tracks = [
   _track('t1', 'Midnight Drive'),
@@ -22,9 +20,21 @@ final _tracks = [
   _track('t3', 'Afterglow'),
 ];
 
-Widget _host(PlaylistQueueController controller, Widget child) {
-  return ChangeNotifierProvider<PlaylistQueueController>.value(
-    value: controller,
+/// [service] sert aussi de [PlaybackTransport] : c'est le même objet qui porte
+/// la file et le volume en production (STR-245), le fake doit donc l'être aussi.
+Widget _host(
+  PlaylistQueueController controller,
+  Widget child, {
+  FakeQueuePlaybackService? service,
+}) {
+  return MultiProvider(
+    providers: [
+      ChangeNotifierProvider<PlaylistQueueController>.value(value: controller),
+      Provider<PlaybackTransport>.value(
+        value: service ?? FakeQueuePlaybackService(),
+      ),
+      Provider<VolumeStore>(create: (_) => InMemoryVolumeStore()),
+    ],
     child: MaterialApp(home: Scaffold(body: child)),
   );
 }
@@ -34,15 +44,8 @@ Widget _host(PlaylistQueueController controller, Widget child) {
 /// L'ordre compte : le widget est monté **avant** l'émission de l'état du
 /// lecteur, car sous `testWidgets` seule une `pump` fait avancer la boucle
 /// d'événements (le temps y est simulé).
-Future<
-    ({
-      PlaylistQueueController controller,
-      FakeQueuePlaybackService service,
-    })> _pumpPlaying(
-  WidgetTester tester,
-  Widget child, {
-  int startIndex = 0,
-}) async {
+Future<({PlaylistQueueController controller, FakeQueuePlaybackService service})>
+_pumpPlaying(WidgetTester tester, Widget child, {int startIndex = 0}) async {
   final service = FakeQueuePlaybackService();
   final controller = PlaylistQueueController(
     service: service,
@@ -57,7 +60,7 @@ Future<
     playlistId: 'p-1',
     startIndex: startIndex,
   );
-  await tester.pumpWidget(_host(controller, child));
+  await tester.pumpWidget(_host(controller, child, service: service));
   service.emitState(PlayerState(true, ProcessingState.ready));
   await tester.pump();
   return (controller: controller, service: service);
@@ -85,8 +88,9 @@ void main() {
       expect(find.byKey(const Key('queue_mini_player')), findsNothing);
     });
 
-    testWidgets('affiche la piste en cours et sa position dans la file',
-        (tester) async {
+    testWidgets('affiche la piste en cours et sa position dans la file', (
+      tester,
+    ) async {
       await _pumpPlaying(tester, const QueueMiniPlayer());
 
       expect(find.text('Midnight Drive'), findsOneWidget);
@@ -120,8 +124,9 @@ void main() {
       expect(find.byIcon(Icons.replay), findsOneWidget);
     });
 
-    testWidgets('la croix arrête la lecture et masque la barre',
-        (tester) async {
+    testWidgets('la croix arrête la lecture et masque la barre', (
+      tester,
+    ) async {
       final t = await _pumpPlaying(tester, const QueueMiniPlayer());
 
       await tester.tap(find.byKey(const Key('queue_mini_stop')));
@@ -133,8 +138,9 @@ void main() {
   });
 
   group('PlaybackQueueSheet (US-05-04)', () {
-    testWidgets('liste la file entière et marque la piste en cours',
-        (tester) async {
+    testWidgets('liste la file entière et marque la piste en cours', (
+      tester,
+    ) async {
       await _pumpPlaying(tester, const QueueMiniPlayer(), startIndex: 1);
       await _openQueueSheet(tester);
 
@@ -158,26 +164,29 @@ void main() {
       expect(t.controller.currentIndex, 2);
     });
 
-    testWidgets('les modes de lecture sont réglables depuis la file (US-05-05)',
-        (tester) async {
-      final t = await _pumpPlaying(tester, const QueueMiniPlayer());
-      await _openQueueSheet(tester);
+    testWidgets(
+      'les modes de lecture sont réglables depuis la file (US-05-05)',
+      (tester) async {
+        final t = await _pumpPlaying(tester, const QueueMiniPlayer());
+        await _openQueueSheet(tester);
 
-      expect(find.byKey(const Key('queue_shuffle_button')), findsOneWidget);
-      expect(find.text('Répétition'), findsOneWidget);
+        expect(find.byKey(const Key('queue_shuffle_button')), findsOneWidget);
+        expect(find.text('Répétition'), findsOneWidget);
 
-      await tester.tap(find.byKey(const Key('queue_repeat_button')));
-      await tester.pumpAndSettle();
-      expect(find.text('Répéter la file'), findsOneWidget);
-      expect(t.service.repeatMode, QueueRepeatMode.all);
+        await tester.tap(find.byKey(const Key('queue_repeat_button')));
+        await tester.pumpAndSettle();
+        expect(find.text('Répéter la file'), findsOneWidget);
+        expect(t.service.repeatMode, QueueRepeatMode.all);
 
-      await tester.tap(find.byKey(const Key('queue_repeat_button')));
-      await tester.pumpAndSettle();
-      expect(find.text('Répéter la piste'), findsOneWidget);
-    });
+        await tester.tap(find.byKey(const Key('queue_repeat_button')));
+        await tester.pumpAndSettle();
+        expect(find.text('Répéter la piste'), findsOneWidget);
+      },
+    );
 
-    testWidgets('en aléatoire, la file affiche l\'ordre réellement joué',
-        (tester) async {
+    testWidgets('en aléatoire, la file affiche l\'ordre réellement joué', (
+      tester,
+    ) async {
       final t = await _pumpPlaying(tester, const QueueMiniPlayer());
       // Le lecteur jouera t2, t3, t1.
       t.service.shuffledOrder = [1, 2, 0];
@@ -195,8 +204,9 @@ void main() {
       expect(t.controller.positionInOrder, 2);
     });
 
-    testWidgets('la barre affiche l\'avancement de la piste (STR-230)',
-        (tester) async {
+    testWidgets('la barre affiche l\'avancement de la piste (STR-230)', (
+      tester,
+    ) async {
       final t = await _pumpPlaying(tester, const QueueMiniPlayer());
       await _openQueueSheet(tester);
 
@@ -216,8 +226,9 @@ void main() {
       expect(slider.max, 200000);
     });
 
-    testWidgets('glisser la barre déplace la lecture (STR-230)',
-        (tester) async {
+    testWidgets('glisser la barre déplace la lecture (STR-230)', (
+      tester,
+    ) async {
       final t = await _pumpPlaying(tester, const QueueMiniPlayer());
       await _openQueueSheet(tester);
       t.service.emitDuration(const Duration(seconds: 200));
@@ -239,8 +250,9 @@ void main() {
       );
     });
 
-    testWidgets('durée inconnue : barre neutralisée plutôt que fausse',
-        (tester) async {
+    testWidgets('durée inconnue : barre neutralisée plutôt que fausse', (
+      tester,
+    ) async {
       final t = await _pumpPlaying(tester, const QueueMiniPlayer());
       await _openQueueSheet(tester);
 
@@ -258,8 +270,9 @@ void main() {
       expect(slider.max, 214000);
     });
 
-    testWidgets('file terminée : la poignée est neutralisée (revue #292)',
-        (tester) async {
+    testWidgets('file terminée : la poignée est neutralisée (revue #292)', (
+      tester,
+    ) async {
       final t = await _pumpPlaying(tester, const QueueMiniPlayer());
       await _openQueueSheet(tester);
       t.service.emitDuration(const Duration(seconds: 200));
@@ -277,8 +290,9 @@ void main() {
       expect(slider.onChanged, isNull);
     });
 
-    testWidgets('changement de piste : pas de durée périmée (revue #292)',
-        (tester) async {
+    testWidgets('changement de piste : pas de durée périmée (revue #292)', (
+      tester,
+    ) async {
       final t = await _pumpPlaying(tester, const QueueMiniPlayer());
       await _openQueueSheet(tester);
       t.service.emitDuration(const Duration(seconds: 200));

--- a/mobile/test/features/streams/presentation/screens/stream_player_screen_test.dart
+++ b/mobile/test/features/streams/presentation/screens/stream_player_screen_test.dart
@@ -102,7 +102,7 @@ Widget _harness({
   return MultiProvider(
     providers: [
       ChangeNotifierProvider<FavoritesController>.value(value: controller),
-      // Le curseur de volume (STR-245) lit le transport, pas le contrôleur de
+      // Le curseur de volume (STR-244) lit le transport, pas le contrôleur de
       // lecture : un fake suffit, il n'a rien à simuler d'autre.
       Provider<PlaybackTransport>.value(value: FakeAudioPlaybackService()),
       Provider<VolumeStore>(create: (_) => InMemoryVolumeStore()),

--- a/mobile/test/features/streams/presentation/screens/stream_player_screen_test.dart
+++ b/mobile/test/features/streams/presentation/screens/stream_player_screen_test.dart
@@ -8,6 +8,9 @@ import 'package:streampulse/features/streams/domain/repositories/stream_reposito
 import 'package:streampulse/features/streams/presentation/providers/audio_player_controller.dart';
 import 'package:streampulse/features/streams/presentation/providers/favorites_controller.dart';
 import 'package:streampulse/features/streams/presentation/screens/stream_player_screen.dart';
+import 'package:streampulse/core/audio/playback_transport.dart';
+import 'package:streampulse/core/audio/volume_store.dart';
+import '../../../../support/fake_audio_playback_service.dart';
 
 /// Contrôleur de lecture fake (sans just_audio) : pilotable par [status] pour
 /// tester le rendu des états (STR-118), méthodes no-op.
@@ -42,17 +45,17 @@ class _FakePlaybackController extends PlaybackController {
 /// Flux « réel » tel que renvoyé par le serveur (métadonnées complètes),
 /// par opposition au placeholder créé en arrivée deep-link.
 LiveStream _realStream(String id) => LiveStream(
-      id: id,
-      title: 'Vrai Titre',
-      startedAt: DateTime.utc(2026, 1, 1),
-      status: 'live',
-    );
+  id: id,
+  title: 'Vrai Titre',
+  startedAt: DateTime.utc(2026, 1, 1),
+  status: 'live',
+);
 
 /// Fake configurable : `listFavorites` renvoie l'état courant (mutable), ce qui
 /// permet de simuler la réconciliation serveur après un ajout.
 class _FakeStreamRepository implements StreamRepository {
   _FakeStreamRepository({List<LiveStream> favorites = const []})
-      : _favorites = favorites;
+    : _favorites = favorites;
 
   List<LiveStream> _favorites;
   int listFavoritesCalls = 0;
@@ -83,8 +86,7 @@ class _FakeStreamRepository implements StreamRepository {
   Future<List<LiveStream>> listLiveStreams({
     int limit = 20,
     int offset = 0,
-  }) async =>
-      const [];
+  }) async => const [];
 
   @override
   Future<bool> isManifestUnavailable(String streamId) async => false;
@@ -97,8 +99,14 @@ Widget _harness({
   required FavoritesController controller,
   PlaybackStatus playbackStatus = PlaybackStatus.idle,
 }) {
-  return ChangeNotifierProvider<FavoritesController>.value(
-    value: controller,
+  return MultiProvider(
+    providers: [
+      ChangeNotifierProvider<FavoritesController>.value(value: controller),
+      // Le curseur de volume (STR-245) lit le transport, pas le contrôleur de
+      // lecture : un fake suffit, il n'a rien à simuler d'autre.
+      Provider<PlaybackTransport>.value(value: FakeAudioPlaybackService()),
+      Provider<VolumeStore>(create: (_) => InMemoryVolumeStore()),
+    ],
     child: ToastificationWrapper(
       child: MaterialApp(
         home: StreamPlayerScreen(
@@ -114,51 +122,56 @@ Widget _harness({
 void main() {
   group('StreamPlayerScreen — réconciliation deep-link', () {
     testWidgets(
-        'ajout en arrivée deep-link (sans métadonnées) : recharge la liste '
-        'et remplace le placeholder par les vraies métadonnées', (tester) async {
-      final repo = _FakeStreamRepository();
-      final controller = FavoritesController(repo);
-      await tester.pumpWidget(
-        _harness(streamId: 's1', repo: repo, controller: controller),
-      );
-      await tester.pumpAndSettle(); // ensureLoaded (listFavorites #1 → vide)
+      'ajout en arrivée deep-link (sans métadonnées) : recharge la liste '
+      'et remplace le placeholder par les vraies métadonnées',
+      (tester) async {
+        final repo = _FakeStreamRepository();
+        final controller = FavoritesController(repo);
+        await tester.pumpWidget(
+          _harness(streamId: 's1', repo: repo, controller: controller),
+        );
+        await tester.pumpAndSettle(); // ensureLoaded (listFavorites #1 → vide)
 
-      await tester.tap(find.byIcon(Icons.favorite_border));
-      await tester.pumpAndSettle();
+        await tester.tap(find.byIcon(Icons.favorite_border));
+        await tester.pumpAndSettle();
 
-      // Ajout effectué, puis load() de réconciliation (listFavorites #2).
-      expect(repo.added, ['s1']);
-      expect(repo.listFavoritesCalls, 2);
-      // La tuile fantôme 'Flux' a été remplacée par les vraies métadonnées.
-      expect(controller.favorites.single.title, 'Vrai Titre');
-      expect(controller.favorites.single.status, 'live');
-    });
+        // Ajout effectué, puis load() de réconciliation (listFavorites #2).
+        expect(repo.added, ['s1']);
+        expect(repo.listFavoritesCalls, 2);
+        // La tuile fantôme 'Flux' a été remplacée par les vraies métadonnées.
+        expect(controller.favorites.single.title, 'Vrai Titre');
+        expect(controller.favorites.single.status, 'live');
+      },
+    );
 
     testWidgets(
-        'métadonnées déjà connues (navigation normale) : pas de rechargement '
-        'superflu', (tester) async {
-      final repo = _FakeStreamRepository();
-      final controller = FavoritesController(repo);
-      await tester.pumpWidget(
-        _harness(
-          streamId: 's1',
-          stream: _realStream('s1'),
-          repo: repo,
-          controller: controller,
-        ),
-      );
-      await tester.pumpAndSettle(); // ensureLoaded (listFavorites #1)
+      'métadonnées déjà connues (navigation normale) : pas de rechargement '
+      'superflu',
+      (tester) async {
+        final repo = _FakeStreamRepository();
+        final controller = FavoritesController(repo);
+        await tester.pumpWidget(
+          _harness(
+            streamId: 's1',
+            stream: _realStream('s1'),
+            repo: repo,
+            controller: controller,
+          ),
+        );
+        await tester.pumpAndSettle(); // ensureLoaded (listFavorites #1)
 
-      await tester.tap(find.byIcon(Icons.favorite_border));
-      await tester.pumpAndSettle();
+        await tester.tap(find.byIcon(Icons.favorite_border));
+        await tester.pumpAndSettle();
 
-      expect(repo.added, ['s1']);
-      // Pas de load() de réconciliation : un seul appel (ensureLoaded initial).
-      expect(repo.listFavoritesCalls, 1);
-    });
+        expect(repo.added, ['s1']);
+        // Pas de load() de réconciliation : un seul appel (ensureLoaded initial).
+        expect(repo.listFavoritesCalls, 1);
+      },
+    );
 
-    testWidgets('retrait : pas de rechargement de réconciliation',
-        (tester) async {
+    testWidgets('retrait : pas de rechargement de réconciliation', (
+      tester,
+    ) async {
       final repo = _FakeStreamRepository(favorites: [_realStream('s1')]);
       final controller = FavoritesController(repo);
       await tester.pumpWidget(
@@ -171,47 +184,60 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(repo.removed, ['s1']);
-      expect(repo.listFavoritesCalls, 1); // aucune réconciliation sur un retrait
+      expect(
+        repo.listFavoritesCalls,
+        1,
+      ); // aucune réconciliation sur un retrait
     });
   });
 
   group('StreamPlayerScreen — états de lecture (STR-118)', () {
     testWidgets('reconnexion : affiche « Reconnexion… »', (tester) async {
       final repo = _FakeStreamRepository();
-      await tester.pumpWidget(_harness(
-        streamId: 's1',
-        repo: repo,
-        controller: FavoritesController(repo),
-        playbackStatus: PlaybackStatus.reconnecting,
-      ));
+      await tester.pumpWidget(
+        _harness(
+          streamId: 's1',
+          repo: repo,
+          controller: FavoritesController(repo),
+          playbackStatus: PlaybackStatus.reconnecting,
+        ),
+      );
       await tester.pump();
 
       expect(find.text('Reconnexion…'), findsOneWidget);
     });
 
-    testWidgets('erreur : « Flux indisponible » + bouton réessayer',
-        (tester) async {
+    testWidgets('erreur : « Flux indisponible » + bouton réessayer', (
+      tester,
+    ) async {
       final repo = _FakeStreamRepository();
-      await tester.pumpWidget(_harness(
-        streamId: 's1',
-        repo: repo,
-        controller: FavoritesController(repo),
-        playbackStatus: PlaybackStatus.error,
-      ));
+      await tester.pumpWidget(
+        _harness(
+          streamId: 's1',
+          repo: repo,
+          controller: FavoritesController(repo),
+          playbackStatus: PlaybackStatus.error,
+        ),
+      );
       await tester.pumpAndSettle();
 
       expect(find.text('Flux indisponible'), findsOneWidget);
-      expect(find.byIcon(Icons.replay), findsOneWidget); // le play devient « réessayer »
+      expect(
+        find.byIcon(Icons.replay),
+        findsOneWidget,
+      ); // le play devient « réessayer »
     });
 
     testWidgets('flux terminé : « Le direct est terminé »', (tester) async {
       final repo = _FakeStreamRepository();
-      await tester.pumpWidget(_harness(
-        streamId: 's1',
-        repo: repo,
-        controller: FavoritesController(repo),
-        playbackStatus: PlaybackStatus.ended,
-      ));
+      await tester.pumpWidget(
+        _harness(
+          streamId: 's1',
+          repo: repo,
+          controller: FavoritesController(repo),
+          playbackStatus: PlaybackStatus.ended,
+        ),
+      );
       await tester.pumpAndSettle();
 
       expect(find.text('Le direct est terminé'), findsOneWidget);

--- a/mobile/test/features/streams/presentation/widgets/listening_time_test.dart
+++ b/mobile/test/features/streams/presentation/widgets/listening_time_test.dart
@@ -1,0 +1,174 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:streampulse/features/streams/presentation/providers/audio_player_controller.dart';
+import 'package:streampulse/features/streams/presentation/widgets/listening_time.dart';
+
+/// Contrôleur pilotable à la main : le temps d'écoute ne dépend que de l'état
+/// de lecture, pas d'un lecteur natif.
+class _FakeController extends PlaybackController {
+  @override
+  PlaybackStatus status = PlaybackStatus.idle;
+
+  NowPlaying? now;
+
+  void emit(PlaybackStatus next, {NowPlaying? playing}) {
+    status = next;
+    if (playing != null) now = playing;
+    notifyListeners();
+  }
+
+  @override
+  NowPlaying? get nowPlaying => now;
+  @override
+  bool get isPlaying => status == PlaybackStatus.playing;
+  @override
+  bool get isBusy =>
+      status == PlaybackStatus.loading || status == PlaybackStatus.buffering;
+  @override
+  bool get isReconnecting => status == PlaybackStatus.reconnecting;
+  @override
+  bool get hasError => status == PlaybackStatus.error;
+  @override
+  bool get isEnded => status == PlaybackStatus.ended;
+
+  @override
+  Future<void> load(NowPlaying n) async => now = n;
+  @override
+  Future<void> togglePlayPause() async {}
+  @override
+  Future<void> stop() async {}
+}
+
+const _live = NowPlaying(streamId: 's1', title: 'Radio Neon');
+
+/// Horloge murale simulée. `tester.pump(Duration)` n'avance que l'horloge
+/// interne de Flutter : sans cette source injectée, le widget lirait l'heure
+/// réelle et le temps d'écoute resterait à zéro pendant tout le test.
+class _FakeWallClock {
+  DateTime value = DateTime(2026, 8, 20, 10, 0, 0);
+  DateTime call() => value;
+}
+
+Future<_FakeWallClock> _pump(
+  WidgetTester tester,
+  _FakeController controller,
+) async {
+  final clock = _FakeWallClock();
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: ListeningTime(controller: controller, now: clock.call),
+      ),
+    ),
+  );
+  return clock;
+}
+
+/// Fait avancer les deux horloges ensemble — celle de Flutter (qui déclenche le
+/// tic) et l'horloge murale (que lit le compteur).
+Future<void> _advance(
+  WidgetTester tester,
+  _FakeWallClock clock,
+  Duration by,
+) async {
+  clock.value = clock.value.add(by);
+  await tester.pump(by);
+}
+
+void main() {
+  testWidgets('rien tant que rien n\'a été écouté', (tester) async {
+    await _pump(tester, _FakeController());
+    // Un « 00:00 » figé pendant le chargement laisse croire que c'est bloqué.
+    expect(find.byType(Icon), findsNothing);
+  });
+
+  testWidgets('compte pendant la lecture', (tester) async {
+    final controller = _FakeController();
+    final clock = await _pump(tester, controller);
+
+    controller.emit(PlaybackStatus.playing, playing: _live);
+    await _advance(tester, clock, const Duration(seconds: 3));
+
+    expect(find.text('00:03'), findsOneWidget);
+  });
+
+  testWidgets('se fige à la pause et reprend au même point', (tester) async {
+    final controller = _FakeController();
+    final clock = await _pump(tester, controller);
+
+    controller.emit(PlaybackStatus.playing, playing: _live);
+    await _advance(tester, clock, const Duration(seconds: 5));
+
+    controller.emit(PlaybackStatus.paused);
+    await _advance(tester, clock, const Duration(seconds: 30));
+    expect(find.text('00:05'), findsOneWidget);
+
+    controller.emit(PlaybackStatus.playing);
+    await _advance(tester, clock, const Duration(seconds: 2));
+    expect(find.text('00:07'), findsOneWidget);
+  });
+
+  // La raison d'être de l'horloge : le contrôleur recharge l'URL à chaque
+  // reprise (STR-118), ce qui remettrait la position du lecteur à zéro.
+  testWidgets('une reconnexion suspend le décompte sans le perdre', (
+    tester,
+  ) async {
+    final controller = _FakeController();
+    final clock = await _pump(tester, controller);
+
+    controller.emit(PlaybackStatus.playing, playing: _live);
+    await _advance(tester, clock, const Duration(seconds: 10));
+
+    controller.emit(PlaybackStatus.reconnecting);
+    await _advance(tester, clock, const Duration(seconds: 4));
+    expect(find.text('00:10'), findsOneWidget);
+
+    controller.emit(PlaybackStatus.playing);
+    await _advance(tester, clock, const Duration(seconds: 1));
+    expect(find.text('00:11'), findsOneWidget);
+  });
+
+  testWidgets('changer de flux redémarre le décompte', (tester) async {
+    final controller = _FakeController();
+    final clock = await _pump(tester, controller);
+
+    controller.emit(PlaybackStatus.playing, playing: _live);
+    await _advance(tester, clock, const Duration(seconds: 8));
+    expect(find.text('00:08'), findsOneWidget);
+
+    controller.emit(
+      PlaybackStatus.playing,
+      playing: const NowPlaying(streamId: 's2', title: 'Autre radio'),
+    );
+    await _advance(tester, clock, const Duration(seconds: 2));
+
+    expect(find.text('00:02'), findsOneWidget);
+    expect(find.text('00:10'), findsNothing);
+  });
+
+  testWidgets('le temps est annoncé en toutes lettres', (tester) async {
+    final controller = _FakeController();
+    final clock = await _pump(tester, controller);
+    controller.emit(PlaybackStatus.playing, playing: _live);
+    await _advance(tester, clock, const Duration(seconds: 65));
+
+    expect(find.bySemanticsLabel('Temps d\'écoute : 01:05'), findsOneWidget);
+  });
+
+  group('formatListeningTime', () {
+    test('mm:ss en deçà d\'une heure', () {
+      expect(formatListeningTime(const Duration(seconds: 9)), '00:09');
+      expect(
+        formatListeningTime(const Duration(minutes: 12, seconds: 3)),
+        '12:03',
+      );
+    });
+
+    test('h:mm:ss au-delà — « 180:24 » se lit mal', () {
+      expect(
+        formatListeningTime(const Duration(hours: 3, seconds: 24)),
+        '3:00:24',
+      );
+    });
+  });
+}

--- a/mobile/test/features/streams/presentation/widgets/mini_player_test.dart
+++ b/mobile/test/features/streams/presentation/widgets/mini_player_test.dart
@@ -15,7 +15,11 @@ Widget _host(AudioPlayerController controller) {
   );
 }
 
-const _now = NowPlaying(streamId: 's1', title: 'Radio Nova', broadcaster: 'DJ Qa');
+const _now = NowPlaying(
+  streamId: 's1',
+  title: 'Radio Nova',
+  broadcaster: 'DJ Qa',
+);
 
 void main() {
   testWidgets('masqué quand rien ne joue (idle)', (tester) async {
@@ -31,8 +35,9 @@ void main() {
     expect(find.byIcon(Icons.play_arrow), findsNothing);
   });
 
-  testWidgets('affiche titre + diffuseur et le bouton pause en lecture',
-      (tester) async {
+  testWidgets('affiche titre + diffuseur et le bouton pause en lecture', (
+    tester,
+  ) async {
     final service = FakeAudioPlaybackService();
     final controller = AudioPlayerController(service: service);
     addTearDown(controller.dispose);
@@ -48,8 +53,9 @@ void main() {
     expect(find.byIcon(Icons.pause), findsOneWidget);
   });
 
-  testWidgets('la croix arrête la lecture et masque le mini-player',
-      (tester) async {
+  testWidgets('la croix arrête la lecture et masque le mini-player', (
+    tester,
+  ) async {
     final service = FakeAudioPlaybackService();
     final controller = AudioPlayerController(service: service);
     addTearDown(controller.dispose);
@@ -68,8 +74,9 @@ void main() {
     expect(find.text('Radio Nova'), findsNothing); // idle → masqué
   });
 
-  testWidgets('flux terminé → affiche « Le direct est terminé » + replay',
-      (tester) async {
+  testWidgets('flux terminé → affiche « Le direct est terminé » + replay', (
+    tester,
+  ) async {
     final service = FakeAudioPlaybackService();
     final controller = AudioPlayerController(
       service: service,
@@ -88,6 +95,9 @@ void main() {
 
     expect(find.text('Le direct est terminé'), findsOneWidget);
     expect(find.byIcon(Icons.replay), findsOneWidget);
-    expect(find.text('DJ Qa'), findsNothing); // le statut prime sur le diffuseur
+    expect(
+      find.text('DJ Qa'),
+      findsNothing,
+    ); // le statut prime sur le diffuseur
   });
 }

--- a/mobile/test/support/fake_audio_playback_service.dart
+++ b/mobile/test/support/fake_audio_playback_service.dart
@@ -33,6 +33,19 @@ class FakeAudioPlaybackService implements AudioPlaybackService {
   @override
   bool get playing => _playing;
 
+  final _volumeCtrl = StreamController<double>.broadcast();
+  double _volume = 1;
+
+  @override
+  double get volume => _volume;
+  @override
+  Stream<double> get volumeStream => _volumeCtrl.stream;
+  @override
+  Future<void> setVolume(double volume) async {
+    _volume = volume.clamp(0.0, 1.0);
+    if (!_volumeCtrl.isClosed) _volumeCtrl.add(_volume);
+  }
+
   @override
   Future<void> loadUri(String url, {required NowPlaying now}) async {
     loadCalls++;

--- a/mobile/test/support/fake_offline_playlist_controller.dart
+++ b/mobile/test/support/fake_offline_playlist_controller.dart
@@ -12,7 +12,10 @@ class _NoopCacheRepository implements OfflineCacheRepository {
   Future<bool> isOffline(String playlistId) async => false;
   @override
   Future<void> enableOffline(
-          String playlistId, String name, List<PlaylistTrack> tracks) async {}
+    String playlistId,
+    String name,
+    List<PlaylistTrack> tracks,
+  ) async {}
   @override
   Future<void> disableOffline(String playlistId) async {}
   @override
@@ -21,10 +24,13 @@ class _NoopCacheRepository implements OfflineCacheRepository {
   Future<List<CachedTrackStatus>> downloadStatuses(String playlistId) async =>
       [];
   @override
-  Future<void> updateTrackStatus(String trackId, String playlistId,
-          {required TrackCacheStatus status,
-          String? filePath,
-          int? fileSize}) async {}
+  Future<void> updateTrackStatus(
+    String trackId,
+    String playlistId, {
+    required TrackCacheStatus status,
+    String? filePath,
+    int? fileSize,
+  }) async {}
   @override
   Future<String?> cachedFilePath(String trackId) async => null;
   @override
@@ -35,10 +41,10 @@ class _NoopCacheRepository implements OfflineCacheRepository {
 
 class FakeOfflinePlaylistController extends OfflinePlaylistController {
   FakeOfflinePlaylistController()
-      : super(
-          cacheRepository: _NoopCacheRepository(),
-          downloadService: TrackDownloadService(Dio(), _NoopCacheRepository()),
-        );
+    : super(
+        cacheRepository: _NoopCacheRepository(),
+        downloadService: TrackDownloadService(Dio(), _NoopCacheRepository()),
+      );
 
   @override
   Future<void> init() async {}

--- a/mobile/test/support/fake_queue_playback_service.dart
+++ b/mobile/test/support/fake_queue_playback_service.dart
@@ -99,6 +99,19 @@ class FakeQueuePlaybackService implements QueuePlaybackService {
   @override
   bool get playing => _playing;
 
+  final _volumeCtrl = StreamController<double>.broadcast();
+  double _volume = 1;
+
+  @override
+  double get volume => _volume;
+  @override
+  Stream<double> get volumeStream => _volumeCtrl.stream;
+  @override
+  Future<void> setVolume(double volume) async {
+    _volume = volume.clamp(0.0, 1.0);
+    if (!_volumeCtrl.isClosed) _volumeCtrl.add(_volume);
+  }
+
   @override
   Future<void> seek(Duration to) async {
     seeks.add(to);


### PR DESCRIPTION
Ferme la **section A** de [STR-244](https://linear.app/streampulse/issue/STR-244) —
les deux éléments manquants du « Lecteur Audio Avancé » listé au barème /15.
La section B (accessibilité, responsive) suit dans une PR distincte : rien de
commun entre les deux, ni fichiers ni raisonnement.

Décisions et alternatives écartées : [ADR 042](docs/adr/042-controle-du-volume-et-temps-decoute.md).

---

## Ce que le sujet demandait

> « Lecteur Audio Avancé : gestion du streaming, **barre de progression**,
> **contrôle du volume** et lecture en arrière-plan. »

Deux sur quatre étaient acquis. Le code documentait même l'absence du volume
comme un choix — « délégué au système, boutons matériels ». L'arbitrage se
défend, mais l'argument ne tient qu'à moitié : baisser le volume système baisse
aussi les notifications et les appels, alors qu'un auditeur veut souvent baisser
*la radio*, pas son téléphone.

---

## Un bug que la fonctionnalité créait, et qui n'existait pas avant

Le ducking d'interruption ([ADR 033](docs/adr/033-gestion-des-interruptions-audio.md))
**capturait** `player.volume` juste avant d'atténuer, pour le restaurer après.
C'était correct tant que personne ne pouvait régler le volume.

Ajouter un curseur cassait ça sans rien changer au code du ducking : un réglage
fait **pendant** la notification était écrasé à sa levée. L'auditeur baisse le
son parce qu'il reçoit un appel, et le son remonte tout seul quand l'appel se
termine.

`VolumeLevel` inverse la dépendance — le réglage est conservé, l'atténuation est
un facteur qui en dérive :

| | Réglage auditeur | Envoyé au lecteur |
| -- | -- | -- |
| Normal | 0,8 | 0,8 |
| Atténué | 0,8 | 0,32 |
| Réglé pendant l'atténuation | 0,3 | 0,12 |
| Atténuation levée | 0,3 | **0,3** |

Un **facteur** et non un niveau absolu : atténuer « à 0,4 » en dur *remonterait*
le son de quelqu'un qui écoute à 0,2.

C'est la seule règle non triviale du ticket, donc la seule extraite en objet pur
— même parti que `InterruptionPolicy` et `PlaybackOrder`. Elle a son test dédié.

---

## Un direct n'a pas de barre de progression

Il n'a pas de fin connue : pas de fraction à remplir, et une barre qui n'avance
jamais serait un mensonge visuel. Ce qu'il a, c'est un **temps d'écoute**.

**Pourquoi pas `positionStream`**, qui aurait coûté une ligne : cette position
est relative à la *source chargée*, et le contrôleur recharge l'URL à chaque
reprise après erreur (STR-118). Une coupure réseau de deux secondes remettrait
le compteur à zéro — sous un libellé qui promet « depuis le début de l'écoute ».

`ListeningClock` est pilotée par l'**état de lecture**, pas par la source : elle
traverse les rechargements. Elle se met en pause pendant une reconnexion, parce
que c'est précisément le moment où l'auditeur n'entend rien.

---

## Deux règles de la maison, respectées à la lettre

**Aucun flux haute fréquence dans un `ChangeNotifier` app-level.** Le curseur
s'abonne directement à `volumeStream`, le compteur tique localement. Rien
au-dessus ne se reconstruit — même règle que `queue_progress.dart` (STR-230).

**Le volume est sur `PlaybackTransport`**, pas sur l'une des deux interfaces
dérivées : le volume ne dépend pas de ce qu'on écoute, donc un seul curseur sert
le direct **et** la file d'attente.

---

## Une difficulté de test qui valait un paramètre

`tester.pump(Duration)` n'avance que l'horloge **simulée** de Flutter. Un widget
qui appelle `DateTime.now()` en dur ne voit donc jamais le temps passer sous
test — le compteur serait resté à zéro et tout le fichier aurait été
invérifiable.

La source de temps est un paramètre injectable, comme le `controller` de
`StreamPlayerScreen`. Les tests avancent les deux horloges ensemble.

---

## Vérifications

```
flutter analyze   No issues found
flutter test      481 tests (452 avant, +29)
liens docs        301 relatifs, 0 cassé
make check-adr-index   40 ADR, toutes résumées
```

Les 29 tests couvrent : la règle d'atténuation (dont le réglage qui survit à
l'interruption, et le facteur qui ne remonte jamais un son bas), l'horloge
(reconnexion, horloge murale qui recule, démarrages répétés du lecteur),
le curseur (application continue vs enregistrement au relâchement, sourdine et
rétablissement, annonce en pourcentage au lecteur d'écran), et le magasin.

---

## Effet de bord assumé

Trois harnais de tests existants fournissent désormais `PlaybackTransport` et
`VolumeStore`, parce que le curseur partagé les exige.

J'ai écarté l'alternative — faire disparaître le curseur quand les providers
manquent : ça aurait fait passer les tests sans rien changer, **et masqué le
même défaut de câblage en production**.

## Dépendance ajoutée

`shared_preferences`, pour un seul réglage aujourd'hui. `SecureStorage` était
disponible mais n'a qu'une responsabilité — les jetons JWT — et un niveau sonore
n'est ni un secret ni quelque chose qu'on veut chiffrer.
