### PR TITLE
docs(ci): documenter l'activation de la signature APK release

### DIFF
--- a/docs/distribution-mobile.md
+++ b/docs/distribution-mobile.md
@@ -41,8 +41,16 @@ Sans ce passage, l'application embarquerait son défaut de développement
 
 ## 2. Signature — état actuel
 
-**La clé de release n'existe pas encore.** Tant qu'elle manque, la chaîne
-fonctionne en **mode dégradé** :
+**La clé de release existe et la signature CI est active.** Le keystore a été
+généré (RSA 2048, format PKCS12, alias `streampulse`, validité 10 000 jours) et
+les quatre secrets GitHub sont posés : la workflow CD signe désormais les
+releases avec la clé de release et produit l'APK **et** l'AAB. Le keystore et ses
+mots de passe vivent hors du dépôt (cf. § 3).
+
+### Repli en mode dégradé (sans la clé)
+
+Pour qui ne dispose pas de la clé (un poste sans `key.properties`, un fork sans
+les secrets), la chaîne retombe en **mode dégradé** :
 
 - le build **réussit**, signé avec la clé de debug ;
 - l'APK est suffixé **`-NON-SIGNE`**, et l'AAB n'est pas produit ;
@@ -153,8 +161,9 @@ installée. Sans ce champ, un retour n'est pas rattachable à une version, et
 
 ## 7. Ce qui manque encore
 
-1. **Aucune clé de signature générée** — tout ce qui précède fonctionne en mode
-   dégradé tant que c'est le cas.
+1. ~~Aucune clé de signature générée~~ : **fait** (2026-09-01). Keystore généré
+   et quatre secrets GitHub posés, la CD signe les releases. Le repli en mode
+   dégradé reste disponible pour les postes ou forks sans la clé.
 2. **Aucun magasin.** Les artefacts vivent dans les GitHub Releases. Une piste
    interne Play Store ou Firebase App Distribution demanderait un compte
    développeur Google (25 $ une fois) et n'a pas été ouverte.


### PR DESCRIPTION
## Contexte

Activation de la **signature de release Android**. L'infrastructure (Gradle + workflow CD avec repli debug) existait déjà ; il ne manquait que l'exécution opérationnelle décrite au §3 de `docs/distribution-mobile.md`.

## Fait (hors dépôt / GitHub, pas dans ce diff)

- **Keystore release généré** (`~/streampulse-release.jks`, hors dépôt, gitignoré) : RSA 2048, PKCS12, alias `streampulse`, validité 10 000 jours.
- **4 secrets GitHub posés** sur le repo : `ANDROID_KEYSTORE_BASE64`, `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS`, `ANDROID_KEY_PASSWORD`.
- Conséquence : la CD signe désormais les releases avec la clé de release (APK + AAB, plus de suffixe `-NON-SIGNE`).

## Ce diff

- `docs/distribution-mobile.md` §2 et §7 : la clé de release existe et la signature CI est active (le mode dégradé reste documenté comme repli pour les postes/forks sans la clé).

## À suivre (hors périmètre de cette PR)

⚠️ Google Sign-In cassera sur un APK signé release tant que le **SHA-1 du keystore release** n'est pas enregistré dans un 2e client OAuth Android sur Google Cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)