### PR TITLE
fix(ci): fiabiliser le build Android avec cache Gradle et retry

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -199,6 +199,22 @@ jobs:
           distribution: temurin
           java-version: "17"
 
+      # Cache des dépendances Gradle (plugins Kotlin/AGP, artefacts Maven). Sans
+      # lui, chaque release retélécharge tout depuis Maven Central / plugins.
+      # gradle.org et se fait throttler (HTTP 429) — la cause de l'échec du run
+      # #364. Un cache chaud évite l'essentiel de ces requêtes réseau. La clé
+      # dépend des fichiers de build : un changement de version de plugin ou du
+      # wrapper invalide le cache et force un retéléchargement propre.
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('mobile/android/**/*.gradle*', 'mobile/android/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
       # La clé de signature n'existe pas tant que personne ne l'a générée. Le
       # job ne doit pas échouer pour autant : un artefact signé en debug reste
       # utile pour installer et tester l'application, il n'est simplement pas
@@ -266,10 +282,33 @@ jobs:
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
         run: |
           set -euo pipefail
-          flutter build apk --release \
+
+          # Retry avec backoff exponentiel : le téléchargement des dépendances
+          # Gradle passe par Maven Central / plugins.gradle.org, qui renvoient
+          # des 429 (Too Many Requests) aux heures de pointe — c'est ce qui a
+          # fait échouer le run #364. Le retry interne de Flutter (une fois,
+          # 100 ms) est trop court pour un throttling. On relance jusqu'à 3 fois
+          # avec 30 s / 60 s d'attente, le temps que la fenêtre de rate-limit se
+          # rouvre. Une vraie erreur de compilation échoue aussi 3 fois : le
+          # retry ne masque donc pas un bug, il n'absorbe qu'un aléa réseau.
+          build_with_retry() {
+            local n=1 max=3 delay=30
+            until "$@"; do
+              if [ "$n" -ge "$max" ]; then
+                echo "::error::build échoué après $max tentatives : $*"
+                return 1
+              fi
+              echo "::warning::tentative $n/$max échouée, nouvelle tentative dans ${delay}s : $*"
+              sleep "$delay"
+              n=$((n + 1))
+              delay=$((delay * 2))
+            done
+          }
+
+          build_with_retry flutter build apk --release \
             --dart-define=API_BASE_URL=https://api.streampulse.win
           if [ "${{ steps.signing.outputs.available }}" = "true" ]; then
-            flutter build appbundle --release \
+            build_with_retry flutter build appbundle --release \
               --dart-define=API_BASE_URL=https://api.streampulse.win
           fi
 


### PR DESCRIPTION
## Contexte

La CD du run [#33341485999](https://github.com/LignacAntony/streampulse/actions/runs/33341485999) a échoué sur le job **Build mobile (Android)**. Le backend (Docker build, deploy VPS, release v1.4.0) est passé sans problème : seul l'APK n'a pas été produit.

## Cause

Erreur **réseau transitoire**, pas un bug de code. Gradle n'a pas pu télécharger les plugins Kotlin depuis Maven Central :

```
Could not GET '.../kotlin-gradle-plugins-bom-2.0.21.pom'.
Received status code 429 from server: Too Many Requests
BUILD FAILED
```

Le retry interne de Flutter (une seule fois, 100 ms) est trop court pour un throttling, et le job n'avait aucun cache Gradle : chaque release retélécharge tout depuis Maven et se fait rate-limiter.

## Changements

Dans le job `Build mobile (Android)` de `.github/workflows/cd.yml` :

- **Cache Gradle** (`~/.gradle/caches`, `~/.gradle/wrapper`), clé sur le hash des fichiers `*.gradle*` + wrapper. Les runs suivants ne retéléchargent plus les plugins → beaucoup moins de requêtes Maven, donc moins de 429.
- **Retry avec backoff exponentiel** autour de `flutter build` (jusqu'à 3 tentatives, 30 s puis 60 s). Absorbe le throttling transitoire. Une vraie erreur de compilation échoue quand même 3 fois : le retry ne masque pas un bug, il n'absorbe qu'un aléa réseau.

## Limites

- Le cache est froid au premier run après merge : c'est le retry qui protège cette première fois, puis le cache prend le relais.
- Aucun impact sur le warning de signature Android (secrets `ANDROID_KEYSTORE_*` manquants) : volontaire et non bloquant.

## Test

Le workflow ne se déclenchant que sur `main`, la validation réelle se fera au prochain déploiement. YAML validé localement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
