### PR TITLE
fix(ci): corriger la configuration Flutter du job CD Android

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -190,8 +190,9 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version-file: mobile/pubspec.yaml
-          cache: true
+            flutter-version: "3.41.9"
+            channel: stable
+            cache: true
 
       - uses: actions/setup-java@v5
         with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -190,9 +190,9 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-            flutter-version: "3.41.9"
-            channel: stable
-            cache: true
+          flutter-version: "3.41.9"
+          channel: stable
+          cache: true
 
       - uses: actions/setup-java@v5
         with:


### PR DESCRIPTION
## Contexte

Le job **Build mobile (Android)** de la CD échouait à l'étape de setup Flutter ([run](https://github.com/LignacAntony/streampulse/actions/runs/32728466101/job/97435277492)) :

\`\`\`
Unable to determine Flutter version for channel: stable version: >=3.27.0
\`\`\`

## Cause

Le CD utilisait \`flutter-version-file: mobile/pubspec.yaml\`. \`subosito/flutter-action\` lit alors la contrainte \`flutter: '>=3.27.0'\` du pubspec, qui est une **plage** et non une version résolvable → l'action échoue avant toute compilation.

## Correctif

Alignement du CD sur la CI (qui passe déjà) : version Flutter épinglée \`3.41.9\` + \`channel: stable\`, au lieu du fichier de version.

## Note

La version Flutter est désormais dupliquée entre \`ci.yml\` et \`cd.yml\`. Un futur bump devra toucher les deux fichiers.