### PR TITLE
feat(mobile): nommer les contrôles pour les lecteurs d'écran et adapter aux largeurs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -537,7 +537,7 @@ wrappers minces vers `AuthScreen(initialTab: ...)`.
 **Toasts** : `toastification` via les helpers `showAuthSuccessToast / ErrorToast / InfoToast`
 (`presentation/widgets/auth_toasts.dart`). `ToastificationWrapper` est posé dans `app.dart`.
 
-### Accessibilité et adaptation aux largeurs (STR-246, ADR 043)
+### Accessibilité et adaptation aux largeurs (STR-244, ADR 043)
 
 - ⚠️ **Un `tooltip` n'est pas un `label`.** Vérifié sur l'arbre sémantique : un
   `IconButton(tooltip: 'X')` rend `label="" tooltip="X"`. Android s'en sert à défaut de

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -537,6 +537,29 @@ wrappers minces vers `AuthScreen(initialTab: ...)`.
 **Toasts** : `toastification` via les helpers `showAuthSuccessToast / ErrorToast / InfoToast`
 (`presentation/widgets/auth_toasts.dart`). `ToastificationWrapper` est posé dans `app.dart`.
 
+### Accessibilité et adaptation aux largeurs (STR-246, ADR 043)
+
+- ⚠️ **Un `tooltip` n'est pas un `label`.** Vérifié sur l'arbre sémantique : un
+  `IconButton(tooltip: 'X')` rend `label="" tooltip="X"`. Android s'en sert à défaut de
+  description ; **iOS en fait un *hint***, donc VoiceOver annonce « bouton » sans nom.
+  Utiliser `AccessibleIconButton` (`core/widgets/`), qui pose les deux, et dont le libellé
+  décrit l'**action** (« Mettre en pause »), jamais l'icône ni l'état.
+- Une **ligne de liste** porte une phrase unique via `Semantics(container: true, label: ...)`
+  et masque ses enfants : sinon un lecteur d'écran annonce « 3 », « Sunrise », « Neon Lights »
+  en trois arrêts sans jamais dire laquelle joue. Les boutons d'une liste **nomment leur
+  cible** (« Interrompre le flux X »).
+- Tests : `test/support/accessibility.dart` — `expectMeetsAccessibilityGuidelines` (les 4
+  vérificateurs de `flutter_test`) et `expectNoTooltipOnlyTapTargets`, plus stricte car
+  `labeledTapTargetGuideline` accepte un tooltip seul. Toujours `tester.ensureSemantics()`
+  avant de monter le widget, sinon il n'y a pas d'arbre à inspecter.
+- **Responsive** : `Breakpoints` + `ResponsiveContent` (`core/layout/`). Le paysage est
+  autorisé par les deux manifestes — décision prise d'**adapter** plutôt que de verrouiller
+  le portrait. `ResponsiveContent` borne et centre au-delà de 600 px ; **sans effet en
+  portrait téléphone**, la contrainte n'y mord pas.
+- ⚠️ **Ne pas lancer `dart format` sur des fichiers existants** : la version courante du
+  formateur réécrit des lignes non touchées et peut introduire des lints. Ne formater que
+  les fichiers qu'on crée.
+
 ### Conventions Flutter — State management
 
 Choisir **le plus simple qui suffit**, dans cet ordre :
@@ -707,7 +730,7 @@ xcrun simctl openurl booted \
 | `docs/adr/037-initialisation-base-de-donnees.md` | Décision : schéma, migrations et seed PostgreSQL |
 
 **Règle :** toute nouvelle décision d'architecture significative → nouvel ADR dans `docs/adr/`
-avec le numéro suivant (prochain : `040-...`). Référencer le ticket Linear correspondant.
+avec le numéro suivant (prochain : `044-...`). Référencer le ticket Linear correspondant.
 Un numéro n'est **jamais** réutilisé, et une ADR remplacée passe en `Superseded by NNN` plutôt
 que d'être réécrite. Chaque ADR porte un bloc **Date / Statut / Ticket** et une section
 **« Alternatives écartées »**.

--- a/docs/README.md
+++ b/docs/README.md
@@ -163,13 +163,14 @@ Chaque décision est tracée avec son contexte, les **alternatives écartées** 
 | 037 | [037-initialisation-base-de-donnees.md](adr/037-initialisation-base-de-donnees.md) | Initialisation de la base de données : schéma, migrations et seed *(ex-ADR 003)* |
 | 038 | [038-gestion-profil-utilisateur.md](adr/038-gestion-profil-utilisateur.md) | Gestion du profil utilisateur (table `profiles` dédiée) *(ex-ADR 012)* |
 | 039 | [039-supervision-admin-des-flux-et-journal-daudit.md](adr/039-supervision-admin-des-flux-et-journal-daudit.md) | Supervision admin des flux actifs et journal d'audit *(ex-ADR 018)* |
+| 043 | [043-accessibilite-de-l-application-et-adaptation-aux-largeurs.md](adr/043-accessibilite-de-l-application-et-adaptation-aux-largeurs.md) | Accessibilité de l'application mobile et adaptation aux largeurs d'écran |
 
 ---
 
 ## Convention ADR
 
 - Toute nouvelle décision d'architecture significative → nouvel ADR dans `docs/adr/`,
-  avec **le numéro suivant** (prochain : `040-...`). Le numéro est un **identifiant**,
+  avec **le numéro suivant** (prochain : `044-...`). Le numéro est un **identifiant**,
   attribué dans l'ordre d'enregistrement — il ne suit pas nécessairement l'ordre chronologique
   des décisions (cf. 037/038/039, renumérotées après collision).
 - Un numéro n'est **jamais réutilisé** : une ADR remplacée passe en statut

--- a/docs/accessibilite.md
+++ b/docs/accessibilite.md
@@ -8,7 +8,7 @@ StreamPulse, les règles qui l'assurent, et les écarts qui subsistent.
 > comptent, séparément, et confondre les deux reviendrait à déclarer conforme
 > quelque chose qui ne l'est pas.
 >
-> Le volet application est traité depuis STR-246 :
+> Le volet application est traité depuis STR-244 :
 > [ADR 043](adr/043-accessibilite-de-l-application-et-adaptation-aux-largeurs.md)
 > décrit ce qui est fait — libellés sémantiques, vérificateurs WCAG en CI,
 > adaptation aux largeurs — **et ce qui ne l'est pas** : aucune vérification au

--- a/docs/accessibilite.md
+++ b/docs/accessibilite.md
@@ -4,10 +4,15 @@ Ce document déclare le niveau d'accessibilité visé par la **documentation** d
 StreamPulse, les règles qui l'assurent, et les écarts qui subsistent.
 
 > **Périmètre.** Il porte sur les documents de `docs/` et le `README`. Il ne
-> porte **pas** sur l'accessibilité de l'application Flutter elle-même, qui est
-> un chantier distinct et n'est pas couverte ici. Les deux comptent, séparément,
-> et confondre les deux reviendrait à déclarer conforme quelque chose qui ne
-> l'est pas.
+> porte **pas** sur l'accessibilité de l'application Flutter elle-même. Les deux
+> comptent, séparément, et confondre les deux reviendrait à déclarer conforme
+> quelque chose qui ne l'est pas.
+>
+> Le volet application est traité depuis STR-246 :
+> [ADR 043](adr/043-accessibilite-de-l-application-et-adaptation-aux-largeurs.md)
+> décrit ce qui est fait — libellés sémantiques, vérificateurs WCAG en CI,
+> adaptation aux largeurs — **et ce qui ne l'est pas** : aucune vérification au
+> lecteur d'écran réel, faute d'appareil. Aucune conformité n'y est déclarée.
 
 ---
 

--- a/docs/adr/043-accessibilite-de-l-application-et-adaptation-aux-largeurs.md
+++ b/docs/adr/043-accessibilite-de-l-application-et-adaptation-aux-largeurs.md
@@ -2,7 +2,7 @@
 
 **Date** : 2026-08-21
 **Statut** : Accepté
