### PR TITLE
feat(api,mobile): distinguer les deux 409 du manifeste HLS (STR-229)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -454,10 +454,15 @@ Voir [ADR 023](docs/adr/023-lecteur-audio-hls-mobile.md) (lecteur HLS),
 - **Répartition** : le handler mappe l'état → notification et **transmet** les erreurs ; le
   contrôleur garde l'arbitrage STR-118 (reconnexion bornée 1/2/4/8 s, gardes `_disposed`/`ended`).
   État terminal → `stop()` retire la notification.
-- **Ambiguïté du 409** : le manifeste renvoie 409 pour un flux **terminé** *comme* pour un flux live
-  **pas encore prêt** (démarrage ~10 s). Le contrôleur ne conclut « terminé » via
-  `isManifestUnavailable` que si la lecture avait démarré (`_hasPlayed`) ; sinon il reconnecte
-  d'abord. La sonde utilise `validateStatus` (<500) pour ne pas logger de faux « erreur ».
+- **Les deux 409 du manifeste (STR-229, ADR 045)** : `stream_not_live` (plus de session — définitif)
+  et `manifest_not_ready` (session vivante, premier segment pas encore écrit — transitoire) portent
+  le même statut mais des conduites opposées. `manifestStatus` rend un `ManifestStatus`, le
+  contrôleur applique ce verdict → un direct terminé s'annonce **immédiatement** au lieu des ~15 s
+  de reconnexions qu'imposait l'ancien flag `_hasPlayed`. ⚠️ Un 409 au code inconnu retombe sur
+  `notReady` : se tromper vers l'attente coûte un backoff borné, se tromper vers la fin couperait un
+  direct qui démarre. ⚠️ La sonde n'utilise **pas** le client généré — `streamPlaylist` est typé
+  `Response<String>` et stringifie le corps d'erreur JSON à la Dart (illisible par `jsonDecode`) ;
+  elle passe par le `Dio` sous-jacent, **même instance**, donc mêmes intercepteurs.
 - **Mini-player** : `MiniPlayer` (titre/diffuseur, play/pause, croix = `stop`) est masqué à l'état
   `idle`. Le plein écran (`StreamPlayerScreen`) lit aussi ce contrôleur partagé et **ne le détruit
   pas**. Dans `MainShell`, c'est `PlayerBar` (`app/shell/`) qui choisit entre ce mini-player et
@@ -800,7 +805,7 @@ xcrun simctl openurl booted \
 | `docs/architecture.md` | Schéma ASCII, composants, flux requête et observabilité, choix techniques |
 | `docs/infrastructure.md` | Services Docker, variables d'env, procédures, troubleshooting |
 | `docs/performance-mobile.md` | Preuves de fluidité 60 FPS : garde de reconstruction (CI) + relevé de trames sur appareil (STR-243) |
-| `docs/README.md` (§ Index complet des ADR) | **Les 40 ADR**, avec leur numéro et leur décision |
+| `docs/README.md` (§ Index complet des ADR) | **Les 45 ADR**, avec leur numéro et leur décision |
 | `docs/adr/001-choix-stack-observabilite.md` | Décision : stack LGTM vs ELK, Datadog, New Relic |
 | `docs/adr/002-choix-conteneurisation-docker.md` | Décision : Docker Compose vs Podman, Nix, K8s local |
 | `docs/adr/003-choix-cicd-github-actions.md` | Décision : GitHub Actions + GHCR vs GitLab CI, Jenkins, CircleCI |
@@ -811,7 +816,7 @@ xcrun simctl openurl booted \
 | `docs/adr/037-initialisation-base-de-donnees.md` | Décision : schéma, migrations et seed PostgreSQL |
 
 **Règle :** toute nouvelle décision d'architecture significative → nouvel ADR dans `docs/adr/`
-avec le numéro suivant (prochain : `045-...`). Référencer le ticket Linear correspondant.
+avec le numéro suivant (prochain : `046-...`). Référencer le ticket Linear correspondant.
 Un numéro n'est **jamais** réutilisé, et une ADR remplacée passe en `Superseded by NNN` plutôt
 que d'être réécrite. Chaque ADR porte un bloc **Date / Statut / Ticket** et une section
 **« Alternatives écartées »**.

--- a/backend/internal/openapi/openapi.yaml
+++ b/backend/internal/openapi/openapi.yaml
@@ -1247,12 +1247,38 @@ paths:
           $ref: "#/components/responses/NotFound"
         "409":
           description: >-
