### PR TITLE
fix(ci): passer GOOGLE_SERVER_CLIENT_ID aux builds mobile et exposer Grafana en prod

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -273,6 +273,14 @@ jobs:
       # serait refusé. En mode dégradé il n'irait donc nulle part : l'attacher à
       # la release afficherait un livrable qui ne mène à rien, ce qui est pire
       # que son absence. L'APK, lui, s'installe et sert au test.
+      #
+      # GOOGLE_SERVER_CLIENT_ID : id du Client Web OAuth, lu au build par
+      # google_auth_service.dart (String.fromEnvironment). Sur Android, il n'y a
+      # pas de fallback Info.plist comme sur iOS : sans ce define, serverClientId
+      # est nul et « Sign in with Google » échoue en DEVELOPER_ERROR (code 10).
+      # C'est un identifiant PUBLIC (audience du jeton, cf. ADR 047), pas un
+      # secret — hardcodé comme API_BASE_URL. Le SHA-1 de la clé de signature
+      # doit par ailleurs être déclaré côté Google Cloud (client OAuth Android).
       - name: Construire les artefacts
         working-directory: ./mobile
         env:
@@ -306,10 +314,12 @@ jobs:
           }
 
           build_with_retry flutter build apk --release \
-            --dart-define=API_BASE_URL=https://api.streampulse.win
+            --dart-define=API_BASE_URL=https://api.streampulse.win \
+            --dart-define=GOOGLE_SERVER_CLIENT_ID=1027794910498-788nf58iql3n7bb9rbdattj15f09l73q.apps.googleusercontent.com
           if [ "${{ steps.signing.outputs.available }}" = "true" ]; then
             build_with_retry flutter build appbundle --release \
-              --dart-define=API_BASE_URL=https://api.streampulse.win
+              --dart-define=API_BASE_URL=https://api.streampulse.win \
+              --dart-define=GOOGLE_SERVER_CLIENT_ID=1027794910498-788nf58iql3n7bb9rbdattj15f09l73q.apps.googleusercontent.com
           fi
 
       # Le suffixe n'est pas cosmétique : un artefact signé en debug installé

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -231,6 +231,10 @@ services:
     environment:
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}
       GF_USERS_ALLOW_SIGN_UP: "false"
+      # URL publique servie par Caddy : sans elle, les redirections et liens
+      # absolus de Grafana pointeraient sur localhost:3000 derrière le proxy et
+      # casseraient (login, invitations email…).
+      GF_SERVER_ROOT_URL: https://grafana.streampulse.win
       # Alertes par email (STR-167, ADR 021) : même relay SMTP que l'API.
       GF_SMTP_ENABLED: "true"
       GF_SMTP_HOST: ${SMTP_HOST}:${SMTP_PORT:-587}

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -32,3 +32,12 @@ api.streampulse.win {
 		header_up X-Forwarded-For {remote_host}
 	}
 }
+
+# grafana.streampulse.win → interface Grafana (accès équipe, auth gérée par Grafana).
+# Prérequis : un enregistrement DNS A `grafana.streampulse.win` → IP du VPS, en DNS-only.
+# Pas de CSP stricte ici (contrairement à l'API JSON) : Grafana sert une UI HTML et
+# pose ses propres en-têtes de sécurité. Caddy joint le conteneur via le réseau
+# interne (grafana:3000) ; le bind loopback du port hôte reste inchangé.
+grafana.streampulse.win {
+	reverse_proxy grafana:3000
+}


### PR DESCRIPTION
## Google Sign-In sur APK release — corrige le DEVELOPER_ERROR (code 10)

Un test sur APK a échoué avec `PlatformException(sign_in_failed, ...: 10: , null, null)` — le code `10` = `DEVELOPER_ERROR` de google_sign_in Android.

**Cause :** sur Android, `google_auth_service.dart` lit le Client Web via `--dart-define=GOOGLE_SERVER_CLIENT_ID` (pas de fallback `Info.plist` comme iOS). Le build APK/AAB du `cd.yml` ne passait qu'`API_BASE_URL` → `serverClientId` nul → erreur 10.

**Fix :** les builds APK **et** AAB passent désormais `--dart-define=GOOGLE_SERVER_CLIENT_ID=...` (id du Client Web OAuth, identifiant **public**, hardcodé comme `API_BASE_URL`).

> ⚠️ Complément **hors code** requis côté Google Cloud pour que ça marche de bout en bout : le client OAuth Android doit porter le **SHA-1 de la clé de signature** de l'APK **et** le package name `fr.streampulse.streampulse` (l'`applicationId`, pas le nom d'affichage).

## Grafana prod

- `docker-compose.prod.yml` + `docker/caddy/Caddyfile` : exposition de Grafana en prod (`GF_SERVER_ROOT_URL` + reverse-proxy Caddy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)