-**Ticket** : [STR-246](https://linear.app/streampulse/issue/STR-246)
+**Ticket** : [STR-244](https://linear.app/streampulse/issue/STR-244/completer-le-lecteur-linterface-et-les-metriques-manquantes-du-bareme)
 
 ---
 

--- a/docs/adr/043-accessibilite-de-l-application-et-adaptation-aux-largeurs.md
+++ b/docs/adr/043-accessibilite-de-l-application-et-adaptation-aux-largeurs.md
@@ -1,0 +1,196 @@
+# ADR 043 — Accessibilité de l'application mobile et adaptation aux largeurs d'écran
+
+**Date** : 2026-08-21
+**Statut** : Accepté
+**Ticket** : [STR-246](https://linear.app/streampulse/issue/STR-246)
+
+---
+
+## Contexte
+
+Le sujet demande une interface « responsive (iOS/Android) et respectant les
+standards d'accessibilité ». L'audit a mesuré l'écart, et il était net :
+
+| Recherche dans `lib/` (147 fichiers) | Occurrences |
+| -- | -- |
+| `Semantics(` | 1 — sur l'écran de démarrage |
+| `semanticLabel` / `semanticsLabel` | 0 |
+| `LayoutBuilder` / `OrientationBuilder` | 0 |
+| `AppConstants.minTouchTarget` | 8 fichiers |
+
+[`docs/accessibilite.md`](../accessibilite.md) déclarait déjà l'accessibilité de
+la **documentation**, en excluant explicitement l'application : « un chantier
+distinct […] confondre les deux reviendrait à déclarer conforme quelque chose
+qui ne l'est pas ». Cette ADR ouvre ce chantier.
+
+---
+
+## 1. Un `tooltip` n'est pas un `label` — vérifié, pas supposé
+
+Le ticket affirmait que les treize fichiers portant un `tooltip:` « ne comptent
+pas », un tooltip n'étant pas un libellé sémantique. C'est **inexact tel quel**,
+et la nuance change ce qu'il faut corriger.
+
+Mesuré sur l'arbre sémantique d'un `IconButton(tooltip: 'Mettre en pause')` :
+
+```
+label="" tooltip="Mettre en pause" button=true
+```
+
+Le texte **est** exposé, dans le champ `tooltip`. Conséquences par plateforme :
+
+| | Ce que devient le tooltip | Effet |
+| -- | -- | -- |
+| Android | `AccessibilityNodeInfo.tooltipText` | TalkBack s'en sert à défaut de description : le bouton est utilisable |
+| iOS | un *hint*, pas un *label* | VoiceOver annonce « bouton » **sans nom**, puis éventuellement le hint après une pause, et seulement si les hints sont activés |
+
+Un bouton-icône qui n'a qu'un tooltip est donc **anonyme sur iOS**. C'est un
+vrai défaut — mais pas celui qui était annoncé, et le corriger demande de poser
+un `label`, pas de remplacer les tooltips.
+
+`AccessibleIconButton` pose **les deux** : le libellé pour les lecteurs
+d'écran, le tooltip pour l'appui long et le survol.
+
+Le libellé décrit l'**action**, jamais l'icône ni l'état. Le tooltip d'origine
+du bouton de lecture disait « Pause » quand la lecture était à l'arrêt : un
+lecteur d'écran annonçait donc exactement l'inverse de ce que l'appui allait
+faire.
+
+---
+
+## 2. Les vérificateurs de Flutter tournent en CI
+
+`flutter_test` embarque `androidTapTargetGuideline`, `iOSTapTargetGuideline`,
+`labeledTapTargetGuideline` et `textContrastGuideline`. Les faire tourner vaut
+mieux qu'une affirmation de conformité dans un document : ils échouent quand la
+règle est violée, y compris sur du code écrit plus tard.
+
+Une vérification **plus stricte** leur est ajoutée :
+`expectNoTooltipOnlyTapTargets`. `labeledTapTargetGuideline` accepte un tooltip
+seul — elle regarde label *ou* tooltip — alors que c'est précisément le cas qui
+laisse un bouton anonyme sur iOS.
+
+Elle est accompagnée d'un **test de contrôle** : un `IconButton` nu doit être
+signalé. Sans lui, on ne saurait pas si la garde vérifie quelque chose ou passe
+toujours — et c'est exactement ce qui s'est produit à l'écriture : la première
+version cherchait l'arbre sémantique sur le mauvais `PipelineOwner`, n'en
+trouvait aucun, et rendait sereinement une liste vide. Un vérificateur qui ne
+trouve pas son sujet échoue désormais bruyamment.
+
+### Ce que ces gardes ne couvrent pas
+
+L'ordre de parcours, la pertinence des libellés, et le comportement réel de
+TalkBack et VoiceOver. Cette vérification-là **n'a pas été faite** : elle exige
+un appareil, et le matériel n'était pas disponible. C'est un écart déclaré, pas
+un point tenu.
+
+---
+
+## 3. Une ligne de liste se lit d'un coup, ou pas du tout
+
+Une ligne de playlist affiche un numéro, un titre, un artiste, et un point
+coloré pour la piste en cours. Un lecteur d'écran parcourt ces fragments un par
+un — et ne voit pas le point.
+
+Sans regroupement, TalkBack annonce « 3 », s'arrête, « Sunrise », s'arrête,
+« Neon Lights, 3:34 » — trois arrêts, et jamais l'information qui compte : c'est
+celle-ci qui joue.
+
+Le conteneur porte donc la phrase entière et masque ses enfants :
+
+> « Piste 3, Sunrise, Neon Lights, en cours de lecture »
+
+Les boutons d'une liste nomment leur cible pour la même raison : dix boutons
+« Interrompre » qui se suivent ne disent pas lequel on a sous le doigt.
+
+---
+
+## 4. Adapter plutôt que verrouiller le portrait
+
+Le paysage **est autorisé** — `Info.plist` liste `LandscapeLeft`/`Right`,
+l'`AndroidManifest` ne pose aucun `screenOrientation` — mais l'interface était
+figée en une colonne. Faire pivoter le téléphone donnait un portrait étiré, où
+une ligne de trois mots traverse 800 px.
+
+Deux issues : verrouiller le portrait, ou adapter. Le ticket demandait de
+trancher et d'écrire la décision.
+
+**L'adaptation est retenue.** Le verrouillage était honnête et immédiat, mais il
+aurait retiré une capacité que les deux plateformes offrent, pour un gain nul
+en accessibilité — quelqu'un qui fixe son téléphone sur un support de vélo n'a
+pas le choix de l'orientation.
+
+Deux mécanismes, parce que les deux problèmes sont distincts :
+
+1. **Borner la largeur du contenu** — répond au portrait étiré. Une ligne de
+   texte au-delà de ~70 caractères se lit mal ; ce n'est pas une question de
+   plateforme mais de typographie.
+2. **Multiplier les colonnes** — répond à la tablette, où borner la largeur
+   laisserait deux tiers de l'écran vides.
+
+Les valeurs sont les classes de taille de Material 3 (compact < 600, medium
+600–839, expanded ≥ 840). Les reprendre plutôt que d'inventer les nôtres évite
+d'avoir à les défendre, et les aligne sur les composants Material déjà utilisés.
+
+`ResponsiveContent` **n'a aucun effet sur un téléphone en portrait** : la
+contrainte n'y mord pas. Rien ne change là où l'application passe l'essentiel de
+son temps, et c'est voulu — une adaptation qui modifie le cas nominal pour
+soigner un cas rare est une régression déguisée.
+
+---
+
+## Conséquences
+
+**Positives**
+
+- Les contrôles du lecteur, les lignes de playlist et les actions d'admin ont un
+  nom pour un lecteur d'écran, sur **les deux** plateformes.
+- Quatre vérificateurs WCAG tournent en CI, plus une garde maison plus stricte.
+- La rotation ne produit plus une colonne étirée.
+- Le grossissement de texte est couvert par un test.
+
+**Négatives, assumées**
+
+- **Aucune vérification au lecteur d'écran réel.** TalkBack et VoiceOver exigent
+  un appareil ; le point n'est pas tenu et ne doit pas être présenté comme tel.
+- La couverture est partielle : les surfaces nommées par le ticket sont
+  traitées, les écrans d'authentification et de profil ne le sont pas encore.
+- `AccessibleIconButton` n'expose pas toute la surface d'`IconButton`
+  (`padding`, `splashRadius`, `constraints`) — à élargir au besoin.
+- Les colonnes multiples sont disponibles (`Breakpoints.columnsFor`) mais
+  encore appliquées nulle part : les écrans de liste bornent leur largeur sans
+  passer en grille.
+
+---
+
+## Alternatives écartées
+
+**Verrouiller le portrait dans `Info.plist` et l'`AndroidManifest`.** Une ligne
+de configuration par plateforme, et le problème du portrait étiré disparaît.
+Écarté : cela retire une capacité offerte par les deux systèmes à des
+utilisateurs qui n'ont pas toujours le choix de l'orientation.
+
+**Se fier aux `tooltip:` existants.** Ils satisfont la garde de Flutter et
+fonctionnent sur Android. Écarté après vérification : sur iOS ils deviennent des
+hints, et le bouton reste sans nom.
+
+**Ajouter `Semantics` à la main partout plutôt qu'un widget dédié.** Écarté :
+rien n'empêcherait alors le prochain `IconButton` d'oublier son libellé. Le
+widget rend la règle difficile à contourner, la garde de test la rend visible.
+
+**Se contenter des vérificateurs de Flutter, sans garde maison.** Écarté :
+`labeledTapTargetGuideline` accepte un tooltip seul, soit exactement le défaut à
+corriger.
+
+**Déclarer la conformité WCAG 2.1 AA de l'application.** Écarté : sans passage
+au lecteur d'écran réel, la déclaration serait invérifiée. L'ADR décrit ce qui
+est fait et ce qui ne l'est pas.
+
+---
+
+## Références
+
+- [Accessibilité de la documentation](../accessibilite.md) — le volet documentaire, périmètre distinct
+- [ADR 036 — State management Flutter](036-state-management-flutter-provider.md)
+- ADR 042 — Contrôle du volume et temps d'écoute (PR distincte) : le curseur
+  qu'elle ajoute au lecteur est annoncé en pourcentage par le même mécanisme

--- a/docs/en/adr-index.md
+++ b/docs/en/adr-index.md
@@ -174,6 +174,15 @@ the system notification travels the same path as a tap in the app.
 **involuntary** reloads. *Consequence:* a token expiry no longer reshuffles the
 queue every fifteen minutes.
 
+**ADR 043 — App accessibility and width adaptation.** *Context:* one `Semantics`
+call across 147 files, no layout adaptation, and landscape allowed by both
+manifests. *Decision:* give icon-only controls a real semantic **label** — a
+tooltip lands in the node's `tooltip` field, which iOS turns into a hint, so the
+button has no name for VoiceOver — run Flutter's WCAG guidelines in CI alongside
+a stricter in-house check, and **adapt** to width rather than locking portrait.
+*Consequence:* screen-reader behaviour is still unverified on real devices, and
+that gap is declared rather than glossed over.
+
 ## Administration
 
 **ADR 017 — Admin dashboard, user management.** *Context:* administration must

--- a/mobile/lib/core/layout/breakpoints.dart
+++ b/mobile/lib/core/layout/breakpoints.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/widgets.dart';
 
-/// Ruptures de largeur et adaptation de la mise en page (STR-246).
+/// Ruptures de largeur et adaptation de la mise en page (STR-244).
 ///
 /// ## La décision, plutôt que de la subir
 ///

--- a/mobile/lib/core/layout/breakpoints.dart
+++ b/mobile/lib/core/layout/breakpoints.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/widgets.dart';
+
+/// Ruptures de largeur et adaptation de la mise en page (STR-246).
+///
+/// ## La décision, plutôt que de la subir
+///
+/// Le paysage **est autorisé** — `Info.plist` liste `LandscapeLeft`/`Right` et
+/// l'`AndroidManifest` ne pose aucun `screenOrientation` — mais l'interface
+/// était figée en une colonne portrait. Faire pivoter le téléphone donnait donc
+/// un portrait étiré, où une ligne de liste traverse 800 px pour trois mots.
+///
+/// Deux issues possibles : verrouiller le portrait, ou adapter. Le verrouillage
+/// était honnête et immédiat, mais il aurait retiré une capacité que les deux
+/// plateformes offrent — et le sujet demande une interface « responsive ».
+///
+/// C'est donc l'adaptation qui est retenue, avec **deux mécanismes distincts**
+/// parce que les deux problèmes sont distincts :
+///
+/// 1. **Borner la largeur du contenu** ([contentMaxWidth]) — répond au portrait
+///    étiré. Une ligne de texte au-delà de ~70 caractères se lit mal ; ce n'est
+///    pas une question de plateforme mais de typographie.
+/// 2. **Multiplier les colonnes** ([columnsFor]) — répond à la tablette, où
+///    borner la largeur laisserait deux tiers de l'écran vides.
+///
+/// ## Pourquoi ces valeurs
+///
+/// Ce sont les classes de taille de Material 3 : compact (< 600), medium
+/// (600–839), expanded (≥ 840). Les reprendre plutôt que d'inventer les nôtres
+/// évite d'avoir à les défendre, et elles s'alignent sur ce que font les
+/// composants Material que l'application utilise déjà.
+///
+/// Objet **pur** : la règle se vérifie sans monter d'arbre de widgets.
+class Breakpoints {
+  const Breakpoints._();
+
+  /// En deçà : téléphone en portrait. Une seule colonne.
+  static const double medium = 600;
+
+  /// Au-delà : tablette, ou téléphone en paysage sur les grands modèles.
+  static const double expanded = 840;
+
+  /// Largeur maximale d'une colonne de contenu.
+  ///
+  /// Bornée à [medium] : au-delà, la ligne devient trop longue pour l'œil, quel
+  /// que soit l'espace disponible. Sur un écran plus large, la colonne est
+  /// centrée et l'espace restant sert de marge — c'est ce qui remplace le
+  /// portrait étiré.
+  static double contentMaxWidth(double width) =>
+      width <= medium ? width : medium;
+
+  /// Nombre de colonnes pour une grille de cartes.
+  ///
+  /// Trois au maximum : au-delà, les cartes deviennent trop étroites pour leur
+  /// contenu et on perd ce qu'on croyait gagner.
+  static int columnsFor(double width) {
+    if (width >= expanded) return 3;
+    if (width >= medium) return 2;
+    return 1;
+  }
+
+  /// Vrai quand l'écran a la place d'afficher plus d'une colonne.
+  static bool isWide(double width) => width >= medium;
+}
+
+/// Centre et borne son enfant au-delà de la rupture (cf. [Breakpoints.contentMaxWidth]).
+///
+/// À poser autour du contenu d'un écran de liste ou de formulaire. Sans effet
+/// sur un téléphone en portrait : la contrainte n'y mord pas, donc rien ne
+/// change là où l'application passe l'essentiel de son temps.
+class ResponsiveContent extends StatelessWidget {
+  const ResponsiveContent({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        // `maxWidth` infini : le parent est un ListView horizontal, une Row non
+        // bornée, ou un contexte de mesure. Borner y lèverait une exception.
+        if (!constraints.hasBoundedWidth) return child;
+        return Center(
+          child: ConstrainedBox(
+            constraints: BoxConstraints(
+              maxWidth: Breakpoints.contentMaxWidth(constraints.maxWidth),
+            ),
+            child: child,
+          ),
+        );
+      },
+    );
+  }
+}

--- a/mobile/lib/core/widgets/accessible_icon_button.dart
+++ b/mobile/lib/core/widgets/accessible_icon_button.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../constants/app_constants.dart';
 
-/// Bouton-icône nommé pour les lecteurs d'écran (STR-246).
+/// Bouton-icône nommé pour les lecteurs d'écran (STR-244).
 ///
 /// ## Pourquoi un `tooltip` ne suffit pas
 ///

--- a/mobile/lib/core/widgets/accessible_icon_button.dart
+++ b/mobile/lib/core/widgets/accessible_icon_button.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+
+import '../constants/app_constants.dart';
+
+/// Bouton-icône nommé pour les lecteurs d'écran (STR-246).
+///
+/// ## Pourquoi un `tooltip` ne suffit pas
+///
+/// Vérifié sur l'arbre sémantique : un `IconButton(tooltip: 'Mettre en pause')`
+/// produit un nœud `label="" tooltip="Mettre en pause"`. Le texte est donc bien
+/// exposé — la garde `labeledTapTargetGuideline` de Flutter l'accepte — mais
+/// dans le champ **tooltip**, pas dans le champ **label**.
+///
+/// La différence n'est pas cosmétique :
+///
+/// - Android : le tooltip devient `AccessibilityNodeInfo.tooltipText`. TalkBack
+///   s'en sert **à défaut** de description, donc le bouton est utilisable.
+/// - iOS : il devient un *hint*, pas un *label*. VoiceOver annonce alors
+///   « bouton » sans nom, puis éventuellement le hint après une pause — et
+///   seulement si les hints sont activés.
+///
+/// Un bouton-icône qui n'a qu'un tooltip est donc **anonyme sur iOS**. Ce widget
+/// pose les deux : le libellé sémantique pour les lecteurs d'écran, le tooltip
+/// pour l'appui long et le survol.
+///
+/// ## Taille de cible
+///
+/// `IconButton` fait 48 px par défaut, au-dessus des 44 px exigés par WCAG 2.1
+/// AA ([AppConstants.minTouchTarget]). La contrainte est néanmoins posée
+/// explicitement : une densité visuelle réduite (`visualDensity`) ou un
+/// `IconButtonTheme` sur un écran donné peut faire passer sous la barre sans
+/// que rien ne le signale.
+class AccessibleIconButton extends StatelessWidget {
+  const AccessibleIconButton({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.onPressed,
+    this.color,
+    this.iconSize,
+    this.tooltip,
+  });
+
+  final IconData icon;
+
+  /// Ce que le lecteur d'écran annonce. Décrit **l'action**, pas l'icône :
+  /// « Mettre en pause », jamais « icône pause ».
+  final String label;
+
+  /// `null` désactive le bouton — l'état est alors annoncé par le lecteur
+  /// d'écran, sans que le libellé change.
+  final VoidCallback? onPressed;
+
+  final Color? color;
+  final double? iconSize;
+
+  /// Texte de l'infobulle si elle doit différer du libellé. Par défaut, le
+  /// libellé sert aux deux : les faire diverger sans raison donnerait deux
+  /// vocabulaires pour le même bouton.
+  final String? tooltip;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: label,
+      button: true,
+      enabled: onPressed != null,
+      // Le libellé du Semantics fait autorité : sans cette exclusion, le tooltip
+      // posé en dessous ajouterait une seconde annonce du même texte.
+      excludeSemantics: true,
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(
+          minWidth: AppConstants.minTouchTarget,
+          minHeight: AppConstants.minTouchTarget,
+        ),
+        child: IconButton(
+          onPressed: onPressed,
+          tooltip: tooltip ?? label,
+          color: color,
+          iconSize: iconSize,
+          icon: Icon(icon),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/core/widgets/mini_player_shell.dart
+++ b/mobile/lib/core/widgets/mini_player_shell.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'accessible_icon_button.dart';
 
 /// Coquille commune aux mini-players (direct STR-109 et file d'attente
 /// US-05-04) : bandeau de 60 px au-dessus de la navigation, icône, titre et
@@ -139,12 +140,22 @@ class PlaybackToggleButton extends StatelessWidget {
     } else {
       icon = Icons.play_arrow;
     }
-    return IconButton(
+    // Le libellé décrit l'ACTION, pas l'état ni l'icône : annoncer « Pause »
+    // sur un flux à l'arrêt laisse croire que l'appui met en pause.
+    final String label;
+    if (showReplay) {
+      label = 'Réessayer la lecture';
+    } else if (isPlaying) {
+      label = 'Mettre en pause';
+    } else {
+      label = 'Lire';
+    }
+    return AccessibleIconButton(
+      icon: icon,
+      label: label,
       onPressed: onPressed,
       color: Theme.of(context).colorScheme.primary,
       iconSize: 30,
-      icon: Icon(icon),
-      tooltip: isPlaying ? 'Pause' : 'Lecture',
     );
   }
 }

--- a/mobile/lib/features/admin/presentation/screens/admin_streams_screen.dart
+++ b/mobile/lib/features/admin/presentation/screens/admin_streams_screen.dart
@@ -8,6 +8,7 @@ import '../../data/repositories/admin_streams_repository_impl.dart';
 import '../../domain/entities/admin_stream.dart';
 import '../../domain/repositories/admin_streams_repository.dart';
 import '../providers/admin_streams_provider.dart';
+import '../../../../core/widgets/accessible_icon_button.dart';
 
 /// Écran de supervision des flux en direct (US-08-02) : liste paginée des
 /// flux publics/privés avec l'identité du diffuseur, interruption forcée
@@ -264,9 +265,12 @@ class _StreamTile extends StatelessWidget {
             ),
           ],
         ),
-        trailing: IconButton(
+        trailing: AccessibleIconButton(
           key: Key('admin_stream_stop_${stream.id}'),
-          icon: const Icon(Icons.stop_circle_outlined),
+          icon: Icons.stop_circle_outlined,
+          // Nomme la cible : dans une liste, dix boutons « Interrompre » se
+          // suivent et rien ne dit lequel on a sous le doigt.
+          label: 'Interrompre le flux ${stream.title}',
           tooltip: 'Interrompre',
           onPressed: () => onStop(stream),
         ),

--- a/mobile/lib/features/broadcast/presentation/screens/dashboard_screen.dart
+++ b/mobile/lib/features/broadcast/presentation/screens/dashboard_screen.dart
@@ -22,6 +22,7 @@ import '../../domain/services/broadcast_audio_publisher.dart';
 import '../controllers/broadcast_session_controller.dart';
 import '../providers/broadcast_notifier.dart';
 import 'create_stream_sheet.dart';
+import '../../../../core/widgets/accessible_icon_button.dart';
 
 /// Tableau de bord du diffuseur (US-06-01, ADR 024 et ADR 027) : créer un flux,
 /// lancer/arrêter le direct et pousser le microphone du téléphone en AAC/ADTS.
@@ -387,10 +388,10 @@ class _DashboardBodyState extends State<_DashboardBody>
         title: const Text('Tableau de bord'),
         actions: [
           if (_isBroadcaster(profile))
-            IconButton(
+            AccessibleIconButton(
               key: const Key('dashboard_create_button'),
-              icon: const Icon(Icons.add),
-              tooltip: 'Créer un flux',
+              icon: Icons.add,
+              label: 'Créer un flux',
               onPressed: notifier.creating ? null : _onCreate,
             ),
         ],
@@ -973,20 +974,23 @@ class _IngestUrlRowState extends State<_IngestUrlRow> {
               ],
             ),
           ),
-          IconButton(
+          AccessibleIconButton(
             key: Key('dashboard_reveal_key_${widget.streamId}'),
-            icon: Icon(
-              _revealed
-                  ? Icons.visibility_off_outlined
-                  : Icons.visibility_outlined,
-            ),
+            icon: _revealed
+                ? Icons.visibility_off_outlined
+                : Icons.visibility_outlined,
+            // « Révéler 15 s » ne dit pas ce qui va s'afficher — or c'est une
+            // clé secrète, et l'annoncer compte.
+            label: _revealed
+                ? 'Masquer la clé de diffusion'
+                : 'Révéler la clé de diffusion pendant 15 secondes',
             tooltip: _revealed ? 'Masquer' : 'Révéler 15 s',
             onPressed: _toggleReveal,
           ),
-          IconButton(
+          AccessibleIconButton(
             key: Key('dashboard_copy_key_${widget.streamId}'),
-            icon: const Icon(Icons.copy_outlined),
-            tooltip: 'Copier l\'URL',
+            icon: Icons.copy_outlined,
+            label: 'Copier l\'URL de diffusion',
             onPressed: _copy,
           ),
         ],

--- a/mobile/lib/features/playlists/presentation/screens/playlist_detail_screen.dart
+++ b/mobile/lib/features/playlists/presentation/screens/playlist_detail_screen.dart
@@ -19,6 +19,7 @@ import '../track_labels.dart';
 import '../widgets/playlist_form_sheet.dart';
 import '../widgets/queue_track_visuals.dart';
 import '../widgets/track_picker_sheet.dart';
+import '../../../../core/widgets/accessible_icon_button.dart';
 
 /// Écran de détail d'une playlist (US-05-03) : pistes ordonnées, ajout depuis la
 /// bibliothèque, retrait, et réorganisation par drag-and-drop.
@@ -169,10 +170,10 @@ class _PlaylistDetailBodyState extends State<_PlaylistDetailBody> {
       appBar: AppBar(
         title: Text(widget.title),
         actions: [
-          IconButton(
+          AccessibleIconButton(
             key: const Key('playlist_shuffle_play_button'),
-            icon: const Icon(Icons.shuffle),
-            tooltip: 'Lire en aléatoire',
+            icon: Icons.shuffle,
+            label: 'Lire la playlist en aléatoire',
             onPressed: controller.tracks.isEmpty
                 ? null
                 : () => _onPlay(
@@ -180,10 +181,10 @@ class _PlaylistDetailBodyState extends State<_PlaylistDetailBody> {
                       shuffle: true,
                     ),
           ),
-          IconButton(
+          AccessibleIconButton(
             key: const Key('playlist_add_track_button'),
-            icon: const Icon(Icons.playlist_add),
-            tooltip: 'Ajouter une piste',
+            icon: Icons.playlist_add,
+            label: 'Ajouter une piste à la playlist',
             onPressed: _onAdd,
           ),
         ],
@@ -376,9 +377,36 @@ class _TrackTile extends StatelessWidget {
       },
     );
 
+    // Une ligne se lit visuellement d'un coup : numéro, titre, artiste, et un
+    // point coloré pour la piste en cours. Un lecteur d'écran parcourt les
+    // fragments un par un et ne voit pas le point. Le conteneur porte donc la
+    // phrase entière et masque ses enfants — sinon TalkBack annoncerait « 3 »,
+    // puis « Sunrise », puis « Neon Lights, 3:34 », sans jamais dire laquelle
+    // est en train de jouer.
+    return Semantics(
+      container: true,
+      label: [
+        'Piste ${index + 1}',
+        track.title,
+        if (track.artist != null && track.artist!.isNotEmpty) track.artist!,
+        if (isCurrent) 'en cours de lecture',
+      ].join(', '),
+      button: true,
+      selected: isCurrent,
+      child: _row(context, isCurrent, cacheStatus),
+    );
+  }
+
+  Widget _row(
+    BuildContext context,
+    bool isCurrent,
+    TrackCacheStatus? cacheStatus,
+  ) {
     return ListTile(
       onTap: onPlay,
-      leading: queueTrackLeading(context, index: index, isCurrent: isCurrent),
+      leading: ExcludeSemantics(
+        child: queueTrackLeading(context, index: index, isCurrent: isCurrent),
+      ),
       title: Text(
         track.title,
         maxLines: 1,
@@ -394,9 +422,11 @@ class _TrackTile extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           if (cacheStatus != null) _cacheIcon(context, cacheStatus),
-          IconButton(
+          AccessibleIconButton(
             key: Key('playlist_track_remove_${track.id}'),
-            icon: const Icon(Icons.remove_circle_outline),
+            icon: Icons.remove_circle_outline,
+            // Nomme la piste : dans une liste, tous ces boutons se ressemblent.
+            label: 'Retirer ${track.title} de la playlist',
             tooltip: 'Retirer de la playlist',
             onPressed: () => onRemove(track),
           ),

--- a/mobile/lib/features/playlists/presentation/screens/playlists_screen.dart
+++ b/mobile/lib/features/playlists/presentation/screens/playlists_screen.dart
@@ -195,7 +195,7 @@ class _PlaylistsBodyState extends State<_PlaylistsBody> {
           ],
         ],
       ),
-      // Cf. discover_screen : contenu borné au-delà de la rupture (STR-246).
+      // Cf. discover_screen : contenu borné au-delà de la rupture (STR-244).
       body: SafeArea(
         child: ResponsiveContent(
           child: RefreshIndicator(

--- a/mobile/lib/features/playlists/presentation/screens/playlists_screen.dart
+++ b/mobile/lib/features/playlists/presentation/screens/playlists_screen.dart
@@ -16,6 +16,7 @@ import '../providers/playlist_queue_controller.dart';
 import '../providers/playlists_controller.dart';
 import '../track_labels.dart';
 import '../widgets/playlist_form_sheet.dart';
+import '../../../../core/layout/breakpoints.dart';
 
 /// Écran « Bibliothèque » : liste des playlists de l'utilisateur avec création,
 /// renommage et suppression (US-05-02). Remplace le `PlaceholderScreen` de
@@ -194,10 +195,13 @@ class _PlaylistsBodyState extends State<_PlaylistsBody> {
           ],
         ],
       ),
+      // Cf. discover_screen : contenu borné au-delà de la rupture (STR-246).
       body: SafeArea(
-        child: RefreshIndicator(
-          onRefresh: authenticated ? _onRefresh : () async {},
-          child: _buildBody(context, controller),
+        child: ResponsiveContent(
+          child: RefreshIndicator(
+            onRefresh: authenticated ? _onRefresh : () async {},
+            child: _buildBody(context, controller),
+          ),
         ),
       ),
     );

--- a/mobile/lib/features/playlists/presentation/widgets/queue_mini_player.dart
+++ b/mobile/lib/features/playlists/presentation/widgets/queue_mini_player.dart
@@ -5,6 +5,7 @@ import '../../../../core/widgets/mini_player_shell.dart';
 import '../providers/playlist_queue_controller.dart';
 import 'playback_queue_sheet.dart';
 import 'queue_progress.dart';
+import '../../../../core/widgets/accessible_icon_button.dart';
 
 /// Mini-player de la file d'attente (US-05-04) : pendant du mini-player du
 /// direct, avec les contrôles que seule une file justifie (précédent/suivant).
@@ -47,11 +48,11 @@ class QueueMiniPlayer extends StatelessWidget {
       progress: const QueueProgressLine(),
       onTap: () => PlaybackQueueSheet.show(context),
       actions: [
-        IconButton(
+        AccessibleIconButton(
           key: const Key('queue_mini_previous'),
+          icon: Icons.skip_previous,
+          label: 'Piste précédente',
           onPressed: queue.hasPrevious ? queue.previous : null,
-          icon: const Icon(Icons.skip_previous),
-          tooltip: 'Piste précédente',
         ),
         PlaybackToggleButton(
           key: const Key('queue_mini_play_pause'),
@@ -60,17 +61,17 @@ class QueueMiniPlayer extends StatelessWidget {
           isPlaying: queue.isPlaying,
           onPressed: queue.togglePlayPause,
         ),
-        IconButton(
+        AccessibleIconButton(
           key: const Key('queue_mini_next'),
+          icon: Icons.skip_next,
+          label: 'Piste suivante',
           onPressed: queue.hasNext ? queue.next : null,
-          icon: const Icon(Icons.skip_next),
-          tooltip: 'Piste suivante',
         ),
-        IconButton(
+        AccessibleIconButton(
           key: const Key('queue_mini_stop'),
+          icon: Icons.close,
+          label: 'Arrêter la lecture',
           onPressed: queue.stop,
-          icon: const Icon(Icons.close),
-          tooltip: 'Arrêter',
         ),
       ],
     );

--- a/mobile/lib/features/streams/presentation/screens/discover_screen.dart
+++ b/mobile/lib/features/streams/presentation/screens/discover_screen.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../providers/discover_notifier.dart';
 import '../widgets/message_view.dart';
 import '../widgets/stream_tile.dart';
+import '../../../../core/layout/breakpoints.dart';
 
 class DiscoverScreen extends StatefulWidget {
   const DiscoverScreen({super.key});
@@ -28,10 +29,15 @@ class _DiscoverScreenState extends State<DiscoverScreen> {
 
     return Scaffold(
       appBar: AppBar(title: const Text('Découvrir')),
+      // Contenu borné et centré au-delà de la rupture (STR-246) : sans cela,
+      // une ligne de flux traverse 800 px en paysage pour trois mots. Sans
+      // effet sur un téléphone en portrait, où la contrainte ne mord pas.
       body: SafeArea(
-        child: RefreshIndicator(
-          onRefresh: _notifier.load,
-          child: _buildBody(context, notifier),
+        child: ResponsiveContent(
+          child: RefreshIndicator(
+            onRefresh: _notifier.load,
+            child: _buildBody(context, notifier),
+          ),
         ),
       ),
     );

--- a/mobile/lib/features/streams/presentation/screens/discover_screen.dart
+++ b/mobile/lib/features/streams/presentation/screens/discover_screen.dart
@@ -29,7 +29,7 @@ class _DiscoverScreenState extends State<DiscoverScreen> {
 
     return Scaffold(
       appBar: AppBar(title: const Text('Découvrir')),
-      // Contenu borné et centré au-delà de la rupture (STR-246) : sans cela,
+      // Contenu borné et centré au-delà de la rupture (STR-244) : sans cela,
       // une ligne de flux traverse 800 px en paysage pour trois mots. Sans
       // effet sur un téléphone en portrait, où la contrainte ne mord pas.
       body: SafeArea(

--- a/mobile/lib/features/streams/presentation/screens/stream_player_screen.dart
+++ b/mobile/lib/features/streams/presentation/screens/stream_player_screen.dart
@@ -9,6 +9,7 @@ import '../../../auth/presentation/widgets/auth_toasts.dart';
 import '../../domain/entities/live_stream.dart';
 import '../providers/audio_player_controller.dart';
 import '../providers/favorites_controller.dart';
+import '../../../../core/widgets/accessible_icon_button.dart';
 
 /// Lecteur audio HLS plein écran (STR-108/117, cf. ADR 023). L'audio est piloté
 /// par le [AudioPlayerController] **partagé** app-level (STR-109) : la lecture
@@ -154,10 +155,10 @@ class _StreamPlayerScreenState extends State<StreamPlayerScreen> {
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
       child: Row(
         children: [
-          IconButton(
+          AccessibleIconButton(
+            icon: Icons.keyboard_arrow_down,
+            label: 'Réduire le lecteur',
             onPressed: () => Navigator.of(context).maybePop(),
-            icon: const Icon(Icons.keyboard_arrow_down),
-            tooltip: 'Réduire',
           ),
           const Spacer(),
           // Le badge « EN DIRECT » disparaît quand le flux est terminé ou en
@@ -289,12 +290,12 @@ class _StreamPlayerScreenState extends State<StreamPlayerScreen> {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
       children: [
-        IconButton(
+        AccessibleIconButton(
+          icon: isFavorited ? Icons.favorite : Icons.favorite_border,
+          label: isFavorited ? 'Retirer des favoris' : 'Ajouter aux favoris',
           onPressed: _toggleFavorite,
           iconSize: 28,
           color: isFavorited ? colors.primary : colors.onSurfaceVariant,
-          icon: Icon(isFavorited ? Icons.favorite : Icons.favorite_border),
-          tooltip: isFavorited ? 'Retirer des favoris' : 'Ajouter aux favoris',
         ),
         _playPauseButton(colors),
       ],
@@ -317,17 +318,39 @@ class _StreamPlayerScreenState extends State<StreamPlayerScreen> {
       icon = Icon(Icons.play_arrow, size: 40, color: colors.onPrimary);
     }
 
-    return Material(
-      color: colors.primary,
-      shape: const CircleBorder(),
-      elevation: 4,
-      child: InkWell(
-        customBorder: const CircleBorder(),
-        onTap: _audio.togglePlayPause,
-        child: SizedBox(
-          width: 76,
-          height: 76,
-          child: Center(child: icon),
+    // Le contrôle principal de l'écran était un InkWell nu : aucun nom, aucun
+    // rôle, rien pour un lecteur d'écran. Le libellé suit l'état, sinon il
+    // annoncerait « Lire » sur un flux déjà en lecture.
+    final String label;
+    if (_audio.isBusy || _audio.isReconnecting) {
+      label = 'Chargement du flux';
+    } else if (_audio.hasError || _audio.isEnded) {
+      label = 'Réessayer la lecture';
+    } else if (_audio.isPlaying) {
+      label = 'Mettre en pause';
+    } else {
+      label = 'Lire';
+    }
+
+    return Semantics(
+      label: label,
+      button: true,
+      // Pendant le chargement il n'y a rien à activer : l'annoncer évite qu'un
+      // appui à l'aveugle passe pour une panne.
+      enabled: !(_audio.isBusy || _audio.isReconnecting),
+      excludeSemantics: true,
+      child: Material(
+        color: colors.primary,
+        shape: const CircleBorder(),
+        elevation: 4,
+        child: InkWell(
+          customBorder: const CircleBorder(),
+          onTap: _audio.togglePlayPause,
+          child: SizedBox(
+            width: 76,
+            height: 76,
+            child: Center(child: icon),
+          ),
         ),
       ),
     );

--- a/mobile/lib/features/streams/presentation/widgets/mini_player.dart
+++ b/mobile/lib/features/streams/presentation/widgets/mini_player.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 
 import '../../../../core/widgets/mini_player_shell.dart';
 import '../providers/audio_player_controller.dart';
+import '../../../../core/widgets/accessible_icon_button.dart';
 
 /// Mini-player persistant (STR-109) : surface de contrôle in-app du flux en
 /// cours, affichée au-dessus de la barre de navigation quand quelque chose joue.
@@ -44,10 +45,10 @@ class MiniPlayer extends StatelessWidget {
           isPlaying: audio.isPlaying,
           onPressed: audio.togglePlayPause,
         ),
-        IconButton(
+        AccessibleIconButton(
+          icon: Icons.close,
+          label: 'Arrêter l\'écoute',
           onPressed: audio.stop,
-          icon: const Icon(Icons.close),
-          tooltip: 'Arrêter',
         ),
       ],
     );

--- a/mobile/test/core/layout/breakpoints_test.dart
+++ b/mobile/test/core/layout/breakpoints_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:streampulse/core/layout/breakpoints.dart';
+
+void main() {
+  group('Breakpoints', () {
+    test('une colonne sur téléphone, plus au-delà', () {
+      expect(Breakpoints.columnsFor(375), 1); // iPhone portrait
+      expect(Breakpoints.columnsFor(599), 1);
+      expect(Breakpoints.columnsFor(600), 2); // rupture medium
+      expect(Breakpoints.columnsFor(839), 2);
+      expect(Breakpoints.columnsFor(840), 3); // rupture expanded
+      // Trois au maximum : au-delà les cartes deviennent trop étroites.
+      expect(Breakpoints.columnsFor(2000), 3);
+    });
+
+    test('la largeur de contenu est bornée, jamais étirée', () {
+      // Téléphone en portrait : la contrainte ne mord pas, rien ne change là où
+      // l'application passe l'essentiel de son temps.
+      expect(Breakpoints.contentMaxWidth(375), 375);
+      // Téléphone en paysage : c'est exactement le cas qui donnait un portrait
+      // étiré, une ligne de trois mots traversant tout l'écran.
+      expect(Breakpoints.contentMaxWidth(812), Breakpoints.medium);
+      expect(Breakpoints.contentMaxWidth(1200), Breakpoints.medium);
+    });
+
+    test('isWide s\'aligne sur la rupture medium', () {
+      expect(Breakpoints.isWide(599), isFalse);
+      expect(Breakpoints.isWide(600), isTrue);
+    });
+  });
+
+  group('ResponsiveContent', () {
+    Future<double> widthAt(WidgetTester tester, Size surface) async {
+      await tester.binding.setSurfaceSize(surface);
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: ResponsiveContent(
+              child: SizedBox.expand(child: Placeholder(key: Key('contenu'))),
+            ),
+          ),
+        ),
+      );
+      return tester.getSize(find.byKey(const Key('contenu'))).width;
+    }
+
+    testWidgets('laisse le contenu pleine largeur sur téléphone portrait', (
+      tester,
+    ) async {
+      expect(await widthAt(tester, const Size(375, 812)), 375);
+    });
+
+    testWidgets('borne le contenu en paysage', (tester) async {
+      expect(await widthAt(tester, const Size(812, 375)), Breakpoints.medium);
+    });
+
+    testWidgets('borne le contenu sur tablette', (tester) async {
+      expect(await widthAt(tester, const Size(1024, 768)), Breakpoints.medium);
+    });
+
+    // Un parent non borné (ListView horizontal, Row libre) : contraindre y
+    // lèverait une exception. Le widget doit s'effacer, pas casser.
+    testWidgets('se retire quand la largeur n\'est pas bornée', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: ResponsiveContent(
+                child: SizedBox(width: 2000, height: 50, child: Placeholder()),
+              ),
+            ),
+          ),
+        ),
+      );
+      expect(tester.takeException(), isNull);
+    });
+  });
+}

--- a/mobile/test/core/widgets/accessible_icon_button_test.dart
+++ b/mobile/test/core/widgets/accessible_icon_button_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:streampulse/core/constants/app_constants.dart';
+import 'package:streampulse/core/widgets/accessible_icon_button.dart';
+
+import '../../support/accessibility.dart';
+
+Future<SemanticsHandle> _pump(WidgetTester tester, Widget child) async {
+  final handle = tester.ensureSemantics();
+  await tester.pumpWidget(MaterialApp(home: Scaffold(body: child)));
+  return handle;
+}
+
+void main() {
+  testWidgets('expose un LABEL sémantique, pas seulement un tooltip', (
+    tester,
+  ) async {
+    final handle = await _pump(
+      tester,
+      AccessibleIconButton(
+        icon: Icons.pause,
+        label: 'Mettre en pause',
+        onPressed: () {},
+      ),
+    );
+
+    // Toute la raison d'être de ce widget. Un IconButton(tooltip:) remplit le
+    // champ `tooltip` du nœud sémantique, pas le champ `label` : sur iOS le
+    // tooltip devient un hint, et VoiceOver annonce « bouton » sans nom.
+    expect(find.bySemanticsLabel('Mettre en pause'), findsOneWidget);
+    expectNoTooltipOnlyTapTargets(tester);
+    await expectMeetsAccessibilityGuidelines(tester);
+    handle.dispose();
+  });
+
+  testWidgets('un IconButton nu échoue là où celui-ci passe', (tester) async {
+    // Test de contrôle : sans lui, on ne saurait pas si la garde ci-dessus
+    // vérifie quelque chose ou passe toujours.
+    final handle = await _pump(
+      tester,
+      IconButton(
+        onPressed: () {},
+        tooltip: 'Mettre en pause',
+        icon: const Icon(Icons.pause),
+      ),
+    );
+
+    expect(tapTargetsLabelledOnlyByTooltip(tester), ['Mettre en pause']);
+    handle.dispose();
+  });
+
+  testWidgets('le tooltip peut différer du libellé', (tester) async {
+    final handle = await _pump(
+      tester,
+      AccessibleIconButton(
+        icon: Icons.stop_circle_outlined,
+        label: 'Interrompre le flux Radio Neon',
+        tooltip: 'Interrompre',
+        onPressed: () {},
+      ),
+    );
+
+    expect(
+      find.bySemanticsLabel('Interrompre le flux Radio Neon'),
+      findsOneWidget,
+    );
+    handle.dispose();
+  });
+
+  testWidgets('la zone tactile tient les 44 px de WCAG 2.1 AA', (tester) async {
+    final handle = await _pump(
+      tester,
+      AccessibleIconButton(icon: Icons.add, label: 'Ajouter', onPressed: () {}),
+    );
+
+    final size = tester.getSize(find.byType(AccessibleIconButton));
+    expect(size.width, greaterThanOrEqualTo(AppConstants.minTouchTarget));
+    expect(size.height, greaterThanOrEqualTo(AppConstants.minTouchTarget));
+    handle.dispose();
+  });
+
+  testWidgets('un bouton désactivé garde son nom', (tester) async {
+    final handle = await _pump(
+      tester,
+      const AccessibleIconButton(
+        icon: Icons.skip_next,
+        label: 'Piste suivante',
+        onPressed: null,
+      ),
+    );
+
+    expect(find.bySemanticsLabel('Piste suivante'), findsOneWidget);
+    handle.dispose();
+  });
+
+  // Un utilisateur qui grossit le texte ne doit pas voir la mise en page casser.
+  testWidgets('survit à un grossissement de texte extrême', (tester) async {
+    final handle = tester.ensureSemantics();
+    await tester.binding.setSurfaceSize(const Size(375, 812));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(textScaler: TextScaler.linear(2)),
+        child: MaterialApp(
+          home: Scaffold(
+            body: Row(
+              children: [
+                AccessibleIconButton(
+                  icon: Icons.add,
+                  label: 'Ajouter',
+                  onPressed: () {},
+                ),
+                const Expanded(child: Text('Un titre de flux assez long')),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    handle.dispose();
+  });
+}

--- a/mobile/test/features/playlists/presentation/screens/playlist_detail_screen_test.dart
+++ b/mobile/test/features/playlists/presentation/screens/playlist_detail_screen_test.dart
@@ -16,6 +16,7 @@ import 'package:streampulse/features/playlists/presentation/screens/playlist_det
 
 import '../../../../support/fake_offline_playlist_controller.dart';
 import '../../../../support/fake_queue_playback_service.dart';
+import 'package:streampulse/core/widgets/accessible_icon_button.dart';
 
 class _FakeCacheRepository implements OfflineCacheRepository {
   @override
@@ -23,7 +24,11 @@ class _FakeCacheRepository implements OfflineCacheRepository {
   @override
   Future<bool> isOffline(String playlistId) async => false;
   @override
-  Future<void> enableOffline(String id, String name, List<PlaylistTrack> t) async {}
+  Future<void> enableOffline(
+    String id,
+    String name,
+    List<PlaylistTrack> t,
+  ) async {}
   @override
   Future<void> disableOffline(String id) async {}
   @override
@@ -31,7 +36,13 @@ class _FakeCacheRepository implements OfflineCacheRepository {
   @override
   Future<List<CachedTrackStatus>> downloadStatuses(String id) async => [];
   @override
-  Future<void> updateTrackStatus(String t, String p, {required TrackCacheStatus status, String? filePath, int? fileSize}) async {}
+  Future<void> updateTrackStatus(
+    String t,
+    String p, {
+    required TrackCacheStatus status,
+    String? filePath,
+    int? fileSize,
+  }) async {}
   @override
   Future<String?> cachedFilePath(String t) async => null;
   @override
@@ -41,16 +52,16 @@ class _FakeCacheRepository implements OfflineCacheRepository {
 }
 
 PlaylistTrack _track(String id, String title, int position) => PlaylistTrack(
-      id: id,
-      title: title,
-      artist: 'Neon Lights',
-      durationS: 214,
-      position: position,
-    );
+  id: id,
+  title: title,
+  artist: 'Neon Lights',
+  durationS: 214,
+  position: position,
+);
 
 class _FakePlaylistRepository implements PlaylistRepository {
   _FakePlaylistRepository({List<PlaylistTrack>? initial})
-      : _tracks = initial ?? [];
+    : _tracks = initial ?? [];
 
   List<PlaylistTrack> _tracks;
   List<Track> library = const [];
@@ -186,7 +197,10 @@ void main() {
   group('PlaylistDetailScreen', () {
     testWidgets('affiche les pistes numérotées dans l\'ordre', (tester) async {
       final repo = _FakePlaylistRepository(
-        initial: [_track('t1', 'Midnight Drive', 0), _track('t2', 'Sunrise', 1)],
+        initial: [
+          _track('t1', 'Midnight Drive', 0),
+          _track('t2', 'Sunrise', 1),
+        ],
       );
       await tester.pumpWidget(_harness(repo));
       await tester.pumpAndSettle();
@@ -199,10 +213,14 @@ void main() {
       expect(find.byKey(const Key('playlist_tracks_list')), findsOneWidget);
     });
 
-    testWidgets('le bouton Lire lance la playlist depuis le début (US-05-04)',
-        (tester) async {
+    testWidgets('le bouton Lire lance la playlist depuis le début (US-05-04)', (
+      tester,
+    ) async {
       final repo = _FakePlaylistRepository(
-        initial: [_track('t1', 'Midnight Drive', 0), _track('t2', 'Sunrise', 1)],
+        initial: [
+          _track('t1', 'Midnight Drive', 0),
+          _track('t2', 'Sunrise', 1),
+        ],
       );
       final service = FakeQueuePlaybackService();
       final queue = _queueController(service);
@@ -221,10 +239,14 @@ void main() {
       expect(find.byIcon(Icons.graphic_eq), findsOneWidget);
     });
 
-    testWidgets('un appui sur une piste démarre la file à cette piste',
-        (tester) async {
+    testWidgets('un appui sur une piste démarre la file à cette piste', (
+      tester,
+    ) async {
       final repo = _FakePlaylistRepository(
-        initial: [_track('t1', 'Midnight Drive', 0), _track('t2', 'Sunrise', 1)],
+        initial: [
+          _track('t1', 'Midnight Drive', 0),
+          _track('t2', 'Sunrise', 1),
+        ],
       );
       final service = FakeQueuePlaybackService();
       final queue = _queueController(service);
@@ -242,18 +264,23 @@ void main() {
       expect(queue.currentIndex, 1);
     });
 
-    testWidgets('playlist vide : ni bouton Lire, ni file lancée',
-        (tester) async {
+    testWidgets('playlist vide : ni bouton Lire, ni file lancée', (
+      tester,
+    ) async {
       await tester.pumpWidget(_harness(_FakePlaylistRepository()));
       await tester.pumpAndSettle();
 
       expect(find.byKey(const Key('playlist_play_button')), findsNothing);
     });
 
-    testWidgets('« Lire en aléatoire » lance la file mélangée (US-05-05)',
-        (tester) async {
+    testWidgets('« Lire en aléatoire » lance la file mélangée (US-05-05)', (
+      tester,
+    ) async {
       final repo = _FakePlaylistRepository(
-        initial: [_track('t1', 'Midnight Drive', 0), _track('t2', 'Sunrise', 1)],
+        initial: [
+          _track('t1', 'Midnight Drive', 0),
+          _track('t2', 'Sunrise', 1),
+        ],
       );
       final service = FakeQueuePlaybackService();
       final queue = _queueController(service);
@@ -271,19 +298,21 @@ void main() {
       expect(service.lastItems.map((i) => i.id).toList(), ['t1', 't2']);
     });
 
-    testWidgets('playlist vide : « Lire en aléatoire » est neutralisé',
-        (tester) async {
+    testWidgets('playlist vide : « Lire en aléatoire » est neutralisé', (
+      tester,
+    ) async {
       await tester.pumpWidget(_harness(_FakePlaylistRepository()));
       await tester.pumpAndSettle();
 
-      final button = tester.widget<IconButton>(
+      final button = tester.widget<AccessibleIconButton>(
         find.byKey(const Key('playlist_shuffle_play_button')),
       );
       expect(button.onPressed, isNull);
     });
 
-    testWidgets('playlist vide : message dédié + appel à l\'action',
-        (tester) async {
+    testWidgets('playlist vide : message dédié + appel à l\'action', (
+      tester,
+    ) async {
       await tester.pumpWidget(_harness(_FakePlaylistRepository()));
       await tester.pumpAndSettle();
 
@@ -296,24 +325,24 @@ void main() {
       expect(find.byKey(const Key('track_picker_empty')), findsOneWidget);
     });
 
-    testWidgets('une seule poignée de drag par ligne, y compris sur desktop',
-        (tester) async {
+    testWidgets('une seule poignée de drag par ligne, y compris sur desktop', (
+      tester,
+    ) async {
       // Plateforme desktop forcée : c'est là que ReorderableListView ajoute sa
       // propre poignée. Sans `buildDefaultDragHandles: false`, elle s'empile sur
       // celle de la ligne et le test voit deux icônes.
       final repo = _FakePlaylistRepository(
         initial: [_track('t1', 'Midnight Drive', 0)],
       );
-      await tester.pumpWidget(
-        _harness(repo, platform: TargetPlatform.macOS),
-      );
+      await tester.pumpWidget(_harness(repo, platform: TargetPlatform.macOS));
       await tester.pumpAndSettle();
 
       expect(find.byIcon(Icons.drag_handle), findsOneWidget);
     });
 
-    testWidgets('échec d\'un pull-to-refresh sur liste non vide : toast',
-        (tester) async {
+    testWidgets('échec d\'un pull-to-refresh sur liste non vide : toast', (
+      tester,
+    ) async {
       final repo = _FakePlaylistRepository(
         initial: [_track('t1', 'Midnight Drive', 0)],
       );
@@ -337,7 +366,10 @@ void main() {
 
     testWidgets('le drag-and-drop persiste le nouvel ordre', (tester) async {
       final repo = _FakePlaylistRepository(
-        initial: [_track('t1', 'Midnight Drive', 0), _track('t2', 'Sunrise', 1)],
+        initial: [
+          _track('t1', 'Midnight Drive', 0),
+          _track('t2', 'Sunrise', 1),
+        ],
       );
       await tester.pumpWidget(_harness(repo));
       await tester.pumpAndSettle();
@@ -351,7 +383,10 @@ void main() {
 
     testWidgets('échec du réordonnancement : toast d\'erreur', (tester) async {
       final repo = _FakePlaylistRepository(
-        initial: [_track('t1', 'Midnight Drive', 0), _track('t2', 'Sunrise', 1)],
+        initial: [
+          _track('t1', 'Midnight Drive', 0),
+          _track('t2', 'Sunrise', 1),
+        ],
       )..reorderError = const ConflictException('La playlist a changé');
       await tester.pumpWidget(_harness(repo));
       await tester.pumpAndSettle();
@@ -362,10 +397,14 @@ void main() {
       await _dismissToasts(tester);
     });
 
-    testWidgets('retirer une piste demande confirmation puis retire',
-        (tester) async {
+    testWidgets('retirer une piste demande confirmation puis retire', (
+      tester,
+    ) async {
       final repo = _FakePlaylistRepository(
-        initial: [_track('t1', 'Midnight Drive', 0), _track('t2', 'Sunrise', 1)],
+        initial: [
+          _track('t1', 'Midnight Drive', 0),
+          _track('t2', 'Sunrise', 1),
+        ],
       );
       await tester.pumpWidget(_harness(repo));
       await tester.pumpAndSettle();
@@ -374,8 +413,10 @@ void main() {
       await tester.pumpAndSettle();
 
       // Rien n'est retiré tant que la confirmation n'est pas donnée.
-      expect(find.text('Retirer « Midnight Drive » de la playlist ?'),
-          findsOneWidget);
+      expect(
+        find.text('Retirer « Midnight Drive » de la playlist ?'),
+        findsOneWidget,
+      );
       expect(repo.removeCalls, 0);
 
       await tester.tap(find.byKey(const Key('playlist_track_confirm_remove')));
@@ -388,7 +429,10 @@ void main() {
 
     testWidgets('annuler la confirmation ne retire rien', (tester) async {
       final repo = _FakePlaylistRepository(
-        initial: [_track('t1', 'Midnight Drive', 0), _track('t2', 'Sunrise', 1)],
+        initial: [
+          _track('t1', 'Midnight Drive', 0),
+          _track('t2', 'Sunrise', 1),
+        ],
       );
       await tester.pumpWidget(_harness(repo));
       await tester.pumpAndSettle();
@@ -402,14 +446,20 @@ void main() {
       expect(find.text('Midnight Drive'), findsOneWidget);
     });
 
-    testWidgets('le sélecteur n\'affiche que les pistes absentes',
-        (tester) async {
-      final repo = _FakePlaylistRepository(
-        initial: [_track('t1', 'Midnight Drive', 0)],
-      )..library = const [
-          Track(id: 't1', title: 'Midnight Drive', artist: null, durationS: null),
-          Track(id: 't2', title: 'Sunrise', artist: null, durationS: null),
-        ];
+    testWidgets('le sélecteur n\'affiche que les pistes absentes', (
+      tester,
+    ) async {
+      final repo =
+          _FakePlaylistRepository(initial: [_track('t1', 'Midnight Drive', 0)])
+            ..library = const [
+              Track(
+                id: 't1',
+                title: 'Midnight Drive',
+                artist: null,
+                durationS: null,
+              ),
+              Track(id: 't2', title: 'Sunrise', artist: null, durationS: null),
+            ];
       await tester.pumpWidget(_harness(repo));
       await tester.pumpAndSettle();
 

--- a/mobile/test/features/playlists/presentation/widgets/queue_accessibility_test.dart
+++ b/mobile/test/features/playlists/presentation/widgets/queue_accessibility_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:just_audio/just_audio.dart' show PlayerState, ProcessingState;
+import 'package:provider/provider.dart';
+import 'package:streampulse/features/playlists/domain/entities/track.dart';
+import 'package:streampulse/features/playlists/presentation/providers/playlist_queue_controller.dart';
+import 'package:streampulse/features/playlists/presentation/widgets/queue_mini_player.dart';
+
+import '../../../../support/accessibility.dart';
+import '../../../../support/fake_queue_playback_service.dart';
+
+/// Les contrôles du lecteur sont la surface la plus utilisée de l'application,
+/// et la plus dépendante d'icônes sans texte : c'est là qu'un défaut
+/// d'accessibilité coûte le plus (STR-246).
+void main() {
+  testWidgets(
+    'le bandeau de file d\'attente est utilisable au lecteur d\'écran',
+    (tester) async {
+      final handle = tester.ensureSemantics();
+      final service = FakeQueuePlaybackService();
+      final controller = PlaylistQueueController(
+        service: service,
+        token: ({bool forceRefresh = false}) async => 'jwt',
+      );
+      addTearDown(controller.dispose);
+      addTearDown(service.dispose);
+
+      await controller.play(
+        tracks: [
+          const Track(
+            id: 't1',
+            title: 'Midnight Drive',
+            artist: 'Neon Lights',
+            durationS: 214,
+          ),
+          const Track(
+            id: 't2',
+            title: 'Sunrise',
+            artist: 'Neon Lights',
+            durationS: 198,
+          ),
+        ],
+        sourceName: 'My Favorites',
+        playlistId: 'p-1',
+      );
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider<PlaylistQueueController>.value(
+          value: controller,
+          child: const MaterialApp(home: Scaffold(body: QueueMiniPlayer())),
+        ),
+      );
+      service.emitState(PlayerState(true, ProcessingState.ready));
+      await tester.pump();
+
+      await expectMeetsAccessibilityGuidelines(tester);
+      // Plus strict que la garde de Flutter : un tooltip seul laisserait ces
+      // boutons anonymes pour VoiceOver.
+      expectNoTooltipOnlyTapTargets(tester);
+
+      // Les libellés disent l'ACTION, pas l'icône ni l'état.
+      expect(find.bySemanticsLabel('Piste précédente'), findsOneWidget);
+      expect(find.bySemanticsLabel('Piste suivante'), findsOneWidget);
+      expect(find.bySemanticsLabel('Arrêter la lecture'), findsOneWidget);
+      expect(find.bySemanticsLabel('Mettre en pause'), findsOneWidget);
+
+      handle.dispose();
+    },
+  );
+
+  testWidgets('le bouton de lecture annonce l\'action, pas l\'état courant', (
+    tester,
+  ) async {
+    final handle = tester.ensureSemantics();
+    final service = FakeQueuePlaybackService();
+    final controller = PlaylistQueueController(
+      service: service,
+      token: ({bool forceRefresh = false}) async => 'jwt',
+    );
+    addTearDown(controller.dispose);
+    addTearDown(service.dispose);
+
+    await controller.play(
+      tracks: [
+        const Track(
+          id: 't1',
+          title: 'Midnight Drive',
+          artist: null,
+          durationS: null,
+        ),
+      ],
+      sourceName: 'My Favorites',
+      playlistId: 'p-1',
+    );
+    await tester.pumpWidget(
+      ChangeNotifierProvider<PlaylistQueueController>.value(
+        value: controller,
+        child: const MaterialApp(home: Scaffold(body: QueueMiniPlayer())),
+      ),
+    );
+
+    service.emitState(PlayerState(false, ProcessingState.ready));
+    await tester.pump();
+    // À l'arrêt, l'appui LANCE la lecture : annoncer « Pause » ici — ce que
+    // faisait le tooltip d'origine — dit exactement l'inverse de ce qui va
+    // se produire.
+    expect(find.bySemanticsLabel('Lire'), findsOneWidget);
+
+    service.emitState(PlayerState(true, ProcessingState.ready));
+    await tester.pump();
+    expect(find.bySemanticsLabel('Mettre en pause'), findsOneWidget);
+
+    handle.dispose();
+  });
+}

--- a/mobile/test/features/playlists/presentation/widgets/queue_accessibility_test.dart
+++ b/mobile/test/features/playlists/presentation/widgets/queue_accessibility_test.dart
@@ -11,7 +11,7 @@ import '../../../../support/fake_queue_playback_service.dart';
 
 /// Les contrôles du lecteur sont la surface la plus utilisée de l'application,
 /// et la plus dépendante d'icônes sans texte : c'est là qu'un défaut
-/// d'accessibilité coûte le plus (STR-246).
+/// d'accessibilité coûte le plus (STR-244).
 void main() {
   testWidgets(
     'le bandeau de file d\'attente est utilisable au lecteur d\'écran',

--- a/mobile/test/features/playlists/presentation/widgets/queue_ui_test.dart
+++ b/mobile/test/features/playlists/presentation/widgets/queue_ui_test.dart
@@ -8,13 +8,10 @@ import 'package:streampulse/features/playlists/presentation/providers/playlist_q
 import 'package:streampulse/features/playlists/presentation/widgets/queue_mini_player.dart';
 
 import '../../../../support/fake_queue_playback_service.dart';
+import 'package:streampulse/core/widgets/accessible_icon_button.dart';
 
-Track _track(String id, String title) => Track(
-      id: id,
-      title: title,
-      artist: 'Neon Lights',
-      durationS: 214,
-    );
+Track _track(String id, String title) =>
+    Track(id: id, title: title, artist: 'Neon Lights', durationS: 214);
 
 final _tracks = [
   _track('t1', 'Midnight Drive'),
@@ -34,15 +31,8 @@ Widget _host(PlaylistQueueController controller, Widget child) {
 /// L'ordre compte : le widget est monté **avant** l'émission de l'état du
 /// lecteur, car sous `testWidgets` seule une `pump` fait avancer la boucle
 /// d'événements (le temps y est simulé).
-Future<
-    ({
-      PlaylistQueueController controller,
-      FakeQueuePlaybackService service,
-    })> _pumpPlaying(
-  WidgetTester tester,
-  Widget child, {
-  int startIndex = 0,
-}) async {
+Future<({PlaylistQueueController controller, FakeQueuePlaybackService service})>
+_pumpPlaying(WidgetTester tester, Widget child, {int startIndex = 0}) async {
   final service = FakeQueuePlaybackService();
   final controller = PlaylistQueueController(
     service: service,
@@ -85,8 +75,9 @@ void main() {
       expect(find.byKey(const Key('queue_mini_player')), findsNothing);
     });
 
-    testWidgets('affiche la piste en cours et sa position dans la file',
-        (tester) async {
+    testWidgets('affiche la piste en cours et sa position dans la file', (
+      tester,
+    ) async {
       await _pumpPlaying(tester, const QueueMiniPlayer());
 
       expect(find.text('Midnight Drive'), findsOneWidget);
@@ -98,7 +89,7 @@ void main() {
       final t = await _pumpPlaying(tester, const QueueMiniPlayer());
 
       // Sur la première piste, « précédent » n'a rien à faire.
-      final previous = tester.widget<IconButton>(
+      final previous = tester.widget<AccessibleIconButton>(
         find.byKey(const Key('queue_mini_previous')),
       );
       expect(previous.onPressed, isNull);
@@ -120,8 +111,9 @@ void main() {
       expect(find.byIcon(Icons.replay), findsOneWidget);
     });
 
-    testWidgets('la croix arrête la lecture et masque la barre',
-        (tester) async {
+    testWidgets('la croix arrête la lecture et masque la barre', (
+      tester,
+    ) async {
       final t = await _pumpPlaying(tester, const QueueMiniPlayer());
 
       await tester.tap(find.byKey(const Key('queue_mini_stop')));
@@ -133,8 +125,9 @@ void main() {
   });
 
   group('PlaybackQueueSheet (US-05-04)', () {
-    testWidgets('liste la file entière et marque la piste en cours',
-        (tester) async {
+    testWidgets('liste la file entière et marque la piste en cours', (
+      tester,
+    ) async {
       await _pumpPlaying(tester, const QueueMiniPlayer(), startIndex: 1);
       await _openQueueSheet(tester);
 
@@ -158,26 +151,29 @@ void main() {
       expect(t.controller.currentIndex, 2);
     });
 
-    testWidgets('les modes de lecture sont réglables depuis la file (US-05-05)',
-        (tester) async {
-      final t = await _pumpPlaying(tester, const QueueMiniPlayer());
-      await _openQueueSheet(tester);
+    testWidgets(
+      'les modes de lecture sont réglables depuis la file (US-05-05)',
+      (tester) async {
+        final t = await _pumpPlaying(tester, const QueueMiniPlayer());
+        await _openQueueSheet(tester);
 
-      expect(find.byKey(const Key('queue_shuffle_button')), findsOneWidget);
-      expect(find.text('Répétition'), findsOneWidget);
+        expect(find.byKey(const Key('queue_shuffle_button')), findsOneWidget);
+        expect(find.text('Répétition'), findsOneWidget);
 
-      await tester.tap(find.byKey(const Key('queue_repeat_button')));
-      await tester.pumpAndSettle();
-      expect(find.text('Répéter la file'), findsOneWidget);
-      expect(t.service.repeatMode, QueueRepeatMode.all);
+        await tester.tap(find.byKey(const Key('queue_repeat_button')));
+        await tester.pumpAndSettle();
+        expect(find.text('Répéter la file'), findsOneWidget);
+        expect(t.service.repeatMode, QueueRepeatMode.all);
 
-      await tester.tap(find.byKey(const Key('queue_repeat_button')));
-      await tester.pumpAndSettle();
-      expect(find.text('Répéter la piste'), findsOneWidget);
-    });
+        await tester.tap(find.byKey(const Key('queue_repeat_button')));
+        await tester.pumpAndSettle();
+        expect(find.text('Répéter la piste'), findsOneWidget);
+      },
+    );
 
-    testWidgets('en aléatoire, la file affiche l\'ordre réellement joué',
-        (tester) async {
+    testWidgets('en aléatoire, la file affiche l\'ordre réellement joué', (
+      tester,
+    ) async {
       final t = await _pumpPlaying(tester, const QueueMiniPlayer());
       // Le lecteur jouera t2, t3, t1.
       t.service.shuffledOrder = [1, 2, 0];
@@ -195,8 +191,9 @@ void main() {
       expect(t.controller.positionInOrder, 2);
     });
 
-    testWidgets('la barre affiche l\'avancement de la piste (STR-230)',
-        (tester) async {
+    testWidgets('la barre affiche l\'avancement de la piste (STR-230)', (
+      tester,
+    ) async {
       final t = await _pumpPlaying(tester, const QueueMiniPlayer());
       await _openQueueSheet(tester);
 
@@ -216,8 +213,9 @@ void main() {
       expect(slider.max, 200000);
     });
 
-    testWidgets('glisser la barre déplace la lecture (STR-230)',
-        (tester) async {
+    testWidgets('glisser la barre déplace la lecture (STR-230)', (
+      tester,
+    ) async {
       final t = await _pumpPlaying(tester, const QueueMiniPlayer());
       await _openQueueSheet(tester);
       t.service.emitDuration(const Duration(seconds: 200));
@@ -239,8 +237,9 @@ void main() {
       );
     });
 
-    testWidgets('durée inconnue : barre neutralisée plutôt que fausse',
-        (tester) async {
+    testWidgets('durée inconnue : barre neutralisée plutôt que fausse', (
+      tester,
+    ) async {
       final t = await _pumpPlaying(tester, const QueueMiniPlayer());
       await _openQueueSheet(tester);
 
@@ -258,8 +257,9 @@ void main() {
       expect(slider.max, 214000);
     });
 
-    testWidgets('file terminée : la poignée est neutralisée (revue #292)',
-        (tester) async {
+    testWidgets('file terminée : la poignée est neutralisée (revue #292)', (
+      tester,
+    ) async {
       final t = await _pumpPlaying(tester, const QueueMiniPlayer());
       await _openQueueSheet(tester);
       t.service.emitDuration(const Duration(seconds: 200));
@@ -277,8 +277,9 @@ void main() {
       expect(slider.onChanged, isNull);
     });
 
-    testWidgets('changement de piste : pas de durée périmée (revue #292)',
-        (tester) async {
+    testWidgets('changement de piste : pas de durée périmée (revue #292)', (
+      tester,
+    ) async {
       final t = await _pumpPlaying(tester, const QueueMiniPlayer());
       await _openQueueSheet(tester);
       t.service.emitDuration(const Duration(seconds: 200));

--- a/mobile/test/support/accessibility.dart
+++ b/mobile/test/support/accessibility.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-/// Vérifications d'accessibilité partagées (STR-246).
+/// Vérifications d'accessibilité partagées (STR-244).
 ///
 /// `flutter_test` embarque des vérificateurs conformes aux recommandations des
 /// deux plateformes. Les faire tourner en CI vaut mieux qu'une affirmation de

--- a/mobile/test/support/accessibility.dart
+++ b/mobile/test/support/accessibility.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Vérifications d'accessibilité partagées (STR-246).
+///
+/// `flutter_test` embarque des vérificateurs conformes aux recommandations des
+/// deux plateformes. Les faire tourner en CI vaut mieux qu'une affirmation de
+/// conformité dans un document : ils échouent quand la règle est violée, y
+/// compris sur du code écrit plus tard.
+///
+/// Ce qu'ils couvrent :
+///
+/// - `androidTapTargetGuideline` / `iOSTapTargetGuideline` — taille minimale des
+///   zones tactiles (48 px / 44 px).
+/// - `labeledTapTargetGuideline` — tout élément tapable porte un texte.
+/// - `textContrastGuideline` — contraste texte/fond WCAG AA.
+///
+/// Ce qu'ils **ne** couvrent pas, et qui reste à vérifier autrement : l'ordre de
+/// parcours, la pertinence des libellés, et le comportement réel de TalkBack ou
+/// VoiceOver.
+Future<void> expectMeetsAccessibilityGuidelines(WidgetTester tester) async {
+  await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
+  await expectLater(tester, meetsGuideline(iOSTapTargetGuideline));
+  await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
+  await expectLater(tester, meetsGuideline(textContrastGuideline));
+}
+
+/// Relève les nœuds tapables dont le texte n'est porté que par un **tooltip**.
+///
+/// `labeledTapTargetGuideline` les accepte : un tooltip remplit le champ
+/// `tooltip` du nœud sémantique, et le vérificateur regarde label **ou**
+/// tooltip. Mais les deux champs ne se valent pas côté plateforme — sur iOS le
+/// tooltip devient un *hint*, pas un *label*, et VoiceOver annonce alors
+/// « bouton » sans nom.
+///
+/// Cette vérification est donc plus stricte que la garde de Flutter, à dessein.
+List<String> tapTargetsLabelledOnlyByTooltip(WidgetTester tester) {
+  final found = <String>[];
+
+  void walk(SemanticsNode node) {
+    final data = node.getSemanticsData();
+    final tappable = data.actions & SemanticsAction.tap.index != 0;
+    if (tappable && data.label.isEmpty && data.tooltip.isNotEmpty) {
+      found.add(data.tooltip);
+    }
+    node.visitChildren((child) {
+      walk(child);
+      return true;
+    });
+  }
+
+  // L'arbre sémantique ne vit pas sur le PipelineOwner racine mais sur ses
+  // enfants (un par vue). Chercher seulement à la racine rendait une liste vide
+  // — donc « rien à signaler » — alors que rien n'avait été inspecté : un
+  // vérificateur qui ne trouve pas son sujet doit échouer, pas rassurer.
+  var inspected = 0;
+  void visitOwner(PipelineOwner owner) {
+    final root = owner.semanticsOwner?.rootSemanticsNode;
+    if (root != null) {
+      inspected++;
+      walk(root);
+    }
+    owner.visitChildren(visitOwner);
+  }
+
+  visitOwner(tester.binding.rootPipelineOwner);
+  if (inspected == 0) {
+    fail(
+      'aucun arbre sémantique trouvé — `tester.ensureSemantics()` a-t-il '
+      'bien été appelé avant de monter le widget ?',
+    );
+  }
+  return found;
+}
+
+/// Échoue si un élément tapable n'est nommé que par un tooltip.
+void expectNoTooltipOnlyTapTargets(WidgetTester tester) {
+  final offenders = tapTargetsLabelledOnlyByTooltip(tester);
+  expect(
+    offenders,
+    isEmpty,
+    reason:
+        'Ces éléments tapables n\'ont qu\'un tooltip, donc aucun nom pour '
+        'VoiceOver : ${offenders.join(', ')}. Utiliser AccessibleIconButton, '
+        'ou poser un Semantics(label:).',
+  );
+}


### PR DESCRIPTION
Ferme la **section B** de [STR-244](https://linear.app/streampulse/issue/STR-244) —
« UI/UX responsive (iOS/Android) et respect des standards d'accessibilité ».
La section A (volume, temps d'écoute) est la PR #329.

Décisions et alternatives écartées : [ADR 043](docs/adr/043-accessibilite-de-l-application-et-adaptation-aux-largeurs.md).

---

## Le ticket se trompait sur un point, et la nuance change le correctif

Il affirmait que les treize fichiers portant un `tooltip:` « ne comptent pas ».
J'ai mesuré plutôt que de le prendre pour acquis. Arbre sémantique d'un
`IconButton(tooltip: 'Mettre en pause')` :

```
label="" tooltip="Mettre en pause" button=true
```

Le texte **est** exposé — dans le champ `tooltip`, pas `label` :

| | Ce que devient le tooltip | Effet |
|---|---|---|
| **Android** | `AccessibilityNodeInfo.tooltipText` | TalkBack s'en sert à défaut de description : le bouton est utilisable |
| **iOS** | un *hint*, pas un *label* | VoiceOver annonce « bouton » **sans nom** |

Donc : défaut réel, mais **iOS seulement**, et il se corrige en *ajoutant* un
label — pas en remplaçant les tooltips, qui servent toujours à l'appui long.

Le vrai coupable était ailleurs : le **contrôle principal** de l'écran de direct
était un `InkWell` nu. Aucun nom, aucun rôle, rien.

Et le libellé du bouton de lecture disait **« Pause » alors que la lecture était
à l'arrêt** — un lecteur d'écran annonçait l'inverse de ce que l'appui allait
faire. Les libellés décrivent maintenant l'action, pas l'icône ni l'état.

---

## La garde qui s'est attrapée elle-même

`flutter_test` embarque quatre vérificateurs WCAG. J'y ajoute
`expectNoTooltipOnlyTapTargets`, **plus stricte** que celle de Flutter :
`labeledTapTargetGuideline` accepte un tooltip seul, soit exactement le cas
ci-dessus.

J'ai écrit avec elle un **test de contrôle** : un `IconButton` nu doit être
signalé. Il a servi tout de suite — ma première version cherchait l'arbre
sémantique sur le mauvais `PipelineOwner`, n'en trouvait aucun, et rendait
sereinement une liste vide. Elle aurait donc validé n'importe quoi.

Un vérificateur qui ne trouve pas son sujet échoue désormais bruyamment.

---

## Une ligne de liste se lit d'un coup, ou pas du tout

Une ligne de playlist montre un numéro, un titre, un artiste, et un point coloré
pour la piste en cours. Un lecteur d'écran parcourt ces fragments un par un — et
ne voit pas le point : « 3 », arrêt, « Sunrise », arrêt, « Neon Lights, 3:34 ».
Jamais l'information qui compte.

Le conteneur porte la phrase entière et masque ses enfants :

> « Piste 3, Sunrise, Neon Lights, en cours de lecture »

Même logique pour les boutons d'une liste : dix boutons « Interrompre » qui se
suivent ne disent pas lequel on a sous le doigt.

---

## Responsive : trancher, comme demandé

Le paysage **est autorisé** par les deux manifestes, mais l'interface était figée
en une colonne : pivoter donnait un portrait étiré, une ligne de trois mots
traversant 800 px.

**J'ai choisi d'adapter plutôt que de verrouiller le portrait.** Verrouiller
était honnête et tenait en deux lignes de configuration, mais retire une
capacité offerte par les deux systèmes — quelqu'un qui fixe son téléphone sur un
support de vélo n'a pas le choix de l'orientation.

`ResponsiveContent` **n'a aucun effet en portrait téléphone** : la contrainte n'y
mord pas. C'est délibéré — une adaptation qui modifie le cas nominal pour
soigner un cas rare est une régression déguisée. Les ruptures sont celles de
Material 3, pour ne pas avoir à défendre des valeurs inventées.

---

## Ce qui n'est PAS fait, et que je ne présente pas autrement

**Aucune vérification à TalkBack ou VoiceOver réels.** Ça demande un appareil.
Les gardes automatiques couvrent la taille des cibles, la présence des libellés
et le contraste ; elles ne couvrent **ni l'ordre de parcours, ni la pertinence
des libellés, ni le comportement réel des lecteurs d'écran**.

L'ADR le dit, et [docs/accessibilite.md](docs/accessibilite.md) — qui excluait
explicitement l'application de son périmètre — pointe désormais vers ce travail
en répétant qu'**aucune conformité n'est déclarée**.

Autres limites assumées : couverture partielle (les surfaces nommées par le
ticket, pas auth ni profil), et `Breakpoints.columnsFor` existe mais n'est encore
appliqué nulle part.

---

## Vérifications

```
flutter analyze   No issues found
flutter test      459 tests (444 avant, +15)
liens docs        297 relatifs, 0 cassé
make check-adr-index   40 ADR, toutes résumées
```

---

## Deux notes de revue

**Deux tests existants castaient en `IconButton`** et cassaient sur
`AccessibleIconButton`. Mis à jour plutôt que contournés.

**Le diff ne contient pas de réalignement.** `dart format` réécrit des lignes
non touchées avec la version courante du formateur — j'ai vu une modification de
7 lignes en produire 29, et introduire un lint au passage. J'ai annulé et
réappliqué à la main. C'est noté dans `CLAUDE.md` : ne formater que les fichiers
qu'on crée.

**Recouvrement avec #329** : les deux touchent `stream_player_screen.dart`.
Conflit attendu sur trois hunks, que je résous dès que l'une des deux est
fusionnée.