-            The stream is not live, or its manifest is not ready yet (window
-            between start and the first segment).
+            The manifest cannot be served. The `error.code` field tells the two
+            causes apart, and they call for opposite client behaviour:
+
+
+            - `stream_not_live` — no live session for this stream. The broadcast
+              is over, or never started. Final: retrying will not help.
+
+            - `manifest_not_ready` — the session is live but the first segment
+              has not been written yet (window between start and the first
+              segment, about one segment duration). Transient: retry.
+
+
+            A client that cannot tell them apart has to guess, and guessing
+            "over" during the start-up window wrongly ends playback. Treat any
+            unrecognised code as transient.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+              examples:
+                streamNotLive:
+                  summary: Broadcast is over (final)
+                  value:
+                    error:
+                      code: stream_not_live
+                      message: stream is not live
+                manifestNotReady:
+                  summary: Starting up, retry (transient)
+                  value:
+                    error:
+                      code: manifest_not_ready
+                      message: stream manifest is not ready yet
         "503":
           description: >-
             Server at listener capacity (HLS_MAX_CONCURRENT concurrent requests

--- a/backend/internal/streaming/handler.go
+++ b/backend/internal/streaming/handler.go
@@ -78,8 +78,8 @@ type StreamService interface {
 type StreamSessions interface {
 	Subscribe(streamID string) (<-chan SessionEvent, func())
 	AttachIngest(streamKey string) (io.Writer, func(), error)
-	Playlist(streamID string) (string, bool)
-	Segment(streamID, name string) (string, bool)
+	Playlist(streamID string) (string, hlsAvailability)
+	Segment(streamID, name string) (string, hlsAvailability)
 	TouchListener(streamID, clientKey string)
 	Stats(streamID string) (SessionStats, bool)
 }
@@ -879,7 +879,7 @@ const (
 // (`manifest_not_ready`) — cf. STR-229 pour la distinction.
 func (h *Handler) Playlist(w http.ResponseWriter, r *http.Request) {
 	h.serveHLSFile(w, r, HLSKindPlaylist, "application/vnd.apple.mpegurl",
-		func(id string) (string, bool) { return h.sessions.Playlist(id) },
+		func(id string) (string, hlsAvailability) { return h.sessions.Playlist(id) },
 		apperror.Conflict("stream is not live").Coded(CodeStreamNotLive),
 		apperror.Conflict("stream manifest is not ready yet").Coded(CodeManifestNotReady))
 }
@@ -895,7 +895,9 @@ func (h *Handler) Segment(w http.ResponseWriter, r *http.Request) {
 	// distinction (STR-229).
 	notFound := apperror.NotFound("segment not found")
 	h.serveHLSFile(w, r, HLSKindSegment, "video/mp2t",
-		func(id string) (string, bool) { return h.sessions.Segment(id, r.PathValue("segment")) },
+		func(id string) (string, hlsAvailability) {
+			return h.sessions.Segment(id, r.PathValue("segment"))
+		},
 		notFound, notFound)
 }
 
@@ -903,16 +905,15 @@ func (h *Handler) Segment(w http.ResponseWriter, r *http.Request) {
 // auditeur : contrôle de visibilité (GetStream, 404 si absent/privé), lookup de la
 // session, en-têtes puis ServeFile. lookup renvoie le chemin disque et sa validité.
 //
-// Deux erreurs distinctes, et non une seule (STR-229) : `notLive` quand aucune
-// session n'existe, `notReady` quand elle existe mais que le fichier n'est pas
-// encore sur le disque. L'appelant décide si la nuance l'intéresse — le manifeste
-// oui, le segment non.
+// Deux erreurs distinctes, et non une seule (STR-229) : `notLive` quand il n'y a
+// rien à attendre, `notReady` quand le flux démarre encore. L'appelant décide si
+// la nuance l'intéresse — le manifeste oui, le segment non.
 //
 // Lecture PUBLIQUE (STR-108) : pas d'authentification requise — le player natif
 // (just_audio → AVPlayer/ExoPlayer) ne peut pas porter le Bearer. Un auditeur
 // anonyme a requesterID = "" ; la visibilité de GetStream sert alors les flux
 // publics et renvoie 404 pour un flux privé (jamais propriétaire de "").
-func (h *Handler) serveHLSFile(w http.ResponseWriter, r *http.Request, kind, contentType string, lookup func(id string) (string, bool), notLive, notReady error) {
+func (h *Handler) serveHLSFile(w http.ResponseWriter, r *http.Request, kind, contentType string, lookup func(id string) (string, hlsAvailability), notLive, notReady error) {
 	requesterID, _ := auth.UserIDFromContext(r.Context()) // "" si anonyme (pas de JWT)
 	id := r.PathValue("id")
 
@@ -921,9 +922,16 @@ func (h *Handler) serveHLSFile(w http.ResponseWriter, r *http.Request, kind, con
 		return
 	}
 
-	path, ok := lookup(id)
-	if !ok {
+	// Le registre distingue « plus rien à attendre » de « pas encore démarré » :
+	// `Start` inscrit la session avant de forker ffmpeg, et un flux déjà annoncé
+	// « en direct » est ouvrable pendant ce laps (revue PR #358).
+	path, avail := lookup(id)
+	switch avail {
+	case hlsUnavailable:
 		httpjson.WriteError(w, r, notLive)
+		return
+	case hlsPending:
+		httpjson.WriteError(w, r, notReady)
 		return
 	}
 

--- a/backend/internal/streaming/handler.go
+++ b/backend/internal/streaming/handler.go
@@ -857,34 +857,62 @@ func ingestError(err error) error {
 	}
 }
 
+// Codes publics du 409 sur le manifeste HLS (STR-229). Le statut ne suffit pas :
+// « le direct est fini » et « le direct démarre, patiente » se ressemblent de
+// l'extérieur alors que le serveur, lui, les distingue — session absente d'un
+// côté, présente mais sans manifeste écrit de l'autre. Sans ces codes le lecteur
+// devait deviner, et une liste Découvrir périmée coûtait ~15 s de « Reconnexion… »
+// avant d'annoncer une fin de direct déjà connue du serveur.
+const (
+	// CodeStreamNotLive : aucune session live pour ce flux — direct terminé, ou
+	// jamais démarré. Verdict définitif, rien à attendre.
+	CodeStreamNotLive = "stream_not_live"
+	// CodeManifestNotReady : session vivante, manifeste pas encore écrit — la
+	// fenêtre entre le start et le premier segment (~10 s, taille de segment
+	// HLS). État transitoire : réessayer a du sens.
+	CodeManifestNotReady = "manifest_not_ready"
+)
+
 // Playlist gère GET /api/streams/{id}/playlist.m3u8 : sert le manifeste HLS d'un
 // flux public (lecture publique, cf. serveHLSFile). 409 si le flux n'est pas en
-// direct ou si le manifeste n'est pas encore prêt.
+// direct (`stream_not_live`) ou si son manifeste n'est pas encore prêt
+// (`manifest_not_ready`) — cf. STR-229 pour la distinction.
 func (h *Handler) Playlist(w http.ResponseWriter, r *http.Request) {
 	h.serveHLSFile(w, r, HLSKindPlaylist, "application/vnd.apple.mpegurl",
 		func(id string) (string, bool) { return h.sessions.Playlist(id) },
-		apperror.Conflict("stream is not live"))
+		apperror.Conflict("stream is not live").Coded(CodeStreamNotLive),
+		apperror.Conflict("stream manifest is not ready yet").Coded(CodeManifestNotReady))
 }
 
 // Segment gère GET /api/streams/{id}/segments/{segment} : sert un segment .ts d'un
 // flux public (lecture publique, cf. serveHLSFile). Le nom du segment est validé
 // (anti path-traversal) dans la couche session ; nom invalide ou segment absent -> 404.
 func (h *Handler) Segment(w http.ResponseWriter, r *http.Request) {
+	// Les deux causes d'indisponibilité d'un segment (flux éteint, ou segment
+	// sorti de la fenêtre glissante) reçoivent volontairement la même réponse :
+	// le lecteur n'en fait rien de différent, il redemande le manifeste — et
+	// c'est *lui* qui portera le verdict. Seul le manifeste a besoin de la
+	// distinction (STR-229).
+	notFound := apperror.NotFound("segment not found")
 	h.serveHLSFile(w, r, HLSKindSegment, "video/mp2t",
 		func(id string) (string, bool) { return h.sessions.Segment(id, r.PathValue("segment")) },
-		apperror.NotFound("segment not found"))
+		notFound, notFound)
 }
 
 // serveHLSFile factorise le service d'un fichier HLS (manifeste ou segment) à un
 // auditeur : contrôle de visibilité (GetStream, 404 si absent/privé), lookup de la
-// session (unavailable si le flux n'est pas en direct), en-têtes puis ServeFile.
-// lookup renvoie le chemin disque et sa validité.
+// session, en-têtes puis ServeFile. lookup renvoie le chemin disque et sa validité.
+//
+// Deux erreurs distinctes, et non une seule (STR-229) : `notLive` quand aucune
+// session n'existe, `notReady` quand elle existe mais que le fichier n'est pas
+// encore sur le disque. L'appelant décide si la nuance l'intéresse — le manifeste
+// oui, le segment non.
 //
 // Lecture PUBLIQUE (STR-108) : pas d'authentification requise — le player natif
 // (just_audio → AVPlayer/ExoPlayer) ne peut pas porter le Bearer. Un auditeur
 // anonyme a requesterID = "" ; la visibilité de GetStream sert alors les flux
 // publics et renvoie 404 pour un flux privé (jamais propriétaire de "").
-func (h *Handler) serveHLSFile(w http.ResponseWriter, r *http.Request, kind, contentType string, lookup func(id string) (string, bool), unavailable error) {
+func (h *Handler) serveHLSFile(w http.ResponseWriter, r *http.Request, kind, contentType string, lookup func(id string) (string, bool), notLive, notReady error) {
 	requesterID, _ := auth.UserIDFromContext(r.Context()) // "" si anonyme (pas de JWT)
 	id := r.PathValue("id")
 
@@ -895,7 +923,7 @@ func (h *Handler) serveHLSFile(w http.ResponseWriter, r *http.Request, kind, con
 
 	path, ok := lookup(id)
 	if !ok {
-		httpjson.WriteError(w, r, unavailable)
+		httpjson.WriteError(w, r, notLive)
 		return
 	}
 
@@ -925,8 +953,14 @@ func (h *Handler) serveHLSFile(w http.ResponseWriter, r *http.Request, kind, con
 	// segment, ou push dont ffmpeg n'a encore rien produit) ou avoir été retiré
 	// (fenêtre glissante) : renvoyer l'erreur JSON documentée plutôt que le
 	// `404 page not found` text/plain brut de http.ServeFile (hors contrat).
+	//
+	// La session existait au lookup, donc `notReady` : c'est une attente, pas une
+	// fin. Le cas limite — session arrêtée entre le lookup et le Stat, son
+	// répertoire nettoyé — est annoncé « pas encore prêt » alors que le direct
+	// vient de finir. Le lecteur ne s'y perd pas : ses reconnexions sont bornées
+	// et la tentative suivante retombe sur `notLive`.
 	if _, err := os.Stat(path); err != nil {
-		httpjson.WriteError(w, r, unavailable)
+		httpjson.WriteError(w, r, notReady)
 		return
 	}
 

--- a/backend/internal/streaming/handler_test.go
+++ b/backend/internal/streaming/handler_test.go
@@ -1010,6 +1010,44 @@ func TestHandler_Playlist_NotLiveCodeDiffersFromNotReady(t *testing.T) {
 	}
 }
 
+// TestHandler_Playlist_SpawnWindowReturnsNotReady vérifie le contrat HTTP de la
+// fenêtre de spawn (revue PR #358), là où le test de session vérifie le registre.
+//
+// Les deux comptent : c'est le *code* que le lecteur mobile lit, et c'est lui
+// qui décide entre patienter et couper. Un `stream_not_live` ici couperait la
+// lecture d'un flux qui démarre — le défaut de STR-229, réintroduit une couche
+// plus bas.
+func TestHandler_Playlist_SpawnWindowReturnsNotReady(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+
+	ls := NewLiveSessions(context.Background())
+	ls.newSeg = func(string) (*hlsSegmenter, error) {
+		close(entered)
+		<-release
+		return fakeSegmenter(t), nil
+	}
+	t.Cleanup(ls.StopAll)
+	t.Cleanup(func() { close(release) })
+
+	go ls.Start("spawning", "KEYSPAWN")
+	<-entered
+
+	h := NewHandler(&stubService{getRet: Stream{ID: "spawning", UserID: testUserID, IsPublic: true}}, testIngestURL, ls)
+	req := httptest.NewRequest(http.MethodGet, "/api/streams/spawning/playlist.m3u8", nil)
+	req.SetPathValue("id", "spawning")
+	rec := httptest.NewRecorder()
+
+	h.Playlist(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("want 409, got %d: %s", rec.Code, rec.Body)
+	}
+	if got := errorCode(t, rec); got != CodeManifestNotReady {
+		t.Errorf("code: got %q, want %q (le flux démarre, il n'est pas terminé)", got, CodeManifestNotReady)
+	}
+}
+
 // TestHandler_Segment_NotLiveAndNotReadyStayIdentical fige l'asymétrie assumée :
 // le segment ne distingue pas ses deux causes d'indisponibilité. Le lecteur n'en
 // ferait rien — il redemande le manifeste, et c'est le manifeste qui tranche.

--- a/backend/internal/streaming/handler_test.go
+++ b/backend/internal/streaming/handler_test.go
@@ -3,6 +3,7 @@ package streaming
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -14,7 +15,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/getkin/kin-openapi/openapi3"
+
 	"github.com/LignacAntony/streampulse/internal/auth"
+	"github.com/LignacAntony/streampulse/internal/openapi"
 	"github.com/LignacAntony/streampulse/internal/shared/apperror"
 )
 
@@ -922,6 +926,22 @@ func TestHandler_Ingest_SurvivesServerReadTimeoutWithoutGrace(t *testing.T) {
 
 // TestHandler_Playlist_NotReadyReturnsJSON409 : session vivante mais manifeste pas
 // encore écrit sur disque -> 409 JSON (contrat) et non un 404 text/plain brut.
+// errorCode lit le champ `error.code` d'une réponse d'erreur JSON. C'est ce que
+// le client mobile lit : l'assertion doit porter sur la charge utile réellement
+// émise, pas sur la valeur passée au constructeur d'erreur.
+func errorCode(t *testing.T, rec *httptest.ResponseRecorder) string {
+	t.Helper()
+	var body struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("réponse illisible: %v (body=%s)", err, rec.Body.String())
+	}
+	return body.Error.Code
+}
+
 func TestHandler_Playlist_NotReadyReturnsJSON409(t *testing.T) {
 	seg := fakeSegmenter(t)
 	if err := os.Remove(filepath.Join(seg.dir, hlsPlaylistName)); err != nil {
@@ -951,6 +971,76 @@ func TestHandler_Playlist_NotReadyReturnsJSON409(t *testing.T) {
 	}
 	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
 		t.Fatalf("l'erreur doit rester JSON, content-type=%q", ct)
+	}
+	if got := errorCode(t, rec); got != CodeManifestNotReady {
+		t.Errorf("code: got %q, want %q (session vivante, manifeste pas encore écrit)", got, CodeManifestNotReady)
+	}
+}
+
+// TestHandler_Playlist_NotLiveCodeDiffersFromNotReady est le cœur de STR-229 :
+// les deux 409 du manifeste doivent être distinguables par leur code.
+//
+// L'assertion qui compte est la *différence*. Vérifier chaque code isolément
+// laisserait passer une régression qui les ferait converger — exactement l'état
+// d'avant, où le lecteur devait deviner lequel des deux il tenait et payait
+// ~15 s de reconnexions inutiles sur un direct déjà terminé.
+func TestHandler_Playlist_NotLiveCodeDiffersFromNotReady(t *testing.T) {
+	// Aucune session : le lookup échoue, on est dans la branche « pas live ».
+	h := NewHandler(
+		&stubService{getRet: Stream{ID: "dead", UserID: testUserID, IsPublic: true}},
+		testIngestURL,
+		NewLiveSessions(context.Background()),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/streams/dead/playlist.m3u8", nil)
+	req.SetPathValue("id", "dead")
+	rec := httptest.NewRecorder()
+
+	h.Playlist(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("want 409 (flux pas en direct), got %d: %s", rec.Code, rec.Body)
+	}
+	got := errorCode(t, rec)
+	if got != CodeStreamNotLive {
+		t.Errorf("code: got %q, want %q (aucune session)", got, CodeStreamNotLive)
+	}
+	if got == CodeManifestNotReady {
+		t.Error("les deux 409 du manifeste doivent rester distinguables (STR-229)")
+	}
+}
+
+// TestHandler_Segment_NotLiveAndNotReadyStayIdentical fige l'asymétrie assumée :
+// le segment ne distingue pas ses deux causes d'indisponibilité. Le lecteur n'en
+// ferait rien — il redemande le manifeste, et c'est le manifeste qui tranche.
+// Sans ce test, quelqu'un « uniformiserait » un jour les deux handlers en
+// croyant corriger un oubli.
+func TestHandler_Segment_NotLiveAndNotReadyStayIdentical(t *testing.T) {
+	// Pas de session : branche « pas live ».
+	dead := NewHandler(
+		&stubService{getRet: Stream{ID: "dead", UserID: testUserID, IsPublic: true}},
+		testIngestURL,
+		NewLiveSessions(context.Background()),
+	)
+	reqDead := httptest.NewRequest(http.MethodGet, "/api/streams/dead/segments/seg_00000.ts", nil)
+	reqDead.SetPathValue("id", "dead")
+	reqDead.SetPathValue("segment", "seg_00000.ts")
+	recDead := httptest.NewRecorder()
+	dead.Segment(recDead, reqDead)
+
+	// Session vivante mais segment absent du disque : branche « pas prêt ».
+	live := newLiveHandler(t, "alive", &stubService{getRet: Stream{ID: "alive", UserID: testUserID, IsPublic: true}})
+	reqGone := httptest.NewRequest(http.MethodGet, "/api/streams/alive/segments/seg_09999.ts", nil)
+	reqGone.SetPathValue("id", "alive")
+	reqGone.SetPathValue("segment", "seg_09999.ts")
+	recGone := httptest.NewRecorder()
+	live.Segment(recGone, reqGone)
+
+	if recDead.Code != http.StatusNotFound || recGone.Code != http.StatusNotFound {
+		t.Fatalf("les deux cas doivent rendre 404: pas-live=%d, pas-prêt=%d", recDead.Code, recGone.Code)
+	}
+	if a, b := errorCode(t, recDead), errorCode(t, recGone); a != b {
+		t.Errorf("le segment ne doit pas distinguer ses deux causes: %q vs %q", a, b)
 	}
 }
 
@@ -1366,5 +1456,57 @@ func TestHandler_ListFavorites_Unauthenticated(t *testing.T) {
 
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("want 401, got %d: %s", rec.Code, rec.Body)
+	}
+}
+
+// TestOpenAPI_DocumenteLesDeuxCodesDu409 relie le handler au contrat publié.
+//
+// Ces deux codes ne sont pas décoratifs : le lecteur mobile *branche* dessus
+// pour décider entre « annoncer la fin » et « reconnecter ». Un code renommé en
+// Go sans mise à jour d'openapi.yaml livrerait donc un client qui ne reconnaît
+// plus rien — et qui, faute de mieux, reprendrait les reconnexions inutiles que
+// STR-229 supprime. Le reste du projet documente ses codes publics sans garde
+// (`storage_quota_exceeded` n'est qu'affiché) ; celui-ci en mérite une.
+func TestOpenAPI_DocumenteLesDeuxCodesDu409(t *testing.T) {
+	doc, err := openapi3.NewLoader().LoadFromData(openapi.SpecYAML())
+	if err != nil {
+		t.Fatalf("chargement de la spec: %v", err)
+	}
+
+	const path = "/api/streams/{id}/playlist.m3u8"
+	item := doc.Paths.Find(path)
+	if item == nil || item.Get == nil {
+		t.Fatalf("chemin %q absent de la spec", path)
+	}
+	resp := item.Get.Responses.Status(http.StatusConflict)
+	if resp == nil || resp.Value == nil {
+		t.Fatalf("réponse 409 absente de %q", path)
+	}
+	media := resp.Value.Content.Get("application/json")
+	if media == nil {
+		t.Fatalf("409 de %q sans corps application/json", path)
+	}
+
+	documentés := map[string]bool{}
+	for nom, ex := range media.Examples {
+		if ex == nil || ex.Value == nil {
+			t.Fatalf("exemple %q sans valeur", nom)
+		}
+		val, ok := ex.Value.Value.(map[string]any)
+		if !ok {
+			t.Fatalf("exemple %q: objet attendu, got %T", nom, ex.Value.Value)
+		}
+		errObj, ok := val["error"].(map[string]any)
+		if !ok {
+			t.Fatalf("exemple %q: champ `error` absent ou mal typé", nom)
+		}
+		code, _ := errObj["code"].(string)
+		documentés[code] = true
+	}
+
+	for _, want := range []string{CodeStreamNotLive, CodeManifestNotReady} {
+		if !documentés[want] {
+			t.Errorf("code %q rendu par le handler mais absent des exemples du 409 (documentés: %v)", want, documentés)
+		}
 	}
 }

--- a/backend/internal/streaming/hls_test.go
+++ b/backend/internal/streaming/hls_test.go
@@ -116,7 +116,7 @@ func TestSegmenterDeath_ReapsSession(t *testing.T) {
 	ls.newSeg = func(string) (*hlsSegmenter, error) { return seg, nil }
 	ls.Start("s1", "KEY1")
 
-	if _, ok := ls.Playlist("s1"); !ok {
+	if _, avail := ls.Playlist("s1"); avail != hlsServable {
 		t.Fatal("le flux devrait être servi tant que le segmenteur est vivant")
 	}
 
@@ -140,8 +140,11 @@ func TestSegmenterDeath_ReapsSession(t *testing.T) {
 	if !waitFor(func() bool { return !ls.IsLive("s1") }, 2*time.Second) {
 		t.Fatal("session non récoltée (toujours live) après la mort du segmenteur")
 	}
-	if _, ok := ls.Playlist("s1"); ok {
-		t.Fatal("Playlist devrait échouer après reap")
+	// hlsUnavailable et non hlsPending : ffmpeg est mort, il n'y a rien à
+	// attendre. Rendre « en démarrage » ici ferait patienter l'auditeur 15 s
+	// avant de lui annoncer une fin déjà consommée (STR-229).
+	if _, avail := ls.Playlist("s1"); avail != hlsUnavailable {
+		t.Fatalf("Playlist après reap: want hlsUnavailable, got %v", avail)
 	}
 	if _, _, err := ls.AttachIngest("KEY1"); !errors.Is(err, errNotLive) {
 		t.Fatalf("AttachIngest après reap: want errNotLive, got %v", err)
@@ -174,21 +177,78 @@ func TestPlaylistAndSegmentLookup(t *testing.T) {
 	ls.Start("s1", "KEY1")
 	defer ls.StopAll()
 
-	if p, ok := ls.Playlist("s1"); !ok || filepath.Base(p) != hlsPlaylistName {
-		t.Fatalf("playlist: want (…/%s, true), got (%q, %v)", hlsPlaylistName, p, ok)
+	if p, avail := ls.Playlist("s1"); avail != hlsServable || filepath.Base(p) != hlsPlaylistName {
+		t.Fatalf("playlist: want (…/%s, hlsServable), got (%q, %v)", hlsPlaylistName, p, avail)
 	}
-	if _, ok := ls.Playlist("inconnu"); ok {
-		t.Fatal(`playlist d'un flux inconnu doit être ("", false)`)
+	if _, avail := ls.Playlist("inconnu"); avail != hlsUnavailable {
+		t.Fatalf("playlist d'un flux inconnu: want hlsUnavailable, got %v", avail)
 	}
 
-	if p, ok := ls.Segment("s1", "seg_00000.ts"); !ok || filepath.Base(p) != "seg_00000.ts" {
-		t.Fatalf("segment valide: got (%q, %v)", p, ok)
+	if p, avail := ls.Segment("s1", "seg_00000.ts"); avail != hlsServable || filepath.Base(p) != "seg_00000.ts" {
+		t.Fatalf("segment valide: got (%q, %v)", p, avail)
 	}
-	if _, ok := ls.Segment("s1", "../secret"); ok {
-		t.Fatal("segment traversal accepté")
+	// Un nom refusé n'est pas une attente : il ne deviendra jamais valide.
+	if _, avail := ls.Segment("s1", "../secret"); avail != hlsUnavailable {
+		t.Fatalf("segment traversal: want hlsUnavailable, got %v", avail)
 	}
-	if _, ok := ls.Segment("inconnu", "seg_00000.ts"); ok {
-		t.Fatal(`segment d'un flux inconnu doit être ("", false)`)
+	if _, avail := ls.Segment("inconnu", "seg_00000.ts"); avail != hlsUnavailable {
+		t.Fatalf("segment d'un flux inconnu: want hlsUnavailable, got %v", avail)
+	}
+}
+
+// TestPlaylist_SpawnWindowIsPending couvre la fenêtre relevée en revue de la
+// PR #358 : `Start` inscrit la session au registre (phase 1) *avant* de forker
+// ffmpeg (phase 2, hors verrou et « potentiellement lente »). Un auditeur qui
+// voit déjà le flux « en direct » dans Découvrir peut l'ouvrir pendant ce laps.
+//
+// Le segmenteur y est nil, comme après la mort de ffmpeg — mais les deux états
+// sont contraires. Les confondre annonçait « direct terminé » à un auditeur
+// arrivé une seconde trop tôt, soit exactement le défaut que STR-229 corrige,
+// déplacé une couche plus bas.
+func TestPlaylist_SpawnWindowIsPending(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+
+	ls := NewLiveSessions(context.Background())
+	ls.newSeg = func(string) (*hlsSegmenter, error) {
+		close(entered) // phase 1 terminée : la session est inscrite
+		<-release      // …et le segmenteur n'est pas encore publié
+		return fakeSegmenter(t), nil
+	}
+	t.Cleanup(ls.StopAll)
+
+	go ls.Start("s1", "KEY1")
+	<-entered
+
+	if _, avail := ls.Playlist("s1"); avail != hlsPending {
+		t.Fatalf("pendant le spawn: want hlsPending, got %v", avail)
+	}
+	if _, avail := ls.Segment("s1", "seg_00000.ts"); avail != hlsPending {
+		t.Fatalf("segment pendant le spawn: want hlsPending, got %v", avail)
+	}
+
+	close(release)
+	if !waitFor(func() bool {
+		_, avail := ls.Playlist("s1")
+		return avail == hlsServable
+	}, 2*time.Second) {
+		t.Fatal("le manifeste devrait devenir servable une fois le segmenteur publié")
+	}
+}
+
+// TestPlaylist_SpawnFailureStaysPending : un spawn ffmpeg qui échoue publie un
+// segmenteur nil de façon permanente. C'est indistinguable d'un spawn en cours,
+// et ce doit le rester — le flux est bien « live » en base, il ne produira
+// simplement jamais d'audio. Le client tranche par ses reprises bornées plutôt
+// que par un verdict serveur que rien ne permet de rendre ici.
+func TestPlaylist_SpawnFailureStaysPending(t *testing.T) {
+	ls := NewLiveSessions(context.Background())
+	ls.newSeg = func(string) (*hlsSegmenter, error) { return nil, errors.New("ffmpeg absent") }
+	ls.Start("s1", "KEY1")
+	t.Cleanup(ls.StopAll)
+
+	if _, avail := ls.Playlist("s1"); avail != hlsPending {
+		t.Fatalf("spawn échoué: want hlsPending, got %v", avail)
 	}
 }
 

--- a/backend/internal/streaming/session.go
+++ b/backend/internal/streaming/session.go
@@ -47,6 +47,44 @@ func (s *session) segmenter() *hlsSegmenter {
 	return s.hls
 }
 
+// hlsAvailability distingue les raisons pour lesquelles un fichier HLS n'est pas
+// servable — distinction que le client doit connaître (STR-229, ADR 045).
+//
+// Un `nil` de [session.segmenter] recouvrait deux états contraires : « ffmpeg
+// est mort » (terminal) et « ffmpeg n'a pas encore démarré » (transitoire). Le
+// second est précisément la fenêtre que STR-229 protège : `Start` inscrit la
+// session au registre *avant* de forker ffmpeg (phase 2 hors verrou), et un flux
+// affiché « en direct » dans Découvrir est ouvrable pendant ce laps.
+type hlsAvailability int
+
+const (
+	// hlsUnavailable : rien à servir, et réessayer n'y changera rien — aucune
+	// session, ou ffmpeg arrêté, ou nom de segment non résoluble.
+	hlsUnavailable hlsAvailability = iota
+	// hlsPending : session enregistrée, segmenteur pas encore publié. Le spawn
+	// est en cours (ou a échoué) ; l'auditeur doit patienter, pas abandonner.
+	hlsPending
+	// hlsServable : le chemin retourné fait foi.
+	hlsServable
+)
+
+// hlsState rend le segmenteur *et* la raison de son absence, sous un unique
+// verrou. Deux appels séparés — « est-ce servable ? » puis « est-ce en
+// démarrage ? » — laisseraient la session changer d'état entre les deux, et un
+// flux devenu prêt entre-temps serait annoncé « terminé ».
+func (s *session) hlsState() (*hlsSegmenter, hlsAvailability) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	switch {
+	case s.dead:
+		return nil, hlsUnavailable // ffmpeg mort : la session part au reap
+	case s.hls == nil:
+		return nil, hlsPending // spawn en cours, ou échoué
+	default:
+		return s.hls, hlsServable
+	}
+}
+
 // LiveSessions est le registre in-memory des flux en direct (une session par
 // flux live). Protégé par mutex. Chaque session porte l'annulation de sa
 // goroutine (STR-84), son segmenteur HLS (STR-70) et ses abonnés SSE (STR-85).
@@ -350,36 +388,42 @@ func (ls *LiveSessions) AttachIngest(streamKey string) (io.Writer, func(), error
 }
 
 // Playlist retourne le chemin disque du manifeste .m3u8 du flux en direct
-// (identifié par son id public). ("", false) si le flux n'est pas en direct ou
-// n'a pas de segmenteur exploitable.
-func (ls *LiveSessions) Playlist(streamID string) (string, bool) {
+// (identifié par son id public), et la raison de son indisponibilité le cas
+// échéant (cf. [hlsAvailability]).
+func (ls *LiveSessions) Playlist(streamID string) (string, hlsAvailability) {
 	ls.mu.Lock()
 	s, ok := ls.byID[streamID]
 	ls.mu.Unlock()
 	if !ok {
-		return "", false
+		return "", hlsUnavailable
 	}
-	seg := s.segmenter()
-	if seg == nil {
-		return "", false
+	seg, avail := s.hlsState()
+	if avail != hlsServable {
+		return "", avail
 	}
-	return seg.playlistPath(), true
+	return seg.playlistPath(), hlsServable
 }
 
 // Segment retourne le chemin disque d'un segment .ts du flux en direct, après
 // validation stricte du nom (anti path-traversal, cf. hlsSegmenter.segmentPath).
-func (ls *LiveSessions) Segment(streamID, name string) (string, bool) {
+func (ls *LiveSessions) Segment(streamID, name string) (string, hlsAvailability) {
 	ls.mu.Lock()
 	s, ok := ls.byID[streamID]
 	ls.mu.Unlock()
 	if !ok {
-		return "", false
+		return "", hlsUnavailable
 	}
-	seg := s.segmenter()
-	if seg == nil {
-		return "", false
+	seg, avail := s.hlsState()
+	if avail != hlsServable {
+		return "", avail
 	}
-	return seg.segmentPath(name)
+	path, ok := seg.segmentPath(name)
+	if !ok {
+		// Nom refusé (traversal) ou hors fenêtre glissante : rien à servir, et
+		// attendre n'y changera rien — même verdict que « pas de session ».
+		return "", hlsUnavailable
+	}
+	return path, hlsServable
 }
 
 // Subscribe abonne un client SSE aux événements du flux. Retourne le canal de

--- a/docs/README.md
+++ b/docs/README.md
@@ -171,13 +171,14 @@ Chaque décision est tracée avec son contexte, les **alternatives écartées** 
 | 042 | [042-controle-du-volume-et-temps-decoute.md](adr/042-controle-du-volume-et-temps-decoute.md) | Contrôle du volume dans l'application et temps d'écoute d'un direct |
 | 043 | [043-accessibilite-de-l-application-et-adaptation-aux-largeurs.md](adr/043-accessibilite-de-l-application-et-adaptation-aux-largeurs.md) | Accessibilité de l'application mobile et adaptation aux largeurs d'écran |
 | 044 | [044-cout-cpu-du-streaming-et-dimensionnement-du-vps.md](adr/044-cout-cpu-du-streaming-et-dimensionnement-du-vps.md) | Coût CPU du streaming, modèle de capacité et dimensionnement du VPS |
+| 045 | [045-codes-derreur-du-manifeste-hls.md](adr/045-codes-derreur-du-manifeste-hls.md) | Codes d'erreur du manifeste HLS : distinguer « terminé » de « pas encore prêt » |
 
 ---
 
 ## Convention ADR
 
 - Toute nouvelle décision d'architecture significative → nouvel ADR dans `docs/adr/`,
-  avec **le numéro suivant** (prochain : `045-...`). Le numéro est un **identifiant**,
+  avec **le numéro suivant** (prochain : `046-...`). Le numéro est un **identifiant**,
   attribué dans l'ordre d'enregistrement — il ne suit pas nécessairement l'ordre chronologique
   des décisions (cf. 037/038/039, renumérotées après collision).
 - Un numéro n'est **jamais réutilisé** : une ADR remplacée passe en statut

--- a/docs/adr/031-lecture-audio-en-arriere-plan.md
+++ b/docs/adr/031-lecture-audio-en-arriere-plan.md
@@ -40,13 +40,14 @@ fake léger la remplace dans les tests. Le contrôleur reste donc testable sans 
 - Le **contrôleur** garde tout l'arbitrage STR-118 (reconnexion bornée avec backoff, garde
   `_disposed`, garde `ended` dans `_onPlayerState`). À l'état terminal (`ended`/`error`), il appelle
   `stop()` pour retirer la notification.
-- **Ambiguïté du 409** (important) : le manifeste renvoie **409 aussi bien pour un flux terminé que
-  pour un flux live dont le manifeste n'est pas encore prêt** (fenêtre de démarrage ~10 s, segments
-  HLS de 10 s). Le contrôleur lève l'ambiguïté avec un flag `_hasPlayed` : il ne conclut « terminé »
-  immédiatement que si la lecture **avait démarré** (manifeste servi au moins une fois) ; sinon il
-  **reconnecte d'abord** (backoff 1+2+4+8 = 15 s) et ne conclut qu'après épuisement. La sonde
-  (`isManifestUnavailable`) accepte les <500 via `validateStatus` pour ne pas polluer les logs d'un
-  faux « erreur » sur un 404/409 attendu.
+- **Ambiguïté du 409** — ⚠️ **résolue depuis, cf. [ADR 045](045-codes-derreur-du-manifeste-hls.md)
+  (STR-229).** Le manifeste rendait 409 aussi bien pour un flux terminé que pour un flux live dont
+  le manifeste n'était pas encore prêt (fenêtre de démarrage ~10 s). Le contrôleur levait
+  l'ambiguïté avec un flag `_hasPlayed` : il ne concluait « terminé » immédiatement que si la
+  lecture avait démarré ; sinon il reconnectait d'abord (backoff 1+2+4+8 = 15 s). Le serveur
+  distingue désormais les deux cas par `error.code` (`stream_not_live` / `manifest_not_ready`), le
+  contrôleur applique ce verdict et `_hasPlayed` a disparu. La sonde continue d'accepter les <500
+  via `validateStatus` pour ne pas polluer les logs d'un faux « erreur » sur un 404/409 attendu.
 - Les **contrôles système** (play/pause/stop de la notif) appellent le handler, dont l'état de
   lecture se propage au contrôleur via `playerStateStream` → l'UI reste synchrone.
 

--- a/docs/adr/045-codes-derreur-du-manifeste-hls.md
+++ b/docs/adr/045-codes-derreur-du-manifeste-hls.md
@@ -1,0 +1,127 @@
+# ADR 045 — Codes d'erreur du manifeste HLS : distinguer « terminé » de « pas encore prêt »
+
+**Date** : 2026-08-25
+**Statut** : Accepté
+**Ticket** : [STR-229](https://linear.app/streampulse/issue/STR-229)
+
+## Contexte
+
+`GET /api/streams/{id}/playlist.m3u8` rendait exactement la même erreur dans deux
+situations qui n'ont rien à voir :
+
+- **flux terminé** — plus aucune session live, `lookup` rend `ok == false` ;
+- **flux live en démarrage** — la session existe, mais `os.Stat` échoue : ffmpeg n'a pas
+  encore écrit le premier segment (~10 s, la taille d'un segment HLS).
+
+Les deux branches de `serveHLSFile` écrivaient `apperror.Conflict("stream is not live")`.
+Le client recevait donc un `409` indistinct — alors que **le serveur, lui, connaissait la
+différence** : `ok` valait `false` dans un cas, `true` dans l'autre.
+
+Ce n'était pas une imprécision cosmétique. Les deux cas appellent des conduites **opposées** :
+abandonner, ou patienter. Faute de pouvoir trancher, le lecteur mobile s'appuyait sur une
+heuristique — le drapeau `_hasPlayed` (ADR 031, PR #282) : ne conclure « direct terminé » que
+si la lecture avait déjà démarré, sinon reconnecter d'abord.
+
+Le coût était mesurable. Ouvrir un flux **déjà terminé** depuis une liste Découvrir périmée
+déclenchait les quatre reconnexions avec backoff (1+2+4+8) avant d'afficher « Le direct est
+terminé » : **~15 s de « Reconnexion… »** pour annoncer une fin que le serveur connaissait dès
+la première requête. La revue de la PR #282 l'avait relevée comme une régression d'UX assumée,
+faute de pouvoir faire mieux côté client.
+
+## Décision
+
+### 1. Deux codes publics sur le même statut
+
+Le `409` reste — c'est bien un conflit d'état dans les deux cas, et changer le statut casserait
+les clients pour un gain nul. C'est le champ `error.code` qui porte la distinction :
+
+| Situation | Code | Nature |
+|---|---|---|
+| Aucune session live | `stream_not_live` | Définitive — réessayer ne sert à rien |
+| Session vivante, manifeste pas encore écrit | `manifest_not_ready` | Transitoire — réessayer a du sens |
+
+Le mécanisme existait déjà et n'a pas eu à être inventé : `apperror.Error.PublicCode`, posé par
+`.Coded(...)`, laisse un domaine publier un code métier stable sans connaître le transport —
+`Code` continue seul de décider du statut HTTP. Le précédent est `storage_quota_exceeded`
+(ADR 032).
+
+### 2. Le segment ne suit pas
+
+`serveHLSFile` prend désormais **deux** erreurs (`notLive`, `notReady`) au lieu d'une, mais
+`Segment` leur passe la même valeur. Ses deux causes d'indisponibilité — flux éteint, ou segment
+sorti de la fenêtre glissante — appellent la même conduite chez le lecteur : redemander le
+manifeste. C'est le manifeste qui portera le verdict.
+
+Uniformiser par symétrie aurait ajouté un code que personne ne lit, sur un endpoint appelé
+plusieurs fois par minute et par auditeur. Un test (`TestHandler_Segment_NotLiveAndNotReady
+StayIdentical`) fige l'asymétrie pour qu'elle ne soit pas « corrigée » plus tard comme un oubli.
+
+### 3. Côté client : un verdict, plus une heuristique
+
+`ManifestStatus` (`available` / `ended` / `notReady` / `unknown`) remplace le booléen
+`isManifestUnavailable`. Le contrôleur applique la décision du serveur au lieu de la reconstituer,
+et `_hasPlayed` disparaît.
+
+La sonde devient **systématique** — elle n'était déclenchée que lorsqu'elle était jugée décisive.
+C'est une requête HTTP de plus par échec, bornée par le même plafond de reprises, et c'est ce qui
+permet le verdict immédiat.
+
+### 4. Le défaut penche vers l'attente
+
+Un `409` dont le code n'est pas reconnu — un backend antérieur à cette décision, un code ajouté
+plus tard — est traité comme `notReady`, pas comme `ended`. Seule la fin de direct est reconnue
+**explicitement**.
+
+Le choix n'est pas symétrique : se tromper vers l'attente coûte au pire les reconnexions bornées
+déjà en place ; se tromper vers la fin couperait un direct en train de démarrer, soit exactement
+le bug que cette ADR corrige. On ne le réintroduit pas par le défaut.
+
+### 5. Ce qui ne change pas
+
+- **Tentatives épuisées avec un manifeste toujours pas servi** → toujours `ended`. Un diffuseur
+  qui démarre sans jamais pousser d'audio produit cet état ; « terminé » reste le message le plus
+  juste pour l'auditeur, et c'est ce que faisait la version précédente.
+- **Manifeste servi mais lecture en échec** → toujours `error` : le problème est réseau ou lecteur,
+  pas côté direct.
+- Le plafond de reprises et le backoff 1/2/4/8 s (STR-118) sont inchangés.
+
+## Conséquences
+
+- Ouvrir un direct terminé depuis une liste périmée affiche « Le direct est terminé »
+  **immédiatement**, au lieu de ~15 s de « Reconnexion… ». C'est le gain visé.
+- Le contrôleur perd un état (`_hasPlayed`) et un raisonnement conditionnel : il lit un verdict.
+- La sonde ne passe **pas** par le client généré, contrairement au reste de la couche data.
+  `StreamingApi.streamPlaylist` est typé `Response<String>` pour le chemin nominal (le `.m3u8`),
+  et sa désérialisation traverse un `case 'String': return '$value'` : un corps d'erreur JSON en
+  ressort stringifié à la Dart (`{error: {code: stream_not_live}}`, sans guillemets), donc illisible
+  par `jsonDecode`. Or c'est ce corps qu'on vient chercher. La sonde utilise le `Dio` sous-jacent —
+  **la même instance**, donc les mêmes intercepteurs et le même `Bearer` : la lecture propriétaire
+  d'un flux privé continue de fonctionner.
+- `ApiConstants.playlistPath` est extrait et `hlsPlaylist` en dérive : le lecteur natif et la sonde
+  doivent viser le même endpoint, les laisser diverger rendrait la sonde muette sur ce qui joue.
+- Un test relie les constantes Go aux exemples publiés dans `openapi.yaml`
+  (`TestOpenAPI_DocumenteLesDeuxCodesDu409`). C'est le seul code d'erreur du projet sur lequel un
+  client **branche** au lieu de l'afficher : un renommage silencieux livrerait une application qui
+  ne reconnaît plus rien et reprendrait les reconnexions inutiles.
+
+## Alternatives écartées
+
+**Deux statuts HTTP distincts (409 / 425 « Too Early », ou 503 + `Retry-After`).** Le statut aurait
+porté la nuance sans champ supplémentaire. Écarté : `425` est défini pour le rejeu TLS early-data,
+le détourner tromperait tout intermédiaire qui le lit ; `503` rangerait un démarrage normal parmi
+les indisponibilités serveur, donc dans les compteurs d'erreur et les alertes (ADR 019) alors que
+rien ne va mal. Le conflit d'état est bien un `409` dans les deux cas — c'est la *cause* qui diffère,
+et le corps est fait pour ça.
+
+**Garder l'ambiguïté et raccourcir le backoff côté client.** Passer de 15 s à ~3 s aurait réduit la
+gêne sans toucher au serveur. Écarté : ça n'aurait pas corrigé le fond — le client continuerait de
+deviner — et raccourcir la fenêtre de reconnexion dégraderait la tolérance aux coupures réseau, qui
+est la raison d'être de ce backoff (STR-118). On aurait échangé un défaut visible contre un défaut
+invisible.
+
+**Un en-tête dédié (`X-Stream-State`).** Écarté : le corps d'erreur JSON est déjà le canal
+conventionnel du projet, il est documenté dans `openapi.yaml` et lisible dans Swagger. Un en-tête
+hors contrat aurait été un second mécanisme pour le même besoin.
+
+**Distinguer aussi les deux cas du segment.** Écarté : cf. §2 — un code que personne ne lit, sur
+l'endpoint le plus appelé du service.

--- a/docs/adr/045-codes-derreur-du-manifeste-hls.md
+++ b/docs/adr/045-codes-derreur-du-manifeste-hls.md
@@ -37,13 +37,43 @@ les clients pour un gain nul. C'est le champ `error.code` qui porte la distincti
 
 | Situation | Code | Nature |
 |---|---|---|
-| Aucune session live | `stream_not_live` | Définitive — réessayer ne sert à rien |
-| Session vivante, manifeste pas encore écrit | `manifest_not_ready` | Transitoire — réessayer a du sens |
+| Rien à attendre | `stream_not_live` | Définitive — réessayer ne sert à rien |
+| Le flux démarre encore | `manifest_not_ready` | Transitoire — réessayer a du sens |
 
 Le mécanisme existait déjà et n'a pas eu à être inventé : `apperror.Error.PublicCode`, posé par
 `.Coded(...)`, laisse un domaine publier un code métier stable sans connaître le transport —
 `Code` continue seul de décider du statut HTTP. Le précédent est `storage_quota_exceeded`
 (ADR 032).
+
+### 1 bis. Le registre de sessions devait d'abord savoir répondre
+
+La première version de cette décision plaçait la frontière au mauvais endroit. Elle lisait
+« session absente » (`lookup` rend `false`) comme « direct terminé » — or `LiveSessions.Playlist`
+rendait ce même `false` dans **trois** situations :
+
+1. aucune entrée dans le registre — direct terminé, ou jamais démarré ;
+2. entrée présente, `s.dead` — ffmpeg s'est arrêté seul, la session part au `reap` ;
+3. entrée présente, `s.hls == nil` — **le segmenteur n'est pas encore publié**.
+
+Le troisième cas est la fenêtre de `LiveSessions.Start` : la phase 1 inscrit la session sous verrou,
+la phase 2 (`MkdirTemp` + fork ffmpeg, « potentiellement lents ») se déroule **hors** verrou, et la
+phase 3 seulement publie le segmenteur. Entre-temps le flux est déjà `live` en base, donc visible
+et ouvrable depuis Découvrir. Un auditeur arrivé une seconde trop tôt recevait `stream_not_live` et
+se voyait couper immédiatement — le défaut même que cette ADR corrige, déplacé une couche plus bas.
+Relevé en revue de la PR #358.
+
+`Playlist`/`Segment` rendent donc un `hlsAvailability` à trois états (`hlsUnavailable` /
+`hlsPending` / `hlsServable`) plutôt qu'un booléen, et `session.hlsState()` distingue `dead` de
+`hls == nil` **sous un unique verrou**. Deux appels successifs — « est-ce servable ? » puis
+« est-ce en démarrage ? » — auraient laissé la session changer d'état entre les deux, et un flux
+devenu prêt dans cet intervalle aurait été annoncé « terminé ».
+
+Un nom de segment refusé (traversal, hors fenêtre glissante) rend `hlsUnavailable` : il n'y a rien
+à servir, et attendre n'y changera rien.
+
+Un spawn ffmpeg **échoué** publie un `nil` permanent, indistinguable d'un spawn en cours — et cela
+reste ainsi. Le flux est bien `live` en base, il ne produira simplement jamais d'audio ; le serveur
+n'a pas de quoi trancher, c'est le plafond de reprises du client qui conclut.
 
 ### 2. Le segment ne suit pas
 

--- a/docs/en/adr-index.md
+++ b/docs/en/adr-index.md
@@ -284,5 +284,18 @@ Every figure is an upper bound: the simulated clients share the measured
 process, so their own HTTP work cannot be separated from the server's. And the
 first ceiling StreamPulse will hit as it grows is bandwidth, not CPU.
 
+**ADR 045 — HLS manifest error codes.** *Context:* the manifest returned one
+indistinguishable `409` for a finished broadcast and for a live one still
+writing its first segment — two situations calling for opposite behaviour, which
+the server could tell apart and the client could not. *Decision:* keep the
+status, split the meaning into two public `error.code` values
+(`stream_not_live`, `manifest_not_ready`), and have the player apply the
+server's verdict instead of guessing from whether playback had ever started.
+*Consequence:* opening an already-ended stream from a stale list now says so
+immediately, where it previously spent ~15 s reconnecting toward a conclusion the
+server had from the first request. An unrecognised code falls back to "not
+ready": erring toward waiting costs a bounded backoff, erring toward "over"
+would cut off a broadcast that is starting.
+
 > ADR 040 lands with the mobile distribution change; it is listed here because
 > this index is meant to stay complete.

--- a/mobile/lib/app/app_providers.dart
+++ b/mobile/lib/app/app_providers.dart
@@ -131,8 +131,10 @@ class StreamPulseApp extends StatelessWidget {
               BroadcasterController(ctx.read<BroadcasterRepository>()),
         ),
         Provider<StreamRemoteDataSource>(
-          create: (ctx) =>
-              StreamRemoteDataSource(ctx.read<DioClient>().streamingApi),
+          create: (ctx) => StreamRemoteDataSource(
+            ctx.read<DioClient>().streamingApi,
+            ctx.read<DioClient>().dio,
+          ),
         ),
         Provider<StreamRepository>(
           create: (ctx) =>
@@ -152,8 +154,7 @@ class StreamPulseApp extends StatelessWidget {
         ChangeNotifierProvider<AudioPlayerController>(
           create: (ctx) => AudioPlayerController(
             service: ctx.read<AudioPlaybackService>(),
-            isManifestUnavailable:
-                ctx.read<StreamRepository>().isManifestUnavailable,
+            manifestStatus: ctx.read<StreamRepository>().manifestStatus,
           ),
         ),
         Provider<OfflineDatabase>(create: (_) => OfflineDatabase()),

--- a/mobile/lib/core/constants/api_constants.dart
+++ b/mobile/lib/core/constants/api_constants.dart
@@ -22,10 +22,18 @@ class ApiConstants {
   // Streams
   static const String streams = '/api/streams';
 
+  /// Chemin du manifeste HLS d'un flux, **relatif** à [baseUrl] — la forme
+  /// qu'attend Dio, qui préfixe lui-même. Utilisé par la sonde de manifeste
+  /// (STR-229).
+  static String playlistPath(String streamId) =>
+      '/api/streams/$streamId/playlist.m3u8';
+
   /// URL du manifeste HLS d'un flux (lecture publique, ADR 023). Passée telle
-  /// quelle au player natif via `AudioSource.uri` — sans en-tête d'auth.
+  /// quelle au player natif via `AudioSource.uri` — sans en-tête d'auth. Dérivée
+  /// de [playlistPath] : le player natif et la sonde doivent viser le même
+  /// endpoint, les laisser diverger rendrait la sonde muette sur ce qui joue.
   static String hlsPlaylist(String streamId) =>
-      '$baseUrl/api/streams/$streamId/playlist.m3u8';
+      '$baseUrl${playlistPath(streamId)}';
 
   // Tracks
   static const String tracks = '/api/tracks';

--- a/mobile/lib/features/streams/data/datasources/stream_remote_data_source.dart
+++ b/mobile/lib/features/streams/data/datasources/stream_remote_data_source.dart
@@ -1,12 +1,19 @@
 import 'package:dio/dio.dart';
 import 'package:streampulse_api/streampulse_api.dart';
 
+import '../../../../core/constants/api_constants.dart';
 import '../../../../core/network/dio_error_mapper.dart';
+import '../../domain/entities/manifest_status.dart';
 
 class StreamRemoteDataSource {
-  StreamRemoteDataSource(this._api);
+  StreamRemoteDataSource(this._api, this._dio);
 
   final StreamingApi _api;
+
+  /// Le Dio sous-jacent, pour la seule sonde de manifeste — cf. [manifestStatus]
+  /// pour la raison. Même instance que celle de [_api] : aucun second chemin
+  /// d'authentification n'est introduit.
+  final Dio _dio;
 
   Future<List<StreamSummaryResponse>> listLive({
     int limit = 20,
@@ -45,26 +52,66 @@ class StreamRemoteDataSource {
     }
   }
 
-  /// Sonde le manifeste HLS **public** du flux : `true` si le manifeste n'est
-  /// plus servi (404/409), `false` sinon (200 en direct, ou réseau indéterminé).
-  ///
-  /// ⚠️ Le 409 est **ambigu** côté backend : il couvre aussi bien un flux
-  /// terminé qu'un flux live dont le manifeste n'est **pas encore prêt** (fenêtre
-  /// de démarrage ~10 s). L'appelant ([AudioPlayerController]) lève cette
-  /// ambiguïté en ne concluant « terminé » que si la lecture avait démarré.
+  /// Sonde le manifeste HLS **public** du flux et rend le verdict du serveur.
   ///
   /// `validateStatus` accepte les <500 pour que 404/409 reviennent en réponse
   /// normale (pas d'exception → pas de log d'erreur parasite ; STR-109).
-  Future<bool> isManifestUnavailable(String streamId) async {
+  ///
+  /// ⚠️ **Volontairement hors du client généré**, contrairement au reste de ce
+  /// fichier. `StreamingApi.streamPlaylist` est typé `Response<String>` pour le
+  /// chemin nominal (le `.m3u8`), et sa désérialisation traverse un `case
+  /// 'String': return '$value'` : un corps d'erreur JSON en ressort **stringifié
+  /// à la Dart** (`{error: {code: stream_not_live}}`, sans guillemets), donc
+  /// illisible par `jsonDecode`. Or c'est précisément ce corps qu'on vient
+  /// chercher ici. Le Dio brut est le même instance que celui du client généré —
+  /// mêmes intercepteurs (trace, auth, log), même `baseUrl` : la lecture
+  /// propriétaire d'un flux privé continue de porter son `Bearer`.
+  Future<ManifestStatus> manifestStatus(String streamId) async {
     try {
-      final response = await _api.streamPlaylist(
-        id: streamId,
-        validateStatus: (status) => status != null && status < 500,
+      final response = await _dio.get<dynamic>(
+        ApiConstants.playlistPath(streamId),
+        options: Options(
+          validateStatus: (status) => status != null && status < 500,
+        ),
       );
-      final code = response.statusCode;
-      return code == 404 || code == 409;
+      switch (response.statusCode) {
+        case 200:
+          return ManifestStatus.available;
+        // Flux absent, archivé, ou devenu privé : pour un auditeur, c'est fini.
+        case 404:
+          return ManifestStatus.ended;
+        case 409:
+          // Seule la fin de direct est un verdict définitif, et elle doit donc
+          // être reconnue **explicitement**. Tout autre 409 — y compris un code
+          // inconnu, face à un backend plus ancien que cette version — retombe
+          // sur « pas encore prêt » : au pire l'auditeur attend le temps des
+          // reconnexions bornées, alors que l'erreur inverse couperait un direct
+          // en train de démarrer. C'est exactement le bug que STR-229 corrige,
+          // on ne le réintroduit pas par le défaut.
+          return _errorCode(response.data) == _codeStreamNotLive
+              ? ManifestStatus.ended
+              : ManifestStatus.notReady;
+        default:
+          return ManifestStatus.unknown; // 503 (capacité), 4xx inattendu…
+      }
     } on DioException {
-      return false; // réseau indéterminé → on ne conclut pas
+      return ManifestStatus.unknown; // réseau indéterminé → on ne conclut pas
     }
+  }
+
+  /// Code publié par le backend pour « aucune session live » (STR-229). Les
+  /// deux valeurs sont documentées sur la réponse 409 de `openapi.yaml` ; seule
+  /// celle-ci est décisive côté client, l'autre est le défaut.
+  static const _codeStreamNotLive = 'stream_not_live';
+
+  /// Extrait `error.code` d'un corps d'erreur, ou `null` si la forme n'est pas
+  /// celle attendue. Tolérant par construction : un corps inattendu doit mener
+  /// au défaut prudent, jamais à une exception dans une sonde de reprise.
+  static String? _errorCode(dynamic data) {
+    if (data is! Map) return null;
+    final error = data['error'];
+    if (error is! Map) return null;
+    final code = error['code'];
+    return code is String ? code : null;
   }
 }

--- a/mobile/lib/features/streams/data/datasources/stream_remote_data_source.dart
+++ b/mobile/lib/features/streams/data/datasources/stream_remote_data_source.dart
@@ -92,10 +92,17 @@ class StreamRemoteDataSource {
               ? ManifestStatus.ended
               : ManifestStatus.notReady;
         default:
-          return ManifestStatus.unknown; // 503 (capacité), 4xx inattendu…
+          // 4xx inattendu. Les 5xx n'arrivent pas ici : `validateStatus` les
+          // rejette, ils partent en `DioException` et sont traités ci-dessous.
+          return ManifestStatus.unknown;
       }
     } on DioException {
-      return ManifestStatus.unknown; // réseau indéterminé → on ne conclut pas
+      // Réseau indisponible, mais **aussi** tout ≥500 — dont le 503 de capacité
+      // auditeurs atteinte (`HLS_MAX_CONCURRENT`). Le direct est alors bien
+      // vivant : le serveur refuse temporairement de le servir. `unknown` est
+      // donc le bon verdict, et surtout pas `ended`, qui annoncerait une fin de
+      // direct inexistante à tous les auditeurs refusés d'un flux populaire.
+      return ManifestStatus.unknown;
     }
   }
 

--- a/mobile/lib/features/streams/data/repositories/stream_repository_impl.dart
+++ b/mobile/lib/features/streams/data/repositories/stream_repository_impl.dart
@@ -1,4 +1,5 @@
 import '../../domain/entities/live_stream.dart';
+import '../../domain/entities/manifest_status.dart';
 import '../../domain/repositories/stream_repository.dart';
 import '../datasources/stream_remote_data_source.dart';
 import '../mappers/stream_dto_mappers.dart';
@@ -31,6 +32,6 @@ class StreamRepositoryImpl implements StreamRepository {
       _remote.removeFavorite(streamId);
 
   @override
-  Future<bool> isManifestUnavailable(String streamId) =>
-      _remote.isManifestUnavailable(streamId);
+  Future<ManifestStatus> manifestStatus(String streamId) =>
+      _remote.manifestStatus(streamId);
 }

--- a/mobile/lib/features/streams/domain/entities/manifest_status.dart
+++ b/mobile/lib/features/streams/domain/entities/manifest_status.dart
@@ -1,0 +1,21 @@
+/// Verdict du serveur sur le manifeste HLS d'un flux (STR-229).
+///
+/// Le statut HTTP ne suffit pas à décider : le backend rend `409` aussi bien
+/// pour un direct terminé que pour un direct qui démarre. Les deux appellent des
+/// conduites **opposées** — abandonner ou patienter — d'où une énumération
+/// plutôt qu'un booléen « indisponible », qui forçait l'appelant à deviner.
+enum ManifestStatus {
+  /// Manifeste servi : le direct est en cours.
+  available,
+
+  /// Aucune session live : direct terminé, ou jamais démarré. Verdict définitif,
+  /// rien à attendre.
+  ended,
+
+  /// Session vivante, manifeste pas encore écrit — la fenêtre entre le start et
+  /// le premier segment (~10 s). État transitoire : réessayer a du sens.
+  notReady,
+
+  /// Le serveur n'a pas répondu, ou a répondu autre chose : on ne conclut pas.
+  unknown,
+}

--- a/mobile/lib/features/streams/domain/repositories/stream_repository.dart
+++ b/mobile/lib/features/streams/domain/repositories/stream_repository.dart
@@ -1,4 +1,5 @@
 import '../entities/live_stream.dart';
+import '../entities/manifest_status.dart';
 
 abstract class StreamRepository {
   Future<List<LiveStream>> listLiveStreams({int limit, int offset});
@@ -12,9 +13,11 @@ abstract class StreamRepository {
   /// Retire le flux des favoris (idempotent côté serveur).
   Future<void> removeFavorite(String streamId);
 
-  /// `true` si le manifeste HLS public n'est plus servi (404/409), `false` sinon
-  /// (200 en direct, ou réseau indéterminé). Le 409 étant ambigu (fin de direct
-  /// **ou** démarrage pas encore prêt), c'est le lecteur qui lève l'ambiguïté
-  /// (STR-118/109).
-  Future<bool> isManifestUnavailable(String streamId);
+  /// Interroge le manifeste HLS **public** du flux et rend le verdict du
+  /// serveur : direct en cours, terminé, en cours de démarrage, ou indéterminé.
+  ///
+  /// C'est le serveur qui tranche entre « terminé » et « pas encore prêt »
+  /// (STR-229) — lui seul sait si une session existe. Le lecteur se contentait
+  /// autrefois d'un booléen et devait deviner.
+  Future<ManifestStatus> manifestStatus(String streamId);
 }

--- a/mobile/lib/features/streams/presentation/providers/audio_player_controller.dart
+++ b/mobile/lib/features/streams/presentation/providers/audio_player_controller.dart
@@ -6,6 +6,7 @@ import 'package:just_audio/just_audio.dart' show PlayerState, ProcessingState;
 import '../../../../core/audio/audio_playback_service.dart';
 import '../../../../core/constants/api_constants.dart';
 import '../../../../core/audio/listening_clock.dart';
+import '../../domain/entities/manifest_status.dart';
 
 export '../../../../core/audio/audio_playback_service.dart'
     show NowPlaying, PlaybackStatus;
@@ -46,11 +47,11 @@ abstract class PlaybackController extends ChangeNotifier {
   Future<void> stop();
 }
 
-/// Sonde le manifeste HLS **public** : `true` s'il n'est plus servi (404/409),
-/// `false` sinon (200 en direct, ou réseau indéterminé). Le 409 étant ambigu
-/// (fin de direct **ou** démarrage pas encore prêt), le contrôleur ne conclut
-/// « terminé » qu'en le combinant à [_hasPlayed] (STR-118/109).
-typedef ManifestUnavailableProbe = Future<bool> Function(String streamId);
+/// Sonde le manifeste HLS **public** et rend le verdict du serveur (STR-229).
+///
+/// C'est le serveur qui distingue une fin de direct d'un démarrage en cours : le
+/// contrôleur applique la décision au lieu de la deviner.
+typedef ManifestStatusProbe = Future<ManifestStatus> Function(String streamId);
 
 /// Contrôleur du lecteur audio HLS, **hissé au niveau application** (STR-109,
 /// cf. [ADR 031]). Pilote un [AudioPlaybackService] partagé (service de premier
@@ -66,22 +67,25 @@ typedef ManifestUnavailableProbe = Future<bool> Function(String streamId);
 class AudioPlayerController extends PlaybackController {
   AudioPlayerController({
     required AudioPlaybackService service,
-    ManifestUnavailableProbe? isManifestUnavailable,
+    ManifestStatusProbe? manifestStatus,
   })  : _service = service,
-        _isManifestUnavailable = isManifestUnavailable {
+        _manifestStatus = manifestStatus {
     _stateSub = _service.playerStateStream.listen(_onPlayerState);
     // Les erreurs de lecture (perte réseau, flux terminé → manifeste 404/409)
     // arrivent via un flux dédié, pas via playerStateStream.
     _errorSub = _service.playbackErrors.listen(_fail);
   }
 
-  /// Nombre de reconnexions automatiques avant d'abandonner (STR-118). Couvre
-  /// aussi la fenêtre de démarrage du manifeste (~10 s, segments HLS de 10 s) :
-  /// backoff 1+2+4+8 = 15 s avant de conclure sur un flux qui n'a jamais démarré.
+  /// Nombre de reconnexions automatiques avant d'abandonner (STR-118). Couvre la
+  /// fenêtre de démarrage du manifeste (~10 s, segments HLS de 10 s) : backoff
+  /// 1+2+4+8 = 15 s.
+  ///
+  /// Ce budget ne s'applique **plus** à un direct terminé (STR-229) : le serveur
+  /// le dit désormais dès la première sonde, et le verdict tombe sans attendre.
   static const int _maxAutoRetries = 4;
 
   final AudioPlaybackService _service;
-  final ManifestUnavailableProbe? _isManifestUnavailable;
+  final ManifestStatusProbe? _manifestStatus;
   StreamSubscription<PlayerState>? _stateSub;
   StreamSubscription<Object>? _errorSub;
   Timer? _retryTimer;
@@ -90,10 +94,6 @@ class AudioPlayerController extends PlaybackController {
   int _retryCount = 0;
   bool _recovering = false;
   bool _disposed = false;
-  // La lecture a-t-elle déjà atteint `ready` sur ce flux ? Sert à lever
-  // l'ambiguïté du 409 : si oui, un manifeste qui disparaît = fin de direct ; si
-  // non, c'est probablement la fenêtre de démarrage (manifeste pas encore prêt).
-  bool _hasPlayed = false;
   PlaybackStatus _status = PlaybackStatus.idle;
 
   /// Horloge du temps d'écoute (STR-244). Pilotée par les transitions d'état
@@ -138,7 +138,6 @@ class AudioPlayerController extends PlaybackController {
     }
     _nowPlaying = now;
     _retryCount = 0;
-    _hasPlayed = false;
     await _start();
   }
 
@@ -180,7 +179,6 @@ class AudioPlayerController extends PlaybackController {
   Future<void> stop() async {
     _retryTimer?.cancel();
     _retryCount = 0;
-    _hasPlayed = false;
     _nowPlaying = null;
     _error = null;
     await _service.stop();
@@ -220,7 +218,6 @@ class AudioPlayerController extends PlaybackController {
         _setStatus(PlaybackStatus.buffering);
       case ProcessingState.ready:
         _retryCount = 0; // lecture rétablie : on réarme les reconnexions futures
-        _hasPlayed = true; // le manifeste a été servi au moins une fois
         _setStatus(
           state.playing ? PlaybackStatus.playing : PlaybackStatus.paused,
         );
@@ -241,13 +238,13 @@ class AudioPlayerController extends PlaybackController {
     _recover();
   }
 
-  /// Décide de la suite après un échec (STR-118/109).
+  /// Décide de la suite après un échec (STR-118/109/229).
   ///
-  /// On ne sonde le manifeste que lorsque c'est **décisif** : soit la lecture
-  /// avait démarré (sa disparition = fin de direct → `ended` immédiat), soit les
-  /// reconnexions sont épuisées (verdict final). Pendant la fenêtre de démarrage
-  /// (jamais joué, manifeste pas encore prêt → 409, comme une fin de direct) on
-  /// **reconnecte d'abord** plutôt que de conclure à tort « terminé ».
+  /// La sonde est **systématique** et son verdict fait autorité : c'est le
+  /// serveur qui sait si une session existe encore. Auparavant il ne rendait
+  /// qu'un 409 indistinct, et ce contrôleur devait deviner à partir de
+  /// « la lecture avait-elle démarré ? » — au prix de 15 s de reconnexions
+  /// inutiles sur un direct qu'on savait déjà terminé (STR-229).
   Future<void> _recover() async {
     if (_recovering) return; // une seule reprise à la fois (échecs en rafale)
     _recovering = true;
@@ -257,24 +254,24 @@ class AudioPlayerController extends PlaybackController {
         _setStatus(PlaybackStatus.error);
         return;
       }
-      final retriesExhausted = _retryCount >= _maxAutoRetries;
-      final probe = _isManifestUnavailable;
-      final manifestGone = probe != null &&
-          (_hasPlayed || retriesExhausted) &&
-          await probe(id);
+      final probe = _manifestStatus;
+      final status =
+          probe == null ? ManifestStatus.unknown : await probe(id);
       // La sonde est asynchrone : si entre-temps l'utilisateur a fermé le
       // lecteur (`stop()`) ou lancé un autre flux, cette reprise est caduque.
       if (_disposed || _nowPlaying?.streamId != id) return;
 
-      // La lecture avait démarré et le manifeste a disparu → fin de direct.
-      if (manifestGone && _hasPlayed) {
+      // Le serveur affirme qu'il n'y a plus de session : verdict immédiat, sans
+      // reconnexion d'attente. C'est tout l'objet de STR-229.
+      if (status == ManifestStatus.ended) {
         _setStatus(PlaybackStatus.ended);
         await _service.stop(); // retire la notification (le direct est fini)
         return;
       }
+
       // Reconnexion automatique bornée (coupure réseau, ou manifeste pas encore
       // prêt au démarrage) avec backoff 1, 2, 4, 8 s.
-      if (!retriesExhausted) {
+      if (_retryCount < _maxAutoRetries) {
         _retryCount++;
         _setStatus(PlaybackStatus.reconnecting);
         final delay = Duration(seconds: 1 << (_retryCount - 1));
@@ -284,9 +281,18 @@ class AudioPlayerController extends PlaybackController {
         });
         return;
       }
-      // Tentatives épuisées : manifeste jamais servi = flux terminé / pas live ;
-      // sinon indisponibilité réseau.
-      _setStatus(manifestGone ? PlaybackStatus.ended : PlaybackStatus.error);
+
+      // Tentatives épuisées. Un manifeste toujours pas servi après tout ce
+      // temps — diffuseur qui a démarré sans jamais pousser d'audio, ou session
+      // éteinte entre deux sondes — vaut fin de direct : c'est le message le
+      // plus juste pour l'auditeur, et c'est déjà ce que faisait la version
+      // précédente. Un manifeste servi alors que la lecture échoue est en
+      // revanche une indisponibilité réseau ou lecteur.
+      _setStatus(
+        status == ManifestStatus.notReady
+            ? PlaybackStatus.ended
+            : PlaybackStatus.error,
+      );
       await _service.stop(); // notification retirée
     } finally {
       _recovering = false;

--- a/mobile/test/features/profile/presentation/screens/profile_screen_test.dart
+++ b/mobile/test/features/profile/presentation/screens/profile_screen_test.dart
@@ -15,6 +15,7 @@ import 'package:streampulse/features/profile/domain/repositories/profile_reposit
 import 'package:streampulse/features/profile/presentation/providers/profile_controller.dart';
 import 'package:streampulse/features/profile/presentation/screens/profile_screen.dart';
 import 'package:streampulse/features/streams/domain/entities/live_stream.dart';
+import 'package:streampulse/features/streams/domain/entities/manifest_status.dart';
 import 'package:streampulse/features/streams/domain/repositories/stream_repository.dart';
 import 'package:streampulse/features/streams/presentation/providers/favorites_controller.dart';
 
@@ -83,7 +84,8 @@ class _FakeStreamRepository implements StreamRepository {
       const [];
 
   @override
-  Future<bool> isManifestUnavailable(String streamId) async => false;
+  Future<ManifestStatus> manifestStatus(String streamId) async =>
+      ManifestStatus.available;
 }
 
 class _FakeProfileRepository implements ProfileRepository {

--- a/mobile/test/features/streams/data/datasources/stream_remote_data_source_test.dart
+++ b/mobile/test/features/streams/data/datasources/stream_remote_data_source_test.dart
@@ -97,6 +97,10 @@ void main() {
       // Le direct est bien vivant : le serveur refuse temporairement de servir.
       // Conclure « terminé » ici afficherait une fin de direct inexistante à
       // tous les auditeurs refusés d'un flux populaire.
+      //
+      // Le verdict passe par le `catch` et non par le `switch` : `validateStatus`
+      // n'accepte que les <500, un 503 lève donc une `DioException`. Ce test
+      // vaut pour le comportement observable, indépendamment de ce chemin.
       adapter.onGet(
         path,
         (server) => server.reply(503, {

--- a/mobile/test/features/streams/data/datasources/stream_remote_data_source_test.dart
+++ b/mobile/test/features/streams/data/datasources/stream_remote_data_source_test.dart
@@ -1,0 +1,125 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http_mock_adapter/http_mock_adapter.dart';
+import 'package:streampulse_api/streampulse_api.dart';
+
+import 'package:streampulse/core/constants/api_constants.dart';
+import 'package:streampulse/features/streams/data/datasources/stream_remote_data_source.dart';
+import 'package:streampulse/features/streams/domain/entities/manifest_status.dart';
+
+/// Verrouille la traduction « réponse HTTP du manifeste → verdict » (STR-229).
+///
+/// C'est le seul endroit du client qui *interprète* un code d'erreur métier
+/// plutôt que de l'afficher, et l'interprétation gouverne un choix visible pour
+/// l'auditeur : annoncer la fin du direct, ou patienter. De vraies réponses
+/// passent donc par un vrai `Dio`, plutôt qu'un faux datasource — le mapping
+/// lui-même est ce qu'on teste.
+void main() {
+  late Dio dio;
+  late DioAdapter adapter;
+  late StreamRemoteDataSource dataSource;
+
+  const streamId = 's1';
+  final path = ApiConstants.playlistPath(streamId);
+
+  setUp(() {
+    dio = Dio(BaseOptions(baseUrl: 'https://api.test'));
+    adapter = DioAdapter(dio: dio);
+    dataSource = StreamRemoteDataSource(StreamingApi(dio), dio);
+  });
+
+  group('manifestStatus', () {
+    test('200 → available', () async {
+      adapter.onGet(path, (server) => server.reply(200, '#EXTM3U'));
+
+      expect(await dataSource.manifestStatus(streamId), ManifestStatus.available);
+    });
+
+    test('409 stream_not_live → ended', () async {
+      adapter.onGet(
+        path,
+        (server) => server.reply(409, {
+          'error': {'code': 'stream_not_live', 'message': 'stream is not live'},
+        }),
+      );
+
+      expect(await dataSource.manifestStatus(streamId), ManifestStatus.ended);
+    });
+
+    test('409 manifest_not_ready → notReady', () async {
+      adapter.onGet(
+        path,
+        (server) => server.reply(409, {
+          'error': {
+            'code': 'manifest_not_ready',
+            'message': 'stream manifest is not ready yet',
+          },
+        }),
+      );
+
+      expect(await dataSource.manifestStatus(streamId), ManifestStatus.notReady);
+    });
+
+    test('404 (flux absent, archivé ou privé) → ended', () async {
+      adapter.onGet(
+        path,
+        (server) => server.reply(404, {
+          'error': {'code': 'not_found', 'message': 'stream not found'},
+        }),
+      );
+
+      expect(await dataSource.manifestStatus(streamId), ManifestStatus.ended);
+    });
+
+    test('409 sans code reconnu → notReady (défaut prudent)', () async {
+      // Le cas d'un backend antérieur à STR-229, qui rend un `conflict` nu.
+      // Le défaut doit pencher vers l'attente : se tromper dans l'autre sens
+      // couperait un direct en train de démarrer — précisément le bug corrigé.
+      adapter.onGet(
+        path,
+        (server) => server.reply(409, {
+          'error': {'code': 'conflict', 'message': 'stream is not live'},
+        }),
+      );
+
+      expect(await dataSource.manifestStatus(streamId), ManifestStatus.notReady);
+    });
+
+    test('409 au corps inattendu → notReady, sans lever', () async {
+      // Une sonde de reprise ne doit jamais échouer sur la forme du corps :
+      // elle est appelée depuis un chemin de récupération d'erreur.
+      adapter.onGet(path, (server) => server.reply(409, 'pas du json'));
+
+      expect(await dataSource.manifestStatus(streamId), ManifestStatus.notReady);
+    });
+
+    test('503 (capacité auditeurs atteinte) → unknown, jamais ended', () async {
+      // Le direct est bien vivant : le serveur refuse temporairement de servir.
+      // Conclure « terminé » ici afficherait une fin de direct inexistante à
+      // tous les auditeurs refusés d'un flux populaire.
+      adapter.onGet(
+        path,
+        (server) => server.reply(503, {
+          'error': {'code': 'unavailable', 'message': 'at capacity'},
+        }),
+      );
+
+      expect(await dataSource.manifestStatus(streamId), ManifestStatus.unknown);
+    });
+
+    test('réseau indisponible → unknown', () async {
+      adapter.onGet(
+        path,
+        (server) => server.throws(
+          0,
+          DioException(
+            requestOptions: RequestOptions(path: path),
+            type: DioExceptionType.connectionError,
+          ),
+        ),
+      );
+
+      expect(await dataSource.manifestStatus(streamId), ManifestStatus.unknown);
+    });
+  });
+}

--- a/mobile/test/features/streams/presentation/providers/audio_player_controller_test.dart
+++ b/mobile/test/features/streams/presentation/providers/audio_player_controller_test.dart
@@ -3,26 +3,60 @@ import 'dart:async';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:just_audio/just_audio.dart' show PlayerState, ProcessingState;
+import 'package:streampulse/features/streams/domain/entities/manifest_status.dart';
 import 'package:streampulse/features/streams/presentation/providers/audio_player_controller.dart';
 
 import '../../../../support/fake_audio_playback_service.dart';
 
 const _now = NowPlaying(streamId: 's1', title: 'Flux test', broadcaster: 'DJ');
 
-/// Amène le contrôleur à l'état `playing` (le manifeste a été servi au moins une
-/// fois → `_hasPlayed`).
+/// Amène le contrôleur à l'état `playing`.
 void _reachPlaying(FakeAudioPlaybackService service) {
   service.emitState(PlayerState(true, ProcessingState.ready));
 }
 
 void main() {
-  group('AudioPlayerController._recover (STR-118 / STR-109)', () {
-    test('lecture démarrée puis manifeste disparu → ended immédiat, notif retirée',
+  group('AudioPlayerController._recover (STR-118 / STR-109 / STR-229)', () {
+    test(
+        'flux déjà terminé, jamais joué → ended immédiat, sans consommer le backoff',
+        () {
+      // Le cas que STR-229 corrige : ouvrir un direct fini depuis une liste
+      // Découvrir périmée. Le serveur le sait (`stream_not_live`), le contrôleur
+      // n'a plus à le deviner à partir de « la lecture avait-elle démarré ? ».
+      //
+      // fakeAsync ici plutôt que async/await : l'assertion qui compte n'est pas
+      // seulement le verdict, c'est qu'il tombe **sans écouler de temps**. Avant,
+      // ce scénario coûtait 15 s de « Reconnexion… » (backoff 1+2+4+8).
+      fakeAsync((async) {
+        final service = FakeAudioPlaybackService()..loadError = Exception('409');
+        final controller = AudioPlayerController(
+          service: service,
+          manifestStatus: (_) async => ManifestStatus.ended,
+        );
+
+        controller.load(_now);
+        async.flushMicrotasks();
+
+        expect(controller.status, PlaybackStatus.ended);
+        expect(service.stopped, isTrue);
+        expect(service.loadCalls, 1); // aucune reconnexion tentée
+
+        // Et aucun timer résiduel : rien ne doit repartir après coup.
+        async.elapse(const Duration(seconds: 20));
+        async.flushMicrotasks();
+        expect(service.loadCalls, 1);
+        expect(controller.status, PlaybackStatus.ended);
+
+        controller.dispose();
+      });
+    });
+
+    test('lecture démarrée puis flux terminé → ended immédiat, notif retirée',
         () async {
       final service = FakeAudioPlaybackService();
       final controller = AudioPlayerController(
         service: service,
-        isManifestUnavailable: (_) async => true,
+        manifestStatus: (_) async => ManifestStatus.ended,
       );
       addTearDown(controller.dispose);
 
@@ -31,8 +65,8 @@ void main() {
       await pumpEventQueue();
       expect(controller.status, PlaybackStatus.playing);
 
-      // Le diffuseur arrête : le player émet une erreur, le manifeste ne répond
-      // plus. Comme la lecture avait démarré → fin de direct, sans reconnexion.
+      // Le diffuseur arrête : le player émet une erreur et le serveur confirme
+      // qu'il n'y a plus de session → fin de direct, sans reconnexion.
       service.emitError(Exception('source error'));
       await pumpEventQueue();
 
@@ -41,15 +75,15 @@ void main() {
       expect(service.loadCalls, 1);
     });
 
-    test(
-        'démarrage jamais joué : manifeste 409 (pas prêt) → reconnexion, pas de faux « terminé »',
+    test('manifeste pas encore prêt → reconnexion, pas de faux « terminé »',
         () async {
-      // Le manifeste répond 409 comme s'il était terminé, mais c'est la fenêtre
-      // de démarrage : `_hasPlayed` étant faux, on ne doit PAS conclure « ended ».
+      // Fenêtre de démarrage (~10 s) : le serveur répond 409 lui aussi, mais avec
+      // `manifest_not_ready`. Conclure « terminé » ici couperait un direct qui
+      // démarre — c'est l'erreur que l'ambiguïté rendait possible.
       final service = FakeAudioPlaybackService()..loadError = Exception('409');
       final controller = AudioPlayerController(
         service: service,
-        isManifestUnavailable: (_) async => true,
+        manifestStatus: (_) async => ManifestStatus.notReady,
       );
       addTearDown(controller.dispose);
 
@@ -65,7 +99,7 @@ void main() {
         final service = FakeAudioPlaybackService()..loadError = Exception('409');
         final controller = AudioPlayerController(
           service: service,
-          isManifestUnavailable: (_) async => true,
+          manifestStatus: (_) async => ManifestStatus.notReady,
         );
 
         controller.load(_now);
@@ -73,8 +107,9 @@ void main() {
         expect(controller.status, PlaybackStatus.reconnecting);
         expect(service.loadCalls, 1);
 
-        // Backoff 1+2+4+8 = 15 s ; à l'épuisement le manifeste répond toujours
-        // 409 → verdict « terminé » (flux jamais réellement servi).
+        // Backoff 1+2+4+8 = 15 s ; à l'épuisement le manifeste n'est toujours pas
+        // servi (diffuseur qui a démarré sans jamais pousser d'audio) → verdict
+        // « terminé », comme avant STR-229.
         async.elapse(const Duration(seconds: 15));
         async.flushMicrotasks();
 
@@ -86,13 +121,13 @@ void main() {
       });
     });
 
-    test('coupure réseau (sonde false) → error après épuisement', () {
+    test('coupure réseau (verdict indéterminé) → error après épuisement', () {
       fakeAsync((async) {
         final service = FakeAudioPlaybackService()
           ..loadError = Exception('network');
         final controller = AudioPlayerController(
           service: service,
-          isManifestUnavailable: (_) async => false,
+          manifestStatus: (_) async => ManifestStatus.unknown,
         );
 
         controller.load(_now);
@@ -114,11 +149,33 @@ void main() {
       });
     });
 
+    test('manifeste servi mais lecture en échec → error, pas ended', () {
+      // Le serveur sert le manifeste : le problème est côté réseau ou lecteur,
+      // pas côté direct. Annoncer « terminé » induirait l'auditeur en erreur.
+      fakeAsync((async) {
+        final service = FakeAudioPlaybackService()
+          ..loadError = Exception('decoder');
+        final controller = AudioPlayerController(
+          service: service,
+          manifestStatus: (_) async => ManifestStatus.available,
+        );
+
+        controller.load(_now);
+        async.elapse(const Duration(seconds: 15));
+        async.flushMicrotasks();
+
+        expect(controller.status, PlaybackStatus.error);
+        expect(controller.isEnded, isFalse);
+
+        controller.dispose();
+      });
+    });
+
     test('état résiduel idle après ended → non écrasé', () async {
       final service = FakeAudioPlaybackService();
       final controller = AudioPlayerController(
         service: service,
-        isManifestUnavailable: (_) async => true,
+        manifestStatus: (_) async => ManifestStatus.ended,
       );
       addTearDown(controller.dispose);
 
@@ -139,10 +196,10 @@ void main() {
     test('dispose() pendant l\'attente de la sonde → aucune notification',
         () async {
       final service = FakeAudioPlaybackService();
-      final probe = Completer<bool>();
+      final probe = Completer<ManifestStatus>();
       final controller = AudioPlayerController(
         service: service,
-        isManifestUnavailable: (_) => probe.future,
+        manifestStatus: (_) => probe.future,
       );
 
       await controller.load(_now);
@@ -155,13 +212,13 @@ void main() {
         if (disposed) notificationsAfterDispose++;
       });
 
-      service.emitError(Exception('x')); // → _recover attend la sonde (hasPlayed)
+      service.emitError(Exception('x')); // → _recover attend la sonde
       await pumpEventQueue();
 
       disposed = true;
       controller.dispose();
 
-      probe.complete(true);
+      probe.complete(ManifestStatus.ended);
       await pumpEventQueue();
 
       expect(notificationsAfterDispose, 0);
@@ -185,26 +242,44 @@ void main() {
     test('stop() pendant la sonde → la reprise caduque ne rebloque pas l\'état',
         () async {
       final service = FakeAudioPlaybackService();
-      final probe = Completer<bool>();
+      final probe = Completer<ManifestStatus>();
       final controller = AudioPlayerController(
         service: service,
-        isManifestUnavailable: (_) => probe.future,
+        manifestStatus: (_) => probe.future,
       );
       addTearDown(controller.dispose);
 
       await controller.load(_now);
       _reachPlaying(service);
       await pumpEventQueue();
-      service.emitError(Exception('x')); // _recover attend la sonde (hasPlayed)
+      service.emitError(Exception('x')); // _recover attend la sonde
       await pumpEventQueue();
 
       await controller.stop(); // l'utilisateur ferme le lecteur pendant la sonde
-      probe.complete(false); // la sonde se résout après coup
+      probe.complete(ManifestStatus.available); // la sonde se résout après coup
       await pumpEventQueue();
 
       // La reprise doit avorter (flux courant changé) et laisser l'état à idle,
       // pas le rebloquer sur « reconnexion ».
       expect(controller.status, PlaybackStatus.idle);
+    });
+
+    test('sans sonde câblée → reconnexions bornées puis error', () {
+      // Le paramètre est optionnel (widget tests). Sans lui, aucun verdict
+      // serveur n'est disponible : le contrôleur ne doit rien inventer.
+      fakeAsync((async) {
+        final service = FakeAudioPlaybackService()..loadError = Exception('x');
+        final controller = AudioPlayerController(service: service);
+
+        controller.load(_now);
+        async.elapse(const Duration(seconds: 15));
+        async.flushMicrotasks();
+
+        expect(service.loadCalls, 5);
+        expect(controller.status, PlaybackStatus.error);
+
+        controller.dispose();
+      });
     });
   });
 }

--- a/mobile/test/features/streams/presentation/providers/favorites_controller_test.dart
+++ b/mobile/test/features/streams/presentation/providers/favorites_controller_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:streampulse/core/errors/exceptions.dart';
 import 'package:streampulse/features/streams/domain/entities/live_stream.dart';
+import 'package:streampulse/features/streams/domain/entities/manifest_status.dart';
 import 'package:streampulse/features/streams/domain/repositories/stream_repository.dart';
 import 'package:streampulse/features/streams/presentation/providers/favorites_controller.dart';
 
@@ -38,7 +39,8 @@ class _FakeRepository implements StreamRepository {
       const [];
 
   @override
-  Future<bool> isManifestUnavailable(String streamId) async => false;
+  Future<ManifestStatus> manifestStatus(String streamId) async =>
+      ManifestStatus.available;
 }
 
 void main() {

--- a/mobile/test/features/streams/presentation/providers/stream_notifier_test.dart
+++ b/mobile/test/features/streams/presentation/providers/stream_notifier_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:streampulse/core/errors/exceptions.dart';
 import 'package:streampulse/features/streams/domain/entities/live_stream.dart';
+import 'package:streampulse/features/streams/domain/entities/manifest_status.dart';
 import 'package:streampulse/features/streams/domain/repositories/stream_repository.dart';
 import 'package:streampulse/features/streams/presentation/providers/stream_notifier.dart';
 
@@ -34,7 +35,8 @@ class _FakeRepository implements StreamRepository {
   Future<void> removeFavorite(String streamId) async {}
 
   @override
-  Future<bool> isManifestUnavailable(String streamId) async => false;
+  Future<ManifestStatus> manifestStatus(String streamId) async =>
+      ManifestStatus.available;
 }
 
 class _PagingRepository implements StreamRepository {
@@ -59,7 +61,8 @@ class _PagingRepository implements StreamRepository {
   Future<void> removeFavorite(String streamId) async {}
 
   @override
-  Future<bool> isManifestUnavailable(String streamId) async => false;
+  Future<ManifestStatus> manifestStatus(String streamId) async =>
+      ManifestStatus.available;
 }
 
 void main() {

--- a/mobile/test/features/streams/presentation/screens/stream_player_screen_test.dart
+++ b/mobile/test/features/streams/presentation/screens/stream_player_screen_test.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'package:toastification/toastification.dart';
 
 import 'package:streampulse/features/streams/domain/entities/live_stream.dart';
+import 'package:streampulse/features/streams/domain/entities/manifest_status.dart';
 import 'package:streampulse/features/streams/domain/repositories/stream_repository.dart';
 import 'package:streampulse/features/streams/presentation/providers/audio_player_controller.dart';
 import 'package:streampulse/features/streams/presentation/providers/favorites_controller.dart';
@@ -95,7 +96,8 @@ class _FakeStreamRepository implements StreamRepository {
       const [];
 
   @override
-  Future<bool> isManifestUnavailable(String streamId) async => false;
+  Future<ManifestStatus> manifestStatus(String streamId) async =>
+      ManifestStatus.available;
 }
 
 Widget _harness({

--- a/mobile/test/features/streams/presentation/widgets/mini_player_test.dart
+++ b/mobile/test/features/streams/presentation/widgets/mini_player_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:just_audio/just_audio.dart' show PlayerState, ProcessingState;
 import 'package:provider/provider.dart';
 
+import 'package:streampulse/features/streams/domain/entities/manifest_status.dart';
 import 'package:streampulse/features/streams/presentation/providers/audio_player_controller.dart';
 import 'package:streampulse/features/streams/presentation/widgets/mini_player.dart';
 
@@ -73,7 +74,7 @@ void main() {
     final service = FakeAudioPlaybackService();
     final controller = AudioPlayerController(
       service: service,
-      isManifestUnavailable: (_) async => true,
+      manifestStatus: (_) async => ManifestStatus.ended,
     );
     addTearDown(controller.dispose);
     addTearDown(service.dispose);


### PR DESCRIPTION
Closes #285 — STR-229.

## Le problème

`GET /api/streams/{id}/playlist.m3u8` rendait exactement la même erreur dans deux situations qui n'ont rien à voir :

- **flux terminé** — plus aucune session live (`lookup` rend `ok == false`) ;
- **flux live en démarrage** — la session existe, mais ffmpeg n'a pas encore écrit le premier segment (~10 s).

Les deux branches de `serveHLSFile` écrivaient `apperror.Conflict("stream is not live")`. Le client recevait un `409` indistinct — alors que le serveur, lui, connaissait la différence.

Ce n'est pas cosmétique : les deux cas appellent des conduites **opposées**, abandonner ou patienter. Le lecteur mobile compensait avec une heuristique (`_hasPlayed`, ADR 031) et le payait cher — ouvrir un direct **déjà terminé** depuis une liste Découvrir périmée déclenchait les quatre reconnexions du backoff avant d'afficher « Le direct est terminé », soit **~15 s de « Reconnexion… »** pour annoncer une fin connue dès la première requête.

## Backend

- `serveHLSFile` prend deux erreurs (`notLive`, `notReady`) au lieu d'une.
- `Playlist` publie `stream_not_live` et `manifest_not_ready` via `apperror.Coded` — le mécanisme existait déjà (`PublicCode`, précédent `storage_quota_exceeded`), il n'était pas utilisé ici.
- **Le statut reste 409** : c'est bien un conflit d'état dans les deux cas. C'est la cause qui diffère, et le corps est fait pour ça. (Alternatives `425` / `503` écartées, argumentées dans l'ADR.)
- `Segment` passe volontairement la **même** valeur aux deux paramètres : ses deux causes d'indisponibilité appellent la même conduite chez le lecteur — redemander le manifeste. Un test fige cette asymétrie pour qu'elle ne soit pas « corrigée » plus tard comme un oubli.

## Mobile

- `ManifestStatus` (`available` / `ended` / `notReady` / `unknown`) remplace le booléen `isManifestUnavailable`. Le contrôleur **applique** le verdict du serveur au lieu de le reconstituer ; `_hasPlayed` disparaît.
- La sonde devient systématique — c'est ce qui permet le verdict immédiat. Une requête de plus par échec, sous le même plafond de reprises.
- **Le défaut penche vers l'attente** : un 409 au code non reconnu (backend antérieur à cette PR) retombe sur `notReady`. Se tromper vers l'attente coûte au pire le backoff borné déjà en place ; se tromper vers la fin couperait un direct en train de démarrer — le bug même qu'on corrige. On ne le réintroduit pas par le défaut.

### Un point qui mérite l'attention en revue

La sonde **ne passe pas** par le client généré, contrairement au reste de la couche data. `StreamingApi.streamPlaylist` est typé `Response<String>` pour le chemin nominal (le `.m3u8`) et sa désérialisation traverse un `case 'String': return '$value'` : un corps d'erreur JSON en ressort **stringifié à la Dart** (`{error: {code: stream_not_live}}`, sans guillemets), donc illisible par `jsonDecode`. Or c'est précisément ce corps qu'on vient chercher.

Elle utilise donc le `Dio` sous-jacent — **la même instance** que le client généré, donc les mêmes intercepteurs et le même `Bearer` : la lecture propriétaire d'un flux privé continue de fonctionner. `ApiConstants.playlistPath` est extrait et `hlsPlaylist` en dérive, pour que le lecteur natif et la sonde ne puissent pas viser des endpoints différents.

## Ce qui ne change pas

- Tentatives épuisées avec un manifeste toujours pas servi → toujours `ended` (diffuseur qui démarre sans jamais pousser d'audio).
- Manifeste servi mais lecture en échec → toujours `error`.
- Plafond de reprises et backoff 1/2/4/8 s inchangés.

## Vérification

| | |
|---|---|
| `go test ./...` | 14 paquets, tous verts |
| `gofmt -l` / `golangci-lint` | propre / `0 issues` |
| `flutter analyze` | `No issues found!` |
| `flutter test` | **521 tests**, tous verts |
| `make check-adr-index` | `45 ADR, toutes résumées` |

Tests ajoutés :

- `TestHandler_Playlist_NotLiveCodeDiffersFromNotReady` — l'assertion porte sur la **différence** ; la vérifier isolément laisserait passer une régression qui les ferait reconverger.
- `TestHandler_Segment_NotLiveAndNotReadyStayIdentical` — fige l'asymétrie assumée du segment.
- `TestOpenAPI_DocumenteLesDeuxCodesDu409` — relie les constantes Go aux exemples publiés dans `openapi.yaml`. C'est le seul code d'erreur du projet sur lequel un client **branche** au lieu de l'afficher : un renommage silencieux livrerait une app qui ne reconnaît plus rien.
- `stream_remote_data_source_test.dart` — 8 cas sur le mapping, dont le défaut prudent et le 503 (« capacité atteinte » ne doit **jamais** devenir « terminé »).
- Côté contrôleur, le test central utilise `fakeAsync` : l'assertion n'est pas seulement le verdict, c'est qu'il tombe **sans écouler de temps** (`loadCalls == 1`, aucun timer résiduel).

## Documentation

ADR 045 (décision, alternatives écartées) ; ADR 031 amendée sur le seul paragraphe concerné plutôt que marquée *superseded* ; `CLAUDE.md`, index FR et EN à jour.

## Note hors périmètre

`mobile/pubspec.lock` a bougé pendant le travail (downgrades transitifs dus à ma version locale du SDK Flutter) — écarté du commit, sans rapport avec le ticket.
