### PR TITLE
docs(docs): traduire user stories, base de données et documents associés en anglais

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,12 @@ la française est la bonne, et l'écart est un défaut à signaler.
 | [infrastructure.md](infrastructure.md) | [en/operations.md](en/operations.md) | Comment lancer, observer et déployer la stack |
 | [securite.md](securite.md) | [en/security.md](en/security.md) | Qui accède à quoi, comment les secrets sont protégés, ce qui est exposé |
 | Toutes les ADR | [en/adr-index.md](en/adr-index.md) | Chaque décision d'architecture, résumée |
+| [user-stories.md](user-stories.md) | [en/user-stories.md](en/user-stories.md) | Les user stories du produit, par épopée, avec leurs critères d'acceptation |
+| [database.md](database.md) | [en/database.md](en/database.md) | Structure de la base de données : tables, relations, contraintes |
+| [diagrammes.md](diagrammes.md) | [en/diagrams.md](en/diagrams.md) | Diagrammes UML, chacun accompagné de son équivalent textuel |
+| [plan-formation.md](plan-formation.md) | [en/training-plan.md](en/training-plan.md) | Plan de formation — publics, modalités, durées, évaluation, et adaptations pour les publics en situation de handicap |
+| [accessibilite.md](accessibilite.md) | [en/accessibility.md](en/accessibility.md) | Déclaration d'accessibilité de la documentation (WCAG 2.1 AA), glossaire, écarts connus |
+| [manuel-utilisateur.md](manuel-utilisateur.md) | [en/user-manual.md](en/user-manual.md) | Manuel utilisateur — parcours auditeur, diffuseur et administrateur, sans ligne de commande |
 | — | [en/README.md](en/README.md) | Index anglais |
 
 ### Français uniquement, et pourquoi
@@ -64,9 +70,8 @@ et une seconde version divergerait — ou, pire, dirait autre chose.
 
 | Document | Motif |
 |---|---|
-| Manuel utilisateur, plan de formation, déclaration d'accessibilité | Écrits pour les personnes qui utilisent le produit et celles qui les forment |
 | Politique de confidentialité, CGU | Textes juridiques. Deux versions d'un texte juridique sont deux textes qui peuvent se contredire — un risque réel, pas théorique |
-| Cahier de recette, user stories | Artefacts de recette, lus par l'équipe et le jury |
+| Cahier de recette | Artefact de recette, lu par l'équipe et le jury |
 | Les ADR intégrales | Résumées dans l'index anglais ; le code, les tableaux et les diagrammes qu'elles contiennent sont déjà neutres en langue |
 | Runbook d'exploitation détaillé | Procédures de dépannage et de mise à jour du VPS, pour l'équipe qui exploite le service |
 | Rapport de couverture de tests | Lu par l'équipe qui écrit le code et par le jury ; les chiffres et les noms de paquets qu'il contient sont déjà neutres en langue |

--- a/docs/accessibilite.md
+++ b/docs/accessibilite.md
@@ -1,5 +1,7 @@
 # Accessibilité de la documentation
 
+> 🇬🇧 **English version: [en/accessibility.md](en/accessibility.md)**
+
 Ce document déclare le niveau d'accessibilité visé par la **documentation** de
 StreamPulse, les règles qui l'assurent, et les écarts qui subsistent.
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,5 +1,7 @@
 # Schéma de base de données — StreamPulse
 
+> 🇬🇧 **English version: [en/database.md](en/database.md)**
+
 > Version : 1.2.0 — dernière révision : 2026-08-19
 
 Modèle physique de la base PostgreSQL, dérivé des **19 migrations** de `backend/migrations/`.

--- a/docs/database.md
+++ b/docs/database.md
@@ -150,7 +150,7 @@ suppression de son auteur.
 | `id` | UUID | PK, `gen_random_uuid()` | Identifiant |
 | `email` | TEXT | NOT NULL, UNIQUE | Identifiant de connexion |
 | `username` | TEXT | NOT NULL, UNIQUE | Pseudonyme public |
-| `password_hash` | TEXT | NOT NULL | bcrypt. Jamais le mot de passe |
+| `password_hash` | TEXT | NULLable | bcrypt. Jamais le mot de passe. NULL pour un compte Google (migration `000024`) — la connexion par mot de passe reste sûre (bcrypt échoue face à une valeur vide) |
 | `role` | TEXT | CHECK `anonymous\|user\|broadcaster\|admin` | Hiérarchie d'autorisation |
 | `is_active` | BOOLEAN | NOT NULL, `true` | Désactivation par un admin, sans suppression |
 
@@ -171,7 +171,7 @@ exister sans profil.
 
 | Colonne | Type | Contrainte | Sens |
 |---|---|---|---|
-| `status` | TEXT | CHECK `idle\|live\|ended` | `ended` est terminal |
+| `status` | TEXT | CHECK `idle\|live\|ended` | `ended` est relançable : `PATCH /start` accepte `idle\|ended → live` et remet `ended_at` à NULL (ADR 048) |
 | `stream_key` | TEXT | NOT NULL, UNIQUE | **Secret de type bearer** : authentifie l'ingest à lui seul, sans JWT |
 | `is_public` | BOOLEAN | NOT NULL, `true` | Un flux privé renvoie 404 à un tiers, jamais 403 |
 | `archived_at` | TIMESTAMPTZ | NULL | Suppression douce |

--- a/docs/diagrammes.md
+++ b/docs/diagrammes.md
@@ -236,7 +236,7 @@ stateDiagram-v2
     live --> ended : PATCH /stop
     live --> ended : bail d'ingest expiré (aucun audio pendant N s)
     live --> ended : mort du segmenteur
-    ended --> [*]
+    ended --> live : PATCH /start (relance, ended_at remis à NULL)
 
     idle --> archived : DELETE (suppression douce)
     live --> archived : DELETE
@@ -249,8 +249,9 @@ propriétaire, à condition qu'aucun autre de ses flux ne soit déjà en direct 
 garantie par un index unique partiel en base, pas seulement par le code.
 
 Trois chemins mènent à `ended` : l'arrêt explicite par le diffuseur, l'expiration du bail
-d'ingest lorsque plus aucun audio n'arrive, et la mort du segmenteur. `ended` est **terminal** :
-un flux terminé ne redémarre pas.
+d'ingest lorsque plus aucun audio n'arrive, et la mort du segmenteur. `ended` n'est **pas
+terminal** : un flux est un canal réutilisable, `PATCH /start` accepte `idle|ended → live` et
+remet `ended_at` à NULL (ADR 048).
 
 La suppression est douce et orthogonale : elle renseigne `archived_at` depuis n'importe quel
 état, sans effacer la ligne.

--- a/docs/diagrammes.md
+++ b/docs/diagrammes.md
@@ -1,5 +1,7 @@
 # Diagrammes — StreamPulse
 
+> 🇬🇧 **English version: [en/diagrams.md](en/diagrams.md)**
+
 > Version : 1.2.0 — dernière révision : 2026-08-19
 
 Vues standardisées du système, en notation UML rendue par Mermaid — GitHub les affiche

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -17,6 +17,17 @@
 | [security.md](security.md) | Who can reach what, how secrets are protected, what is exposed |
 | [adr-index.md](adr-index.md) | Every architecture decision, summarised |
 
+## Also in English
+
+| Document | What it answers |
+|---|---|
+| [user-stories.md](user-stories.md) | The product's user stories, by epic, with their original acceptance criteria |
+| [database.md](database.md) | The database schema: tables, relationships, constraints |
+| [diagrams.md](diagrams.md) | UML views of the system, each backed by a textual equivalent |
+| [training-plan.md](training-plan.md) | How each audience — including people with disabilities — is brought to autonomy on the product |
+| [accessibility.md](accessibility.md) | The documentation's declared accessibility level (WCAG 2.1 AA), glossary, known gaps |
+| [user-manual.md](user-manual.md) | The listener, broadcaster and administrator walkthroughs, with no command line |
+
 ## What is French-only, and why
 
 The following are deliberately not translated. The reason is the same in every
@@ -25,9 +36,8 @@ or, worse, carry a different meaning.
 
 | Document | Why |
 |---|---|
-| User manual, training plan, accessibility statement | Written for the people who use the product and the people who train them |
 | Privacy policy, terms of use | Legal texts. Two versions of a legal text are two texts that can disagree — a real risk, not a theoretical one |
-| Test book (*cahier de recette*), user stories | Acceptance artefacts, read by the team and the examining board |
+| Test book (*cahier de recette*) | An acceptance artefact, read by the team and the examining board |
 | The full ADR records | Summarised in [adr-index.md](adr-index.md); the code, tables and diagrams inside are already language-neutral |
 | Detailed operations runbook | Troubleshooting procedures for the team that operates the service; [operations.md](operations.md) covers what a reader needs to run and understand the stack |
 

--- a/docs/en/accessibility.md
+++ b/docs/en/accessibility.md
@@ -1,0 +1,125 @@
+# Documentation accessibility
+
+> 🇫🇷 **Version française : [docs/accessibilite.md](../accessibilite.md)** —
+> the French version is the reference.
+
+This document declares the accessibility level targeted by StreamPulse's **documentation**, the
+rules that ensure it, and the gaps that remain.
+
+> **Scope.** It covers the documents in `docs/` and the `README`. It does **not** cover the
+> accessibility of the Flutter application itself. Both matter, separately, and conflating the
+> two would amount to declaring something compliant when it is not.
+>
+> The application side has been addressed since STR-244:
+> [ADR 043](../adr/043-accessibilite-de-l-application-et-adaptation-aux-largeurs.md) describes
+> what is done — semantic labels, WCAG checkers in CI, adaptation to screen widths — **and what
+> is not**: no verification with an actual screen reader, for lack of a device. No compliance is
+> declared there.
+
+---
+
+## 1. Targeted and declared level
+
+**WCAG 2.1 level AA**, applied to the documentary content.
+
+RGAA (the French public-sector accessibility framework) was not chosen as the reference standard
+for this declaration: it is designed for public online services, and a good share of its
+criteria cover interface components — forms, navigation, time-based media — that Markdown
+documentation does not contain. WCAG 2.1 AA covers what genuinely applies here, without claiming
+compliance on criteria that are beside the point.
+
+## 2. What this requires, and how it is upheld
+
+| Rule | Criterion | How it is applied |
+|---|---|---|
+| Every image carries a textual alternative | 1.1.1 | Every screenshot in the manual comes with a description in the body text, never only in the `alt` attribute |
+| Every diagram has a textual equivalent | 1.1.1 | Mermaid diagrams are followed by a "Textual equivalent" paragraph describing the same content |
+| Information does not rely on colour alone | 1.4.1 | Status tables use **words** ("yes", "no", "owner"), not colour-coded dots alone |
+| Structure is carried by markup | 1.3.1 | Headings are hierarchical with no level skipped, tables have a header row, lists are real lists |
+| Reading does not depend on spatial formatting | 1.3.2 | No information is carried by space-based alignment or character-drawn art |
+| Links are explicit out of context | 2.4.4 | No "click here": the label names the target |
+| The language is declared | 3.1.1 | Each document is written in one consistent language, French or English; foreign terms it keeps are defined in the glossary |
+
+## 3. Concrete consequences for writing
+
+**A document must remain complete once its images are removed.** That is the test we apply: if
+removing the screenshots makes a step incomprehensible, the text is insufficient, not the missing
+illustration. The [user manual](user-manual.md) is written in that order — the text first, the
+screenshots in support.
+
+**Diagrams are in Mermaid, not drawn with characters.** A Mermaid diagram is structured text: a
+screen reader reads back its nodes and links. A diagram drawn with box-drawing characters is read
+out character by character — "dash dash dash vertical bar" — which is actively painful, not
+merely unhelpful. See [diagrams.md](diagrams.md).
+
+**Tables stay readable in a linear pass.** A screen reader goes through a table cell by cell; we
+therefore keep few columns and headers that stand on their own.
+
+## 4. Printable version
+
+The documents are Markdown: they print from any viewer, or convert to PDF with the heading
+structure preserved — a condition for the PDF to stay navigable by assistive technology.
+
+No layout relies on spaces or tabs, which guarantees that conversion does not destroy the
+meaning.
+
+## 5. Glossary
+
+The documentation stays dense. The terms that cannot be avoided:
+
+| Term | What it is |
+|---|---|
+| **Stream** (or *live*) | A real-time audio broadcast, created by a broadcaster |
+| **Stream key** | The secret that authorises sending audio to a given stream |
+| **Ingest** | The act of sending audio to the server, from the broadcaster's side |
+| **HLS** | The broadcasting technique used: audio is split into small successive files that the player fetches one after another |
+| **Segment** | One of those small files, about ten seconds of audio |
+| **Manifest** (`.m3u8`) | The list of available segments, which the player re-fetches regularly |
+| **Playlist** | A personal list of tracks — unrelated to the manifest above, despite the shared word "list" |
+| **Track** | An audio file uploaded by a user |
+| **Queue** | What the player will play, in order, once a playlist has started |
+| **Token** | The proof of identity the application presents to the server on every request |
+| **Favourite** | A stream set aside to find again from the home screen |
+| **Role** | An account's level of rights: listener, broadcaster, administrator |
+| **ADR** | *Architecture Decision Record* — a note that explains **why** a technical choice was made |
+| **Audit log** | The record of administration actions: who did what, when |
+
+## 6. Known gaps
+
+1. **The French `architecture.md` still contains diagrams drawn with box-drawing characters** —
+   79 lines are affected. This is the main shortfall of this declaration, and it is **active**: a
+   screen reader reads them out character by character. The English
+   [architecture.md](architecture.md) already uses Mermaid instead.
+
+   Immediate mitigation: the same content also exists in Mermaid, with textual equivalents, in
+   [diagrams.md](diagrams.md). A reader using assistive technology should be directed to that
+   document.
+
+   Rewriting the French file is deliberately left out of this change: it is being rewritten
+   elsewhere, and two concurrent rewrites of the same file would not merge cleanly. To be
+   addressed as soon as that rewrite lands.
+
+2. **Only one screenshot has been produced** — the login screen. The manual is written to be
+   complete without images — that is the rule in § 3 — but their scarcity denies people who rely
+   on visual landmarks an anchor point. The missing screenshots require navigating the
+   application, and therefore sending it taps, which the available tooling did not allow at the
+   time of writing.
+
+3. **Part of the documentation still exists only in French.** The bilingual scope is declared
+   separately in [docs/README.md § Bilingual scope](../README.md#périmètre-bilingue), and is not
+   covered by this declaration.
+
+4. **No audit by a person who actually uses assistive technology** has been carried out. The
+   rules above are applied in good faith; they have not been tested against real use. That is
+   the honest limit of this declaration.
+
+5. **No audio version of the documentation.** The criterion asks for documentation that is
+   "readable, audible": here, the audible part rests on the screen reader's speech synthesis, not
+   on a recording. That is a choice — a recording would drift from the text at the first update
+   — but it is one, and it is declared as such.
+
+## 7. Reporting an accessibility issue
+
+Open an issue on the project's repository describing the document in question, the assistive
+technology used and what is blocking. Accessibility issues are handled with the same priority as
+a functional defect.

--- a/docs/en/architecture.md
+++ b/docs/en/architecture.md
@@ -7,7 +7,7 @@
 > box-drawing characters. That is not a divergence of content: a screen reader
 > reads box-drawing art one character at a time, and rewriting these diagrams
 > was the opportunity to stop doing that. The French version is expected to
-> follow — see [accessibilite.md](../accessibilite.md) § 6.
+> follow — see [accessibility.md](accessibility.md) § 6.
 
 ---
 

--- a/docs/en/database.md
+++ b/docs/en/database.md
@@ -1,0 +1,268 @@
+# Database schema — StreamPulse
+
+> 🇫🇷 **Version française : [docs/database.md](../database.md)** — the French
+> version is the reference.
+
+> Version 1.2.0 — last revised: 2026-08-19
+
+Physical model of the PostgreSQL database, derived from the **19 migrations** in
+`backend/migrations/`. This document is the reference. The database
+initialisation ADR describes the original decision and covered only the first
+six tables — it is indexed in the [decision index](adr-index.md) (its number
+keeps shifting as the ongoing ADR renumbering plays out, hence no direct link
+here).
+
+The schema now counts **12 tables**.
+
+---
+
+## Entity-relationship diagram
+
+```mermaid
+erDiagram
+    users ||--o{ streams : "broadcasts"
+    users ||--o{ tracks : "owns"
+    users ||--o{ playlists : "owns"
+    users ||--o{ queue_items : "queues"
+    users ||--o{ refresh_tokens : "authenticates"
+    users ||--o{ password_reset_tokens : "resets"
+    users ||--|| profiles : "described by"
+    users ||--o{ broadcaster_requests : "requests"
+    users ||--o{ favorites : "favourites"
+    users ||--o{ audit_logs : "acts"
+    streams ||--o{ favorites : "favourited"
+    playlists ||--o{ playlist_tracks : "contains"
+    tracks ||--o{ playlist_tracks : "appears in"
+    tracks ||--o{ queue_items : "queued"
+
+    users {
+        uuid id PK
+        text email UK
+        text username UK
+        text password_hash
+        text role "anonymous|user|broadcaster|admin"
+        boolean is_active
+        timestamptz created_at
+        timestamptz updated_at
+    }
+    profiles {
+        uuid id PK
+        uuid user_id FK,UK
+        text pseudo
+        text bio
+        text avatar_url
+        text theme "system|light|dark"
+        boolean notifications_enabled
+        text audio_quality "low|normal|high"
+    }
+    streams {
+        uuid id PK
+        uuid user_id FK
+        text title
+        text description
+        text category
+        text status "idle|live|ended"
+        text stream_key UK
+        boolean is_public
+        timestamptz started_at
+        timestamptz ended_at
+        timestamptz archived_at
+    }
+    tracks {
+        uuid id PK
+        uuid user_id FK
+        text title
+        text artist
+        integer duration_s "CHECK > 0"
+        text file_path
+        text mime_type "audio/mpeg|aac|ogg"
+        bigint file_size "CHECK > 0"
+    }
+    playlists {
+        uuid id PK
+        uuid user_id FK
+        text name
+        text description
+        boolean is_public
+    }
+    playlist_tracks {
+        uuid playlist_id PK,FK
+        uuid track_id PK,FK
+        integer position "CHECK >= 0"
+        timestamptz added_at
+    }
+    queue_items {
+        uuid id PK
+        uuid user_id FK
+        uuid track_id FK
+        integer position "CHECK >= 0"
+        timestamptz added_at
+    }
+    favorites {
+        uuid user_id PK,FK
+        uuid stream_id PK,FK
+        timestamptz created_at
+    }
+    refresh_tokens {
+        uuid id PK
+        uuid user_id FK
+        text token_hash UK
+        timestamptz expires_at
+    }
+    password_reset_tokens {
+        uuid id PK
+        uuid user_id FK
+        text token_hash UK
+        timestamptz expires_at
+        timestamptz used_at
+    }
+    broadcaster_requests {
+        uuid id PK
+        uuid user_id FK
+        text status "pending|approved|rejected"
+        text message
+        uuid reviewed_by FK
+        text review_note
+    }
+    audit_logs {
+        uuid id PK
+        uuid actor_id FK "ON DELETE SET NULL"
+        text action
+        text target_type
+        uuid target_id
+        timestamptz created_at
+    }
+```
+
+**Textual equivalent** — `users` sits at the centre: everything a user produces
+(streams, tracks, playlists, queue) or that authenticates them (refresh and
+password-reset tokens) depends on it, and disappears with it. `profiles` is a
+one-to-one extension created automatically by a trigger. `playlist_tracks` and
+`favorites` are association tables with a composite primary key. `audit_logs`
+is the only link that **survives** the deletion of its author.
+
+---
+
+## Data dictionary
+
+### `users` — accounts
+
+| Column | Type | Constraint | Meaning |
+|---|---|---|---|
+| `id` | UUID | PK, `gen_random_uuid()` | Identifier |
+| `email` | TEXT | NOT NULL, UNIQUE | Login identifier |
+| `username` | TEXT | NOT NULL, UNIQUE | Public handle |
+| `password_hash` | TEXT | NOT NULL | bcrypt. Never the password itself |
+| `role` | TEXT | CHECK `anonymous\|user\|broadcaster\|admin` | Authorisation hierarchy |
+| `is_active` | BOOLEAN | NOT NULL, `true` | Deactivated by an admin, without deletion |
+
+### `profiles` — preferences and public identity
+
+Created automatically at registration by the `trg_create_profile_for_user`
+trigger (migration `000011`): no application code has to worry about it, and an
+account can never exist without a profile.
+
+| Column | Type | Constraint | Meaning |
+|---|---|---|---|
+| `user_id` | UUID | NOT NULL, **UNIQUE**, cascading FK | One-to-one relationship |
+| `bio` | TEXT | NOT NULL, `''` | Never NULL — simplifies rendering |
+| `theme` | TEXT | CHECK `system\|light\|dark` | Display preference |
+| `audio_quality` | TEXT | CHECK `low\|normal\|high` | Playback preference |
+
+### `streams` — broadcast streams
+
+| Column | Type | Constraint | Meaning |
+|---|---|---|---|
+| `status` | TEXT | CHECK `idle\|live\|ended` | `ended` is terminal |
+| `stream_key` | TEXT | NOT NULL, UNIQUE | **Bearer-style secret**: authenticates ingest on its own, without a JWT |
+| `is_public` | BOOLEAN | NOT NULL, `true` | A private stream returns 404 to a third party, never 403 |
+| `archived_at` | TIMESTAMPTZ | NULL | Soft delete |
+
+### `tracks` — audio library
+
+| Column | Type | Constraint | Meaning |
+|---|---|---|---|
+| `duration_s` | INTEGER | CHECK > 0 | **Declared by the client**, not extracted from the file |
+| `file_path` | TEXT | NOT NULL | Path under `STORAGE_PATH`, outside the served directory |
+| `mime_type` | TEXT | CHECK `audio/mpeg\|aac\|ogg` | Value **sniffed** server-side, never taken on trust |
+| `file_size` | BIGINT | CHECK > 0 | Feeds the 500 MB per-account quota |
+
+### `playlist_tracks` — a playlist's composition
+
+| Column | Type | Constraint |
+|---|---|---|
+| `playlist_id`, `track_id` | UUID | **Composite PK**, cascading FK |
+| `position` | INTEGER | CHECK ≥ 0, `UNIQUE (playlist_id, position)` **DEFERRABLE** |
+
+### `audit_logs` — moderation log
+
+| Column | Type | Constraint | Meaning |
+|---|---|---|---|
+| `actor_id` | UUID | FK **ON DELETE SET NULL** | The trace survives the account's deletion, **without** the identity |
+| `target_type`, `target_id` | TEXT, UUID | NOT NULL | Polymorphic target, without a FK |
+
+---
+
+## Non-obvious constraints
+
+Four schema decisions do not show up in the diagram, and they govern how the
+application behaves.
+
+**`uq_playlist_tracks_position` is `DEFERRABLE INITIALLY DEFERRED`** (`000019`).
+Reordering a playlist rewrites every position within one transaction, and its
+intermediate states necessarily contain duplicates — moving track 3 to position
+0 before the others have shifted. The constraint is only checked at COMMIT.
+Consequence for the code: every track mutation goes through a transaction, and
+an `INSERT … ON CONFLICT` must **name its columns**
+(`ON CONFLICT (playlist_id, track_id)`) — a deferred constraint cannot serve as
+an arbiter, and a bare `ON CONFLICT DO NOTHING` fails with SQLSTATE 55000.
+
+**`streams_one_live_per_user`** (`000016`) is a **partial** unique index:
+`ON streams (user_id) WHERE status = 'live' AND archived_at IS NULL`. It is the
+database, not the application, that guarantees a broadcaster has only one live
+stream at a time. Two concurrent start requests cannot both go through.
+
+**`broadcaster_requests_one_pending`** follows the same principle: a partial
+unique index `WHERE status = 'pending'` stops a user from stacking up requests,
+while keeping the history of their processed ones.
+
+**`idx_streams_public_live`** is a partial covering index for public discovery:
+`WHERE is_public AND status = 'live' AND archived_at IS NULL`, ordered by
+`started_at DESC`. The application's most frequent query therefore never scans
+ended streams.
+
+---
+
+## Deleting an account
+
+`DELETE FROM users` cascades across **nine** tables: `streams`, `tracks`,
+`playlists`, `queue_items`, `refresh_tokens`, `password_reset_tokens`,
+`profiles`, `broadcaster_requests`, `favorites` — and, transitively,
+`playlist_tracks`.
+
+Two deliberate exceptions:
+
+- `audit_logs.actor_id` is set to `NULL`: the moderation trace survives
+  **without** its author's identity. This is what reconciles traceability with
+  the right to erasure.
+- `broadcaster_requests.reviewed_by` is also set to `NULL`: deleting an
+  administrator does not erase the requests they processed.
+
+**Audio files** are not covered by the SQL cascade: they live on a volume.
+Their deletion is chained at the application level, and only once the `DELETE`
+has succeeded — so as never to leave an orphaned row. See
+`track.Service.PurgeUserTracks`.
+
+---
+
+## Schema version notes
+
+- Migration **`000012` does not exist**: a gap in the numbering, with no
+  consequence — `golang-migrate` orders by number and does not require
+  continuity.
+- The `uq_streams_user_title` constraint was **removed** in `000015`: two
+  streams from the same broadcaster can share a title, so there is no 409 on
+  that ground.
+- `queue_items` is created (`000005`) but **unused by the application**: the
+  queue is managed on the Flutter side (ADR 034). The generated sqlc type
+  exists; no call references it.

--- a/docs/en/database.md
+++ b/docs/en/database.md
@@ -152,7 +152,7 @@ is the only link that **survives** the deletion of its author.
 | `id` | UUID | PK, `gen_random_uuid()` | Identifier |
 | `email` | TEXT | NOT NULL, UNIQUE | Login identifier |
 | `username` | TEXT | NOT NULL, UNIQUE | Public handle |
-| `password_hash` | TEXT | NOT NULL | bcrypt. Never the password itself |
+| `password_hash` | TEXT | NULLable | bcrypt. Never the password itself. NULL for a Google-only account (migration `000024`) — password login stays safe (bcrypt fails against an empty value) |
 | `role` | TEXT | CHECK `anonymous\|user\|broadcaster\|admin` | Authorisation hierarchy |
 | `is_active` | BOOLEAN | NOT NULL, `true` | Deactivated by an admin, without deletion |
 
@@ -173,7 +173,7 @@ account can never exist without a profile.
 
 | Column | Type | Constraint | Meaning |
 |---|---|---|---|
-| `status` | TEXT | CHECK `idle\|live\|ended` | `ended` is terminal |
+| `status` | TEXT | CHECK `idle\|live\|ended` | `ended` is restartable: `PATCH /start` accepts `idle\|ended → live` and resets `ended_at` to NULL (ADR 048) |
 | `stream_key` | TEXT | NOT NULL, UNIQUE | **Bearer-style secret**: authenticates ingest on its own, without a JWT |
 | `is_public` | BOOLEAN | NOT NULL, `true` | A private stream returns 404 to a third party, never 403 |
 | `archived_at` | TIMESTAMPTZ | NULL | Soft delete |

--- a/docs/en/diagrams.md
+++ b/docs/en/diagrams.md
@@ -236,7 +236,7 @@ stateDiagram-v2
     live --> ended : PATCH /stop
     live --> ended : ingest lease expired (no audio for N s)
     live --> ended : segmenter died
-    ended --> [*]
+    ended --> live : PATCH /start (restart, ended_at reset to NULL)
 
     idle --> archived : DELETE (soft delete)
     live --> archived : DELETE
@@ -249,7 +249,8 @@ request, provided none of their other streams is already live — a constraint g
 partial unique index in the database, not only by the code.
 
 Three paths lead to `ended`: an explicit stop by the broadcaster, the ingest lease expiring once
-no more audio arrives, and the segmenter dying. `ended` is **terminal**: an ended stream does not
-restart.
+no more audio arrives, and the segmenter dying. `ended` is **not terminal**: a stream is a
+reusable channel, and `PATCH /start` accepts `idle|ended → live`, resetting `ended_at` to NULL
+(ADR 048).
 
 Deletion is soft and orthogonal: it sets `archived_at` from any state, without erasing the row.

--- a/docs/en/diagrams.md
+++ b/docs/en/diagrams.md
@@ -1,0 +1,255 @@
+# Diagrams — StreamPulse
+
+> 🇫🇷 **Version française : [docs/diagrammes.md](../diagrammes.md)** — the
+> French version is the reference.
+
+> Version 1.2.0 — last revised: 2026-08-19
+
+Standardised views of the system, in UML notation rendered by Mermaid — GitHub displays them
+natively, with no tool and no image to regenerate.
+
+**Each diagram is followed by a textual equivalent.** A diagram remains an image to a screen
+reader; the description that comes with it carries the same information in a readable form.
+
+The data schema has its own document: [`database.md`](database.md).
+
+---
+
+## 1. Use cases — the four roles
+
+```mermaid
+graph LR
+    anonymous(("Anonymous"))
+    user(("User"))
+    broadcaster(("Broadcaster"))
+    admin(("Administrator"))
+
+    anonymous --> UC1["Discover live streams"]
+    anonymous --> UC2["Listen to a public stream"]
+    anonymous --> UC3["Register / log in"]
+
+    user --> UC1
+    user --> UC2
+    user --> UC4["Add a stream to favourites"]
+    user --> UC5["Upload a track"]
+    user --> UC6["Manage playlists"]
+    user --> UC7["Listen to a playlist"]
+    user --> UC8["Manage profile"]
+    user --> UC9["Request the broadcaster role"]
+    user --> UC10["Delete account"]
+
+    broadcaster --> UC11["Create a stream"]
+    broadcaster --> UC12["Start / stop a live stream"]
+    broadcaster --> UC13["Broadcast from the microphone"]
+    broadcaster --> UC14["View audience"]
+    broadcaster --> UC15["Rotate stream key"]
+
+    admin --> UC16["Manage accounts"]
+    admin --> UC17["Supervise active streams"]
+    admin --> UC18["Interrupt a stream"]
+    admin --> UC19["Process role requests"]
+
+    user -.inherits from.-> anonymous
+    broadcaster -.inherits from.-> user
+    admin -.inherits from.-> broadcaster
+```
+
+**Textual equivalent** — Four hierarchical roles: each inherits the capabilities of the one
+before it, in the order anonymous → user → broadcaster → administrator. The anonymous visitor
+discovers and listens to public streams, and can register. The user adds favourites, the
+library, playlists, their profile, the role request and account deletion. The broadcaster adds
+creating streams, starting and stopping a live stream, broadcasting from the microphone, viewing
+their audience and rotating their key. The administrator adds account management, supervising and
+interrupting streams, and processing role requests.
+
+The hierarchy is enforced by `auth.RequireRole`: a higher rank always satisfies the requirement
+of a lower one.
+
+---
+
+## 2. Sequence — authentication and token rotation
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant M as Mobile application
+    participant A as Go API
+    participant DB as PostgreSQL
+
+    M->>A: POST /api/auth/login (email, password)
+    A->>DB: SELECT user WHERE email
+    DB-->>A: user + password_hash
+    A->>A: bcrypt.CompareHashAndPassword
+    A->>A: sign an HS256 access token (15 min, claims sub + role)
+    A->>DB: INSERT refresh_tokens (SHA-256 of the token, 7 days)
+    A-->>M: access token + refresh token
+    M->>M: store in the OS's secure vault
+
+    Note over M,A: 15 minutes later
+
+    M->>A: GET /api/playlists (Bearer access token)
+    A-->>M: 401 — expired token
+    M->>A: POST /api/auth/refresh (refresh token)
+    A->>DB: SELECT by hash, check expiry
+    A->>DB: DELETE the old one, INSERT the new one
+    Note right of A: rotation: a consumed refresh<br/>token cannot be reused
+    A-->>M: new token pair
+    M->>A: replay GET /api/playlists
+    A-->>M: 200
+```
+
+**Textual equivalent** — At login, the API checks the password with bcrypt, signs an HS256
+access token valid for 15 minutes carrying the user id and role, and stores in the database the
+**SHA-256 hash** of a refresh token valid for 7 days. The mobile app keeps both in the platform's
+secure store. When the access token expires, the API answers 401; the client then exchanges its
+refresh token for a new pair. The old refresh token is deleted in the process: a consumed token
+cannot be reused. The client finally replays its original request.
+
+On the mobile side, this cycle is serialised: N requests that come back with 401 at the same time
+trigger only a single refresh.
+
+---
+
+## 3. Sequence — from ingest to the listener's ear
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant D as Broadcaster (mobile)
+    participant A as Go API
+    participant F as ffmpeg
+    participant FS as Session directory
+    participant L as Listener (mobile)
+
+    D->>A: PATCH /api/streams/{id}/start (Bearer JWT)
+    A->>A: status idle → live, create the session (cancellable context)
+    A-->>D: 200 + stream_source_url
+
+    D->>A: POST /api/streams/ingest/{stream_key}
+    Note right of A: authenticated by the key alone,<br/>without a JWT
+    A->>F: write the audio to stdin
+    F->>FS: .ts segments (~10 s) + sliding .m3u8 manifest
+
+    par The broadcaster keeps pushing
+        loop continuously
+            D->>A: audio bytes
+            A->>F: relay to stdin
+        end
+    and The listener reads independently
+        L->>A: GET /api/streams/{id}/playlist.m3u8
+        A->>FS: read the manifest
+        A-->>L: 200 (or 409 if not ready yet)
+        loop every ~10 s
+            L->>A: GET /api/streams/{id}/segments/{segment}.ts
+            A-->>L: 200 — audio segment
+        end
+    end
+
+    D->>A: PATCH /api/streams/{id}/stop
+    A->>F: close stdin, then kill the process
+    A->>FS: delete the directory
+    A->>A: status live → ended, cancel the context
+    A-->>L: SSE "ended" event
+```
+
+**Textual equivalent** — The broadcaster starts their stream with their JWT: the status moves
+from `idle` to `live` and a cancellable session is created in memory. They then push the audio to
+the ingest route, authenticated by the stream key alone — without a JWT, since third-party
+broadcasting software has no way to present one. The API relays these bytes to the standard input
+of an ffmpeg process, which writes segments of about ten seconds and a sliding manifest into the
+session's working directory.
+
+In parallel, the listener fetches the manifest, then the segments, in a loop. The fan-out from
+one broadcaster to N listeners therefore happens **through files**, not through an in-memory
+channel: each player reads independently.
+
+On stop, the API closes ffmpeg's input to let it finalise its last segment, kills the process,
+deletes the directory, cancels the session's context and notifies subscribed listeners with an
+`ended` SSE event.
+
+---
+
+## 4. Components and deployment flow
+
+```mermaid
+graph TB
+    subgraph clients["Clients"]
+        mobile["Flutter application<br/>iOS · Android"]
+    end
+
+    subgraph vps["VPS — streampulse-net network"]
+        caddy["Caddy<br/>TLS Let's Encrypt<br/>only public port"]
+
+        subgraph app["Application"]
+            api["Go API<br/>net/http · 127.0.0.1:8080"]
+            pg[("PostgreSQL 16")]
+            vol[/"track_storage volume"/]
+        end
+
+        subgraph obs["Observability"]
+            prom["Prometheus"]
+            loki["Loki"]
+            tempo["Tempo"]
+            alloy["Alloy"]
+            grafana["Grafana"]
+        end
+    end
+
+    mobile -->|HTTPS| caddy
+    caddy -->|internal HTTP| api
+    api --> pg
+    api --> vol
+    prom -->|scrapes /metrics| api
+    alloy -->|JSON logs| loki
+    api -.->|stdout| alloy
+    api -->|OTLP| tempo
+    grafana --> prom
+    grafana --> loki
+    grafana --> tempo
+```
+
+**Textual equivalent** — The Flutter application reaches the VPS over HTTPS. **Caddy is the only
+public entry point**: it terminates TLS with an automatically renewed Let's Encrypt certificate,
+and relays over HTTP on the internal network to the Go API, which only listens on the loopback
+interface.
+
+The API talks to PostgreSQL and writes audio files to a named volume, outside any served
+directory.
+
+Three observability flows leave from there: Prometheus comes to fetch metrics on `/metrics`
+through an internal scrape, Alloy collects the API's standard output and ships it to Loki, and
+the API pushes its traces to Tempo over OTLP. Grafana reads all three sources and serves both the
+dashboards and the alerts.
+
+⚠️ **This view describes the target state.** As of 2026-08-19, Prometheus and Grafana are still
+published on every interface of the VPS, and Caddy's block on `/metrics` is not deployed — the
+fixes are written but await a manual infrastructure sync. See STR-240.
+
+---
+
+## 5. Stream states
+
+```mermaid
+stateDiagram-v2
+    [*] --> idle : stream created
+    idle --> live : PATCH /start (owner, no other live stream)
+    live --> ended : PATCH /stop
+    live --> ended : ingest lease expired (no audio for N s)
+    live --> ended : segmenter died
+    ended --> [*]
+
+    idle --> archived : DELETE (soft delete)
+    live --> archived : DELETE
+    ended --> archived : DELETE
+    archived --> [*]
+```
+
+**Textual equivalent** — A stream is born `idle` when created. It moves to `live` at its owner's
+request, provided none of their other streams is already live — a constraint guaranteed by a
+partial unique index in the database, not only by the code.
+
+Three paths lead to `ended`: an explicit stop by the broadcaster, the ingest lease expiring once
+no more audio arrives, and the segmenter dying. `ended` is **terminal**: an ended stream does not
+restart.
+
+Deletion is soft and orthogonal: it sets `archived_at` from any state, without erasing the row.

--- a/docs/en/training-plan.md
+++ b/docs/en/training-plan.md
@@ -1,0 +1,122 @@
+# User training plan
+
+> 🇫🇷 **Version française : [docs/plan-formation.md](../plan-formation.md)** —
+> the French version is the reference.
+
+How to bring every audience to autonomy on StreamPulse, including people with
+disabilities.
+
+This plan is sized for the product's real use: a mobile listening and
+broadcasting application. It does not claim to be a certifying professional
+training scheme — it describes what is necessary and sufficient for each role
+to know how to do what it needs to do.
+
+**Related documents** — [user-manual.md](user-manual.md) (the main resource),
+[accessibility.md](accessibility.md).
+
+---
+
+## 1. Audiences and objectives
+
+| Audience | Expected size | What they must be able to do by the end | Prerequisite |
+|---|---|---|---|
+| **Listener** | The largest group | Create an account, find a live stream, listen, manage favourites and playlists | Know how to install an application |
+| **Broadcaster** | A few dozen | Everything above, plus: create a stream, obtain and protect their key, start and stop, read their audience | Be an autonomous listener |
+| **Administrator** | 2 to 3 people | Manage accounts, moderate live streams, process role requests, understand what is irreversible | Be an autonomous broadcaster |
+| **Relay contact** | 1 per user organisation | Support the three audiences above, know where to direct an adaptation request | Have completed the broadcaster track |
+
+## 2. Programme
+
+| Audience | Format | Duration | Resource | Assessment |
+|---|---|---|---|---|
+| Listener | Guided self-training | 20 min | [user-manual.md](user-manual.md) § 1 | Listen to a live stream and create a 3-track playlist |
+| Listener | Assisted walkthrough, on request | 30 min | Demonstration on a device | Same, done unaided |
+| Broadcaster | Small-group workshop (4 to 6) | 1 h | Manual § 2 + a test stream | Broadcast for 5 minutes, stop, read back the audience |
+| Broadcaster | "My stream key" cheat sheet | 5 min | One printable page | Know when to rotate their key |
+| Administrator | One-on-one session | 1 h 30 | Manual § 3 + [security.md](security.md) §§ 1-2 | Deactivate then reactivate a test account; interrupt a test live stream |
+| Administrator | Guided GDPR reading | 30 min | [rgpd.md](../rgpd.md) § 3 | Explain what deleting an account erases and what it keeps |
+| Relay contact | Full track + questions | 3 h | All of `docs/` | Replay a track for each role in front of someone else |
+
+## 3. Progression
+
+The broadcaster track assumes the listener track, and the administrator track assumes the
+broadcaster track. This is not a pedagogical convention: an administrator who has never
+broadcast does not grasp what interrupting a live stream means for the person on the other end.
+
+> The diagram below is rendered in Mermaid rather than the French version's box-drawing
+> characters, for the reason given in [architecture.md](architecture.md) and
+> [accessibility.md](accessibility.md) § 6: a screen reader reads box-drawing art one character
+> at a time.
+
+```mermaid
+flowchart LR
+    Listener --> Broadcaster --> Administrator
+    Listener --> Relay["Relay contact"]
+    Relay --> Administrator
+```
+
+**Textual equivalent of the diagram.** The listener track is the entry point. It leads to the
+broadcaster track, which in turn leads to the administrator track. The "relay contact" track also
+starts from the listener track and rejoins the administrator level, without taking on moderation
+responsibility.
+
+## 4. Adaptations for audiences with disabilities
+
+This section is not an add-on: it is a requirement of the reference framework, and it shapes the
+rest of the programme.
+
+### 4.1 Visual impairment
+
+- **Every written resource works with a screen reader.** The manual is structured with
+  hierarchical headings, which allows navigating heading by heading rather than reading
+  linearly.
+- **No information is carried by an image alone.** Every screenshot comes with a textual
+  equivalent, and every diagram is followed by its description. A resource stripped of its
+  images stays complete.
+- **No information is carried by colour alone** (see [accessibility.md](accessibility.md)).
+- The assisted walkthrough can be done **entirely by voice**, relying on the labels the screen
+  reader announces — the very ones the manual quotes word for word.
+
+### 4.2 Hearing impairment
+
+- **No training sequence relies on sound.** This is counter-intuitive for an audio application,
+  and that is precisely the point: *using* StreamPulse — creating an account, managing a
+  playlist, starting a stream, moderating — does not require hearing. Only quality-checking a
+  broadcast does, and that can be delegated.
+- Live demonstrations come with a **written resource handed out before the session**, so as not
+  to depend on lip-reading.
+- A deaf or hard-of-hearing broadcaster can check that their stream is going out through the
+  **visual indicators**: the stream shown as **"en direct"** (live) and the listener count
+  climbing.
+
+### 4.3 Motor impairment
+
+- The application is operated **with no complex gesture**: simple taps, no double-tap, no
+  multi-finger gesture. Only one interaction requires a drag — reordering a playlist — and it
+  has an alternative: rebuilding the order by removing and re-adding tracks.
+- Assisted sessions run **with no time limit**; no exercise is timed.
+- The resources work with the system's assistive technologies (voice control, switch access),
+  since they rely on the platform's standard labels.
+
+### 4.4 Cognitive and learning disabilities
+
+- The manual proceeds **in numbered steps**, one action per step.
+- Technical vocabulary is kept to a minimum, and what remains is defined in the
+  [accessibility.md](accessibility.md) **glossary**.
+- A **"What to do if…"** table closes the manual: it gives the right course of action without
+  requiring everything before it to have been read.
+- Sessions can be **split up**: one goal per short session rather than a single hour-long track.
+
+### 4.5 Requesting an adaptation
+
+Any adaptation request not covered here — large-print material, an audio version, sign-language
+interpretation for a session — goes through the organisation's relay contact, or through opening
+an issue on the project's repository.
+
+## 5. Staying current
+
+A change that alters a user journey **triggers an update to the manual within the same
+change**, not afterwards. Training material that describes an earlier version of the product is
+more harmful than no material at all: it makes the person doubt what they see on screen.
+
+The table in § 2 is revised at every major version.

--- a/docs/en/user-manual.md
+++ b/docs/en/user-manual.md
@@ -1,0 +1,295 @@
+# User manual
+
+> 🇫🇷 **Version française : [docs/manuel-utilisateur.md](../manuel-utilisateur.md)** — the
+> French version is the reference.
+
+This guide is for people who **use** StreamPulse, not those who develop it. No command, no
+terminal: everything is done from the application.
+
+It covers the three roles, in the order you meet them:
+
+1. [Listener](#1-listener) — listen, add favourites, build a library
+2. [Broadcaster](#2-broadcaster) — create a stream and broadcast live
+3. [Administrator](#3-administrator) — manage accounts and moderate streams
+
+**Related documents** — [accessibility.md](accessibility.md) (how to read this documentation
+another way), [training-plan.md](training-plan.md),
+[politique-confidentialite.md](../politique-confidentialite.md).
+
+---
+
+## Installing the application
+
+The application is not yet published on a store. It installs directly from the file attached to
+each release.
+
+1. Open the project's releases page on GitHub.
+2. Download the latest release's `.apk` file, from an **Android** phone.
+3. Open the downloaded file. Android will ask for permission to install an application from
+   outside the store: grant it for this one time.
+
+> ⚠️ If the file name contains **`-NON-SIGNE`** (unsigned), it is a test build. It works, but it
+> cannot later be updated by a final release: it has to be uninstalled first. This is not a
+> precaution taken out of caution — it is an Android rule: it refuses to replace an application
+> with another one signed differently.
+
+**iOS**: the application cannot be distributed on iPhone. It works, but making it available
+requires a paid Apple developer account, which the team does not have. Details are in
+[distribution-mobile.md](../distribution-mobile.md).
+
+## Reporting a problem
+
+From the repository's **Issues** tab, choose **"Retour utilisateur"** (User feedback). The form
+asks for the installed version — visible at the bottom of the **Profil** (Profile) screen.
+Without it, a problem cannot be tied to a version, and it becomes very hard to know whether it
+has already been fixed.
+
+## Finding your way around the app
+
+A bar at the bottom of the screen gives access to five spaces:
+
+| Tab | What it's for |
+|---|---|
+| **Accueil** (Home) | Your favourites and what's live right now |
+| **Bibliothèque** (Library) | Your tracks and playlists |
+| **Découvrir** (Discover) | Browse every public live stream |
+| **Tableau** (Dashboard) | Manage your own broadcasts — only useful to broadcasters |
+| **Profil** (Profile) | Your account, your preferences, and administration for those entitled to it |
+
+While something is playing, a **bar** appears just above this one. It stays visible whichever tab
+you're on: playback does not stop when you navigate.
+
+---
+
+## 1. Listener
+
+### 1.1 Creating an account
+
+1. On opening the app, tap **"Créer un compte"** (Create an account).
+2. Enter an email address, a username and a password, then confirm it.
+3. Tick the consent checkbox. The words **"politique de confidentialité"** (privacy policy) and
+   **"conditions d'utilisation"** (terms of use) are links: tapping them opens the document,
+   which can be read before committing, then return to the form — what has already been entered
+   is kept.
+4. Tap **"Créer mon compte"** (Create my account). The button stays disabled until the box is
+   ticked.
+
+### 1.2 Logging in, and what to do if you forget your password
+
+![StreamPulse home screen, Login tab selected](../captures/01-connexion.png)
+
+**Textual equivalent.** The screen shows the name "StreamPulse" above a logo, and the tagline
+"Redéfinissez votre expérience sonore." ("Redefine your sound experience."). Below it, two tabs
+side by side: **Connexion** (Login, selected) and **Inscription** (Register). Then the **E-mail**
+field, the **Mot de passe** (Password) field with an eye-shaped button to reveal what has been
+typed, then the **"Mot de passe oublié ?"** (Forgot password?) link aligned to the right. The
+**"Se connecter"** (Log in) button spans the full width. Further down, an "Ou" (Or) divider, two
+third-party sign-in buttons, and finally **"Continuer en tant qu'invité"** (Continue as a guest),
+which gives access to discovering public live streams without creating an account.
+
+The login screen asks for the email and password.
+
+If you forget it, tap **"Mot de passe oublié ?"** (Forgot password?) and enter your address. An
+email arrives with a link; opening it from the phone switches straight into the application, on
+the screen for choosing a new password.
+
+> The message shown is the same whether or not the address exists. This is not a bug: it is what
+> stops a third party from discovering who has an account.
+
+### 1.3 Listening to a live stream
+
+1. Open **Découvrir** (Discover). The list shows the public streams currently live, with their
+   title and the broadcaster's name.
+2. Tap a stream: playback starts and the player screen opens.
+3. Going back does not interrupt anything — the playback bar takes over.
+
+The bar offers **play/pause** and a **cross** to stop. Sound continues when the screen locks, and
+the phone's controls (lock screen, headphones) work.
+
+**If playback stops** — unstable network, a broadcaster who cuts the stream: the application
+reconnects on its own, several times, spacing out the attempts. If the stream has genuinely
+ended, it announces this and stops.
+
+**When a live stream starts**, expect about ten seconds before the sound is available. The
+application waits for you.
+
+### 1.4 Adding a stream to favourites
+
+From a stream's screen, tap the **star**. The stream joins the **Accueil** (Home) tab. Tapping it
+again removes it. Favourites stay visible even when the stream is not live.
+
+### 1.5 Adding your own tracks
+
+1. **Bibliothèque** (Library) tab, then the add button.
+2. Choose an audio file on the phone — MP3, AAC or OGG, **50 MB maximum**.
+3. Give it a title (required); the artist is optional.
+4. Confirm.
+
+Each account has **500 MB**. Beyond that, the upload is refused with a clear message. A file that
+is not really audio is refused even if its name ends in `.mp3` — the content is checked, not the
+extension.
+
+### 1.6 Creating and listening to a playlist
+
+1. **Bibliothèque** (Library) tab, create a playlist and give it a name. Two playlists cannot
+   share the same name.
+2. Open it, add tracks from your library.
+3. Reorder by dragging.
+4. Tap **"Lire"** (Play) to listen from the start, or a track to start there.
+
+While a playlist plays, the bar shows **previous / play / next**. Tapping it opens the full
+queue, where you can jump to any track, drag the progress bar, and turn on:
+
+- **Aléatoire** (Shuffle) — the playback order is randomised
+- **Répétition** (Repeat) — three states: off, repeat track, repeat playlist
+
+> The queue is a **snapshot** taken at launch. Reordering the playlist afterwards does not change
+> what is currently playing: playback has to be restarted.
+
+### 1.7 Requesting to become a broadcaster
+
+**Profil** (Profile) tab → **"Devenir diffuseur"** (Become a broadcaster). Briefly explain what
+you want to broadcast, then send. An administrator reviews the request; the status can be checked
+in the same place. Once accepted, the **Tableau** (Dashboard) tab becomes useful.
+
+---
+
+## 2. Broadcaster
+
+This chapter assumes the broadcaster role has been granted (§ 1.7).
+
+### 2.1 Creating a stream
+
+**Tableau** (Dashboard) tab → create a stream. Fill in:
+
+- a **title** — several streams can share one
+- a **description**, optional
+- the **visibility**: *public* (visible in Discover) or *private* (visible to you only)
+
+### 2.2 Getting your stream key
+
+The stream's screen shows a **stream key** and a **source URL**. This is what you give to the
+software that pushes the audio.
+
+> ⚠️ **This key is authorisation to broadcast on your stream.** It is never visible to anyone
+> else. Do not publish it, do not show it in a screenshot.
+
+### 2.3 Broadcasting
+
+1. Tap **"Démarrer"** (Start). The stream goes live.
+2. Send the audio, in one of two ways:
+   - **From the phone**: the application can capture the microphone directly.
+   - **From broadcasting software**: configure it with the source URL.
+3. Tap **"Arrêter"** (Stop) to end it. Listeners are notified that the stream ended and the
+   player stops cleanly.
+
+**Only one live stream at a time per broadcaster.** Trying to start a second one fails with a
+clear message; stop the first one first.
+
+The audio accepted is broad: if the format is not the expected one, it is converted on the fly.
+Unreadable content is refused rather than broadcast broken.
+
+### 2.4 Following your audience
+
+While live, the stream's screen shows: the number of listeners, the **peak** reached, and the
+elapsed duration.
+
+> The listener count is an **estimate**. The broadcasting technology does not keep a permanent
+> connection open: the server counts recent requests and infers an audience from them. The order
+> of magnitude is right; the exact figure does not exist.
+
+Off air, the counters are at zero.
+
+### 2.5 Rotating a compromised key
+
+If the key may have been seen by someone else: stream screen → **rotate the key**. The old one
+stops working immediately.
+
+**The stream must be stopped.** Rotating during a live broadcast is refused — the ongoing
+broadcast relies on the old key.
+
+---
+
+## 3. Administrator
+
+The administrator role cannot be requested from the application: it is granted directly in the
+database. The tools appear in the **Profil** (Profile) tab, in a card visible only to
+administrators.
+
+### 3.1 Managing accounts
+
+**Profil** (Profile) → **"Gestion des utilisateurs"** (User management).
+
+- **Search** by email or username.
+- **Filter** by role and by state (active or not).
+- **Deactivate** an account: the person can no longer log in, and their current session drops
+  within fifteen minutes at most. Nothing is erased, the action is reversible.
+- **Delete** an account: **permanent**. The account, their streams, playlists, favourites and
+  audio files disappear. Any of the person's ongoing broadcasts are stopped first.
+
+Two actions are refused, with a message:
+
+- deactivating or deleting yourself;
+- removing the **last active administrator** — otherwise no one could administer the platform
+  anymore.
+
+### 3.2 Supervising and interrupting a live stream
+
+**Profil** (Profile) → **"Supervision des flux"** (Stream supervision). The list shows **every**
+live stream, public and private alike, with the broadcaster's identity.
+
+The interrupt button stops a stream immediately, without going through its owner. Listeners are
+disconnected cleanly.
+
+Every interruption is recorded in the **audit log**: who, what, when. This trace survives even if
+the administrator's account is deleted later — **without their identity**, which is then
+detached.
+
+### 3.3 Processing broadcaster role requests
+
+**Profil** (Profile) → role requests. Each request shows the reason. **Accepting** promotes the
+person immediately. **Rejecting** requires a note, sent to the requester.
+
+---
+
+## What to do if…
+
+| Situation | What is happening | What to do |
+|---|---|---|
+| "Email ou mot de passe incorrect" (Incorrect email or password) | The pair matches no active account | Check the address; use "Mot de passe oublié ?" (Forgot password?) |
+| Sound does not start on a live stream | The stream has just started — allow ~10 s | Wait; the application retries on its own |
+| Playback stops on its own | Unstable network, or the end of the live stream | The application reconnects; if it is over, it says so |
+| "Trop de tentatives" (Too many attempts) | Protection against repeated attempts | Wait a few seconds |
+| A track upload is refused | File > 50 MB, the 500 MB quota is reached, or the file is not audio | The message states which |
+| Cannot start a live stream | Another of your streams is already live | Stop it first |
+| Cannot rotate the key | The stream is live | Stop it first |
+| An opened stream returns "introuvable" (not found) | It is private, or deleted | Only its owner can access it |
+
+---
+
+## Deleting your account
+
+**Profil** (Profile) → account deletion. The password is asked again: an unattended phone is not
+enough to delete an account.
+
+Deletion is **immediate and permanent**. What is erased, what is kept, and why:
+[politique-confidentialite.md](../politique-confidentialite.md).
+
+---
+
+## Illustrations
+
+This manual is **deliberately readable without images**: every journey is described using the
+labels actually shown on screen, so that it stays usable by someone who cannot see the
+screenshots — a screen reader, black-and-white printing, or reading from a terminal.
+
+Screenshots live in [`captures/`](../captures/) and are **always paired with their textual
+equivalent** in the corresponding section. A screenshot never introduces information that is
+absent from the text: that is the rule that makes this document compliant with the accessibility
+criteria declared in [accessibility.md](accessibility.md).
+
+**Current state: only one screenshot has been produced** — the login screen (§ 1.2), taken on an
+iPhone 17 simulator running iOS 26, with the application connected to a local API. Screenshots
+for the remaining journeys require navigating the application, and therefore sending it taps; the
+simulator's control tooling was not working during writing. The journeys are still described in
+full by the text — that is exactly what the rule above guarantees.

--- a/docs/en/user-stories.md
+++ b/docs/en/user-stories.md
@@ -1,0 +1,583 @@
+# User stories — StreamPulse
+
+> 🇫🇷 **Version française : [docs/user-stories.md](../user-stories.md)** — the
+> French version is the reference.
+
+> Version 1.2.0 — last revised: 2026-08-19
+
+Export of the project's user stories, until now visible only in Linear. An external system is
+neither versioned, nor archivable, nor readable by an examining board: this document makes them
+readable from the repository.
+
+Each story keeps **its original statement and acceptance criteria**, exactly as they were written
+before implementation — not a reconstruction after the fact. The traceability column links each
+one to the PR that delivered it.
+
+The corresponding verification scenarios live in the test book (`docs/cahier-de-recette.md`),
+delivered by a separate PR still open at the time of writing.
+
+---
+
+## Convention
+
+| Item | Meaning |
+|---|---|
+| **Identifier** | `US-<epic>-<rank>`. The Linear ticket (`STR-NNN`) is the technical identifier |
+| **Estimate** | In points, as set at scoping. Not reassessed since |
+| **Status** | Actual state in Linear as of 2026-08-19 |
+
+⚠️ **Six founding epics have no US number.** They were created before the `US-XX-YY` convention
+was adopted, and carry a free-form title. Later stories' dependencies nonetheless refer to them by
+number (`US-01-02`, `US-02-02`, `US-03-02`…). The mapping given further down is a **proposal for
+the team to confirm**: it is inferred from what the dependencies mean, not from a written
+decision.
+
+The dependency table below reproduces exactly what Linear contains, including these references to
+unassigned numbers.
+
+---
+
+## 1. Infrastructure & Setup
+
+### STR-5 — Git repository setup · ✅ Done
+
+As a developer, I want a well-structured Git repository with develop/main branches, so that
+collaborative work is organised and the production branch is protected.
+
+### STR-11 — Setting up Docker Compose · ✅ Done
+
+As a developer, I want a working Docker Compose environment, so that I can start every service
+(API, database, observability) with a single command.
+
+- **Given**: Docker and Docker Compose installed
+- **When**: I run `docker-compose up`
+- **Then**: the go-api, postgres, prometheus, grafana, loki and tempo services start without
+  error and are connected on an internal network.
+
+### STR-17 — GitHub Actions CI/CD pipeline · ✅ Done
+
+As a tech lead, I want an automated CI/CD pipeline, so that every push to main automatically
+triggers build, tests and deployment with no manual step.
+
+- **Given**: a commit pushed to main
+- **When**: the pipeline triggers
+- **Then**: the Go build succeeds, unit tests pass, the Docker image is built and the deployment
+  to the VPS runs — all in under 5 minutes.
+
+### STR-23 — 12-Factor App configuration · ✅ Done
+
+As a developer, I want all configuration externalised through environment variables, so that the
+project follows the 12-Factor App methodology and avoids any hard-coding.
+
+- **Given**: a documented `.env.example` file
+- **When**: I launch the application with injected environment variables
+- **Then**: the application starts correctly — no configuration value (JWT secret, database URL,
+  ports) is hard-coded in the source.
+
+### STR-28 — PostgreSQL database initialisation · ✅ Done
+
+As a backend developer, I want a versioned PostgreSQL schema, so that migrations are reproducible
+and the database stays consistent across environments.
+
+- **Given**: an empty PostgreSQL container
+- **When**: I run the migrations
+- **Then**: every table (users, streams, tracks, playlists, queue_items) is created with the
+  appropriate integrity constraints and indexes.
+
+> ⚠️ The shipped schema has **12 tables**, not five: the statement dates from the initial
+> scoping. See [`database.md`](database.md).
+
+### US-01-06 (STR-92) — Flutter mobile project setup · ✅ Done · 4 pts
+
+As a Flutter developer, I want a mobile project structured with Clean Architecture and every
+dependency configured, so that the team can start building features without any prior setup.
+
+- **Given**: the developer clones the repo and moves into `mobile/`
+- **When**: they run `flutter pub get` then `flutter analyze`
+- **Then**: the project compiles and the analysis reports no issue.
+
+---
+
+## 2. Authentication & Role Management
+
+### STR-33 — New user registration · ✅ Done
+
+As a visitor, I want to create an account with my email and a password, so that I can access the
+platform's personalised features.
+
+- **Given**: a visitor on the registration screen
+- **When**: they submit a valid email, a unique username and a password of at least 8 characters
+- **Then**: the account is created, the password is hashed with bcrypt (cost ≥ 12), a
+  confirmation is shown and the user can log in immediately.
+
+### STR-38 — Secure login with JWT · ✅ Done
+
+As a registered user, I want to log in with my email and password, so that I obtain a JWT token
+to access protected resources.
+
+- **Given**: a registered user
+- **When**: they enter the correct credentials
+- **Then**: the API returns a JWT access token (15 min expiry) and a refresh token (7-day
+  expiry) — the token carries the user's role in its claims.
+
+### STR-44 — User profile management · ✅ Done
+
+As a logged-in user, I want to view and edit my personal information, so that I can keep my
+profile up to date.
+
+- **Given**: a logged-in user on their profile
+- **When**: they change their username or avatar and confirm
+- **Then**: the changes are saved, the UI is updated and a confirmation is shown.
+
+### STR-49 — Requesting and activating the Broadcaster role · ✅ Done
+
+As a standard user, I want to request the Broadcaster role from my profile, so that I can create
+and manage live streams.
+
+- **Given**: a user with the standard User role
+- **When**: they submit a Broadcaster role request
+- **Then**: their request is pending, an admin can approve it from the dashboard — once
+  approved, the user gets the Broadcaster role and can create streams.
+
+### STR-54 — Password reset · ✅ Done
+
+As a user who forgot their password, I want to receive a reset link by email, so that I can
+recover access to my account.
+
+- **Given**: a valid email submitted on the "forgot password" screen
+- **When**: the user clicks the link they received (valid for 1 hour)
+- **Then**: they can set a new password — the old token is invalidated after use.
+
+### STR-59 — Account deletion (GDPR compliance) · ✅ Done
+
+As a logged-in user, I want to be able to permanently delete my account and all my data, so that
+I can exercise my right to erasure (GDPR Art. 17).
+
+- **Given**: an authenticated user confirming the deletion
+- **When**: they confirm the deletion (double confirmation)
+- **Then**: all their personal data (email, username, history, playlists, audio files) is
+  removed from the database and from storage.
+
+---
+
+## 3. Live Streaming Engine (Go Backend)
+
+### STR-64 — Creating and configuring a live stream · ✅ Done
+
+As a broadcaster, I want to create a new live stream with a title, a description and a
+visibility, so that I can prepare it before starting the broadcast.
+
+- **Given**: an authenticated broadcaster
+- **When**: they create a stream (title, description, public/private)
+- **Then**: the stream is persisted in the database with the status "inactive", a unique
+  identifier is generated and the broadcaster gets the stream's source URL.
+
+### STR-70 — HLS engine: segmentation and manifest generation · ✅ Done
+
+As the backend, I want to segment the incoming audio stream into ~10-second `.ts` files and
+generate a continuously updated `.m3u8` manifest, so that HLS playback by clients is possible.
+
+- **Given**: a broadcaster sends an AAC audio stream over HTTP multipart
+- **When**: the backend receives the stream
+- **Then**: `.ts` segments are generated every 10 seconds, the `.m3u8` manifest is updated with
+  the new segments, and a listener can fetch the manifest and start playback.
+
+### STR-77 — Starting and stopping the stream (broadcaster) · ✅ Done
+
+As a **broadcaster**, I want to **start** then **stop** my live stream, so that I can move a
+prepared stream (`idle`) into broadcast (`live`), then end it cleanly (`ended`) while warning
+listeners.
+
+- **Given**: an authenticated broadcaster, owner of an `idle` stream, with no other stream
+  already live
+- **When**: they start the stream (`PATCH /api/streams/{id}/start`)
+- **Then**: the status becomes `live`, `started_at` is set, a broadcast session is recorded in
+  memory (a cancellable goroutine), and the stream becomes visible in the list of live streams.
+
+- **Given**: a broadcaster who owns a `live` stream
+- **When**: they stop the stream (`PATCH /api/streams/{id}/stop`)
+- **Then**: the status becomes `ended`, `ended_at` is set, the session goroutine is released (no
+  leak), and subscribed listeners receive an `ended` event in real time (SSE).
+
+Additional criteria:
+
+- **Only one `live` stream at a time per broadcaster**: a `start` is refused (409) if the
+  broadcaster already has a stream live, or if the stream is not `idle`.
+- **Owner-only**: only the owner (`broadcaster` role) can `start`/`stop` (404 otherwise); `stop`
+  on a non-`live` stream → 409; `ended` is terminal.
+- **Real-time notification**: `GET /api/streams/{id}/events` exposes an SSE stream.
+- **Clean concurrency**: each session is cancelled through a `context.Context` on `stop` and on
+  server shutdown; the absence of goroutine leaks is checked by a test.
+
+### STR-87 — Scalability: handling N simultaneous listeners · ✅ Done
+
+As the system, I want to support at least 50 simultaneous listeners on the same stream, so that
+the Go streaming engine's scalability is proven.
+
+- **Given**: an active HLS stream
+- **When**: 50 HTTP clients simulate fetching the manifest and the segments
+- **Then**: p95 latency stays under 300 ms, memory consumption stays under 2 MB per connection
+  and no goroutine leak is detected via pprof.
+
+---
+
+## 4. Mobile Listener Experience (Flutter)
+
+### US-04-01 (STR-107) — Discovering and listing active streams · ✅ Done · 2 pts
+
+As a listener (or an anonymous visitor), I want to see the list of live streams, so that I can
+easily join a broadcast that interests me.
+
+- **Given**: active public streams exist
+- **When**: I open the home screen
+- **Then**: the list of active streams is shown with title, listener count and broadcast
+  duration — it refreshes automatically every 10 seconds.
+
+*Dependencies: US-03-01, US-02-02*
+
+### US-04-02 (STR-108) — HLS audio player (play/pause/volume) · ✅ Done · 4 pts
+
+As a listener, I want to listen to a live HLS stream with playback controls, so that I can enjoy
+a smooth audio experience.
+
+- **Given**: a joined active stream
+- **When**: the player opens
+- **Then**: playback starts automatically in under 3 seconds, the play/pause controls and the
+  volume setting work, the stream's title is shown and the rebuffering rate is under 2%.
+
+*Dependencies: US-03-02, US-04-01*
+
+> ⚠️ The **in-app volume control was not delivered**: volume is delegated to the hardware
+> buttons. This criterion from the brief remains open, tracked in STR-244.
+
+### US-04-03 (STR-109) — Background audio playback · ✅ Done · 3 pts
+
+As a listener, I want playback to continue when I leave the application, so that I can use my
+phone freely while listening.
+
+- **Given**: a stream currently being listened to
+- **When**: the user presses the Home button
+- **Then**: playback continues without interruption and the controls appear in the notification
+  bar and on the lock screen (iOS and Android).
+
+*Dependencies: US-04-02*
+
+### US-04-04 (STR-110) — Handling interruptions · ✅ Done · 2 pts
+
+As a listener, I want playback to pause during an incoming call and resume automatically
+afterwards, so that I do not miss any content.
+
+- **Given**: a stream playing in the background
+- **When**: an incoming phone call is received
+- **Then**: playback pauses automatically — and once the call ends, playback resumes from the
+  live stream's current point.
+
+*Dependencies: US-04-03*
+
+### US-04-05 (STR-111) — Adding a stream to favourites · ✅ Done · 1 pt
+
+As a logged-in user, I want to add a stream to my favourites, so that I can easily find it again
+the next time it broadcasts.
+
+- **Given**: a logged-in user on a stream's page
+- **When**: they tap the favourites icon
+- **Then**: the stream is added to their favourites list, the icon changes state — and the
+  stream appears in their Favourites tab.
+
+*Dependencies: US-04-01, US-02-02*
+
+---
+
+## 5. On-Demand Audio Library
+
+### US-05-01 (STR-130) — Uploading an audio track · ✅ Done · 3 pts
+
+As a broadcaster or a user, I want to upload an audio file (MP3/AAC/OGG), so that I can add it to
+my personal library.
+
+- **Given**: a logged-in user
+- **When**: they select an audio file of at most 50 MB in MP3/AAC/OGG format
+- **Then**: the file is uploaded, its MIME type is validated server-side, it is stored outside
+  the web-served directory and referenced in the database with its metadata (title, duration,
+  size).
+
+*Dependencies: US-02-02, US-01-05*
+
+### US-05-02 (STR-131) — Creating and managing playlists · ✅ Done · 2 pts
+
+As a logged-in user, I want to create, rename and delete my playlists, so that I can organise my
+personal music library.
+
+- **Given**: a logged-in user
+- **When**: they create a playlist with a name
+- **Then**: the playlist is created empty and appears in their list — they can rename or delete
+  it at any time, with confirmation before deletion.
+
+*Dependencies: US-02-02, US-01-05*
+
+### US-05-03 (STR-132) — Adding and reordering tracks · ✅ Done · 3 pts
+
+As a user, I want to add, remove and reorder a playlist's tracks, so that I can build a
+personalised listening queue.
+
+- **Given**: an existing playlist
+- **When**: the user adds a track or changes its order by drag-and-drop
+- **Then**: the change is persisted, the playlist shows the new order and the queue is updated.
+
+*Dependencies: US-05-01, US-05-02*
+
+### US-05-04 (STR-133) — Playing a playlist with a queue · ✅ Done · 3 pts
+
+As a user, I want to play my playlist with automatic advance to the next track, so that I can
+enjoy continuous listening with no intervention.
+
+- **Given**: a playlist with 3 or more tracks
+- **When**: the user starts playback
+- **Then**: tracks play one after another automatically, the queue is visible, the user can jump
+  to any track — playback continues in the background.
+
+*Dependencies: US-05-03, US-04-03*
+
+### US-05-05 (STR-134) — Shuffle and Repeat modes · ✅ Done · 1 pt
+
+As a user, I want to turn on shuffle playback or repetition (repeat track / repeat playlist), so
+that I can vary my listening experience.
+
+- **Given**: a playlist currently playing
+- **When**: the user turns on shuffle
+- **Then**: the playback order becomes random — and with repeat-one, the current track repeats
+  indefinitely.
+
+*Dependencies: US-05-04*
+
+---
+
+## 6. Broadcaster Dashboard
+
+### US-06-01 (STR-153) — Starting and stopping a stream from the dashboard · ✅ Done · 4 pts
+
+As a broadcaster, I want to start and stop my stream from a simplified interface, so that I can
+control my broadcast without technical complexity.
+
+- **Given**: a broadcaster on their dashboard
+- **When**: they tap **"Démarrer la diffusion"** (Start broadcasting)
+- **Then**: the application starts sending the audio stream to the backend, the stream's status
+  becomes **"En direct"** (Live) and the listener count is shown in real time.
+
+*Dependencies: US-03-03, US-02-04*
+
+### US-06-02 (STR-154) — Real-time broadcast statistics · ✅ Done · 2 pts
+
+As a broadcaster, I want to see my stream's statistics in real time (connected listeners,
+duration, disconnections), so that I can gauge my broadcast's audience.
+
+- **Given**: an active stream
+- **When**: I open my broadcaster dashboard
+- **Then**: the number of connected listeners is shown and updated every 5 seconds, along with
+  the total broadcast duration.
+
+*Dependencies: US-06-01, US-03-02*
+
+> ⚠️ The listener count is an **estimate**: HLS has no persistent connection. See
+> [ADR 025](../adr/025-statistiques-daudience-en-temps-reel.md).
+
+---
+
+## 7. Observability & Supervision
+
+### US-07-01 (STR-163) — Structured JSON logs · ✅ Done · 2 pts
+
+As an SRE, I want every Go backend log to be emitted in structured JSON format, so that it can be
+indexed automatically in Loki and analysed by third-party tools.
+
+- **Given**: the Go application running
+- **When**: an HTTP request is processed or an error occurs
+- **Then**: a JSON log is emitted with the fields timestamp, level, message, trace_id, service,
+  environment — no `fmt.Println()` exists in production.
+
+*Dependencies: US-01-02*
+
+### US-07-02 (STR-164) — OpenTelemetry instrumentation · ✅ Done · 4 pts
+
+As a developer, I want to instrument the Go backend with OpenTelemetry, so that I can trace a
+request's path from the mobile app all the way to the database.
+
+- **Given**: the Go OTEL SDK configured
+- **When**: a request reaches the API
+- **Then**: a span is created for each HTTP handler, SQL query spans are recorded, the trace_id
+  is propagated in the headers — and the full trace (mobile → API → DB) is visible in
+  Tempo/Grafana.
+
+*Dependencies: US-07-01, US-01-02*
+
+> ⚠️ **Partially met criterion.** The trace starts at the server: no `traceparent` is emitted by
+> the Flutter client. The `API → DB` leg is delivered, the `mobile →` leg is not. See
+> [ADR 020](../adr/020-traces-opentelemetry-otlp-tempo.md) and STR-244.
+
+### US-07-03 (STR-165) — Prometheus metrics + API & Infra panels · ✅ Done · 3 pts
+
+As an SRE, I want to expose HTTP and infrastructure metrics through Prometheus, so that I can
+visualise them in the Grafana API Backend and Infrastructure panels.
+
+- **Given**: the Go application started
+- **When**: Prometheus scrapes `/metrics` every 15 seconds
+- **Then**: the `http_requests_total`, `http_request_duration_seconds` (p50/p95/p99),
+  `go_goroutines` and `go_memstats_heap_alloc_bytes` metrics are collected and visible in
+  Grafana.
+
+*Dependencies: US-07-01, US-01-02*
+
+### US-07-04 (STR-166) — Grafana Live Streaming panel dashboard · ✅ Done · 3 pts
+
+As an SRE, I want a dashboard dedicated to live streaming, so that I can see in real time the
+number of active streams, connected listeners, HLS latency and the rebuffering rate.
+
+- **Given**: at least one active stream and connected listeners
+- **When**: I view Panel 1 in Grafana
+- **Then**: the gauges show the number of active streams, listeners connected per stream, p95
+  HLS latency and the error rate on `.ts` segments — with real data, not fixtures.
+
+*Dependencies: US-07-03, US-03-02*
+
+### US-07-05 (STR-167) — Logs & Errors panel + Alerts · ✅ Done · 3 pts
+
+As an SRE, I want to view logs in real time in Grafana and configure alerts on critical
+thresholds, so that I am notified proactively of incidents.
+
+- **Given**: JSON logs indexed in Loki and traces in Tempo
+- **When**: I view Panel 4
+- **Then**: logs filterable by level (info/warn/error) and by trace_id are visible — and an
+  alert fires if the HTTP 5xx error rate exceeds 5% over 5 minutes.
+
+*Dependencies: US-07-01, US-07-02, US-07-03*
+
+---
+
+## 8. Administrator Dashboard
+
+### US-08-01 (STR-191) — Listing, searching and managing users · ✅ Done · 3 pts
+
+As an administrator, I want to view and manage the complete list of users, so that I can oversee
+the community.
+
+- **Given**: an administrator logged in at `/admin`
+- **When**: they search for a user by name or filter by role
+- **Then**: the filtered list is shown — they can activate, deactivate or delete an account with
+  confirmation.
+
+*Dependencies: US-02-02, US-02-04*
+
+### US-08-02 (STR-192) — Supervising and interrupting active streams · ✅ Done · 2 pts
+
+As an administrator, I want to see every active stream and be able to interrupt one if needed, so
+that I can moderate the platform.
+
+- **Given**: an administrator on the dashboard
+- **When**: they select an active stream and click **"Interrompre"** (Interrupt)
+- **Then**: the stream is stopped immediately, listeners receive an end-of-broadcast
+  notification and an audit log entry is recorded.
+
+*Dependencies: US-03-03, US-08-01*
+
+---
+
+## 9. Bonus features
+
+The brief scores these features out of 5 points, on top of the 15 for the core scope.
+
+### US-09-01 (STR-200) — Live chat between listeners (WebSocket) · ⬜ Backlog · 5 pts
+
+As a listener on a stream, I want to send and receive messages in real time, so that I can
+interact with the community during the broadcast.
+
+- **Given**: several listeners connected to the same stream
+- **When**: one of them sends a text message
+- **Then**: every listener receives the message in under 500 ms over WebSocket — the broadcaster
+  can delete a message or ban a user from the chat.
+
+*Dependencies: US-03-02, US-02-02*
+
+### US-09-02 (STR-201) — Offline mode (playlist caching) · 🔵 In Review · 5 pts
+
+As a user, I want to make a playlist available offline, so that I can listen to my tracks without
+internet access.
+
+- **Given**: a playlist with tracks
+- **When**: the user turns on offline mode for that playlist
+- **Then**: the audio files are downloaded and cached locally — the playlist is accessible and
+  playable without a network, with a visual indication of the offline state.
+
+*Dependencies: US-05-04*
+
+### US-09-03 (STR-202) — Kubernetes deployment · ⬜ Backlog · 5 pts
+
+As a DevOps engineer, I want to deploy StreamPulse on a Kubernetes cluster with resource
+management, so that I can demonstrate production-grade cloud-native infrastructure.
+
+- **Given**: an available K8s cluster (Minikube or cloud)
+- **When**: I apply the kubectl manifests
+- **Then**: the Go API, PostgreSQL and the OTEL stack are deployed with configured resource
+  limits/requests, a HorizontalPodAutoscaler is active and the application responds on its
+  endpoint.
+
+*Dependencies: US-01-03*
+
+### US-09-04 (STR-203) — Simple recommendation algorithm · ⬜ Backlog · 4 pts
+
+As a user, I want to see recommended streams and playlists on my home page, so that I can
+discover content matching my taste.
+
+- **Given**: a user with a listening history
+- **When**: they open the home page
+- **Then**: a **"Recommandé pour vous"** (Recommended for you) section shows 5 streams or
+  playlists based on their most-listened categories (simplified collaborative filtering or
+  content-based).
+
+*Dependencies: US-04-02, US-05-04*
+
+### US-09-05 (STR-204) — On-the-fly transcoding (FFmpeg) · ✅ Done · 4 pts
+
+As the system, I want to transcode non-AAC audio formats on the fly with FFmpeg, so that I can
+accept any incoming format (MP3, OGG, WAV) for HLS broadcasting.
+
+- **Given**: a broadcaster sending an MP3 stream
+- **When**: the backend receives the stream
+- **Then**: FFmpeg transcodes the stream to AAC on the fly, the result is segmented into HLS and
+  listeners receive a clean AAC stream — the added latency from transcoding is under 2 seconds.
+
+*Dependencies: US-03-02*
+
+> ⚠️ This transcoding covers **ingest** (normalising the incoming format), not adapting the
+> bitrate to the listener's bandwidth. The brief, for its part, asks for the second. See
+> [ADR 030](../adr/030-transcodage-a-la-volee-des-formats-dingest.md).
+
+---
+
+## Mapping the unnumbered epics
+
+⚠️ **Proposal, to be confirmed by the team.** These mappings are inferred from what the
+dependencies declared in Linear mean; no written decision fixes them.
+
+| Number cited as a dependency | Likely epic | Ticket |
+|---|---|---|
+| US-01-02 | Setting up Docker Compose | STR-11 |
+| US-01-03 | GitHub Actions CI/CD pipeline | STR-17 |
+| US-01-05 | PostgreSQL database initialisation | STR-28 |
+| US-01-06 | Flutter project setup | STR-92 ✅ *(confirmed by the title)* |
+| US-02-02 | Secure login with JWT | STR-38 |
+| US-02-04 | Requesting and activating the Broadcaster role | STR-49 |
+| US-03-01 | Creating and configuring a live stream | STR-64 |
+| US-03-02 | HLS engine: segmentation and manifest | STR-70 |
+| US-03-03 | Starting and stopping the stream | STR-77 |
+
+Numbers `US-01-01` and `US-01-04` are not cited by any dependency; they most likely correspond to
+STR-5 (Git repository) and STR-23 (12-Factor), with no way to tell which is which.
+
+---
+
+## What this document does not cover
+
+- Each story's **sub-tasks** (about a hundred `STR-NNN` tickets with no user-facing statement):
+  they describe implementation steps, not user expectations.
+- The **fix tickets** opened after the compliance audit (STR-232 to STR-245): they live in a
+  separate Linear project and are not user stories.

--- a/docs/en/user-stories.md
+++ b/docs/en/user-stories.md
@@ -202,9 +202,10 @@ listeners.
 Additional criteria:
 
 - **Only one `live` stream at a time per broadcaster**: a `start` is refused (409) if the
-  broadcaster already has a stream live, or if the stream is not `idle`.
+  broadcaster already has a stream live, or if the stream is already `live` — an `idle` or
+  `ended` stream can start (ADR 048).
 - **Owner-only**: only the owner (`broadcaster` role) can `start`/`stop` (404 otherwise); `stop`
-  on a non-`live` stream → 409; `ended` is terminal.
+  on a non-`live` stream → 409; `ended` restarts (`ended → live`, ADR 048).
 - **Real-time notification**: `GET /api/streams/{id}/events` exposes an SSE stream.
 - **Clean concurrency**: each session is cancelled through a `context.Context` on `stop` and on
   server shutdown; the absence of goroutine leaks is checked by a test.

--- a/docs/manuel-utilisateur.md
+++ b/docs/manuel-utilisateur.md
@@ -1,5 +1,7 @@
 # Manuel utilisateur
 
+> 🇬🇧 **English version: [en/user-manual.md](en/user-manual.md)**
+
 Ce guide s'adresse aux personnes qui **utilisent** StreamPulse, pas à celles qui
 le développent. Aucune commande, aucun terminal : tout se fait depuis
 l'application.

--- a/docs/plan-formation.md
+++ b/docs/plan-formation.md
@@ -1,5 +1,7 @@
 # Plan de formation des utilisateurs
 
+> 🇬🇧 **English version: [en/training-plan.md](en/training-plan.md)**
+
 Comment amener chaque public à l'autonomie sur StreamPulse, y compris les
 personnes en situation de handicap.
 

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -204,9 +204,10 @@ prévenant les auditeurs.
 Critères complémentaires :
 
 - **Un seul flux `live` à la fois par diffuseur** : un `start` est refusé (409) si le diffuseur
-  a déjà un flux en direct, ou si le flux n'est pas `idle`.
+  a déjà un flux en direct, ou si le flux est déjà `live` — un flux `idle` ou `ended` se lance
+  (ADR 048).
 - **Owner-only** : seul le propriétaire (rôle `broadcaster`) peut `start`/`stop` (404 sinon) ;
-  `stop` sur un flux non-`live` → 409 ; `ended` est terminal.
+  `stop` sur un flux non-`live` → 409 ; `ended` se relance (`ended → live`, ADR 048).
 - **Notification temps réel** : `GET /api/streams/{id}/events` expose un flux SSE.
 - **Concurrence propre** : chaque session est annulée via `context.Context` au `stop` et à
   l'arrêt du serveur ; absence de fuite de goroutines vérifiée par test.

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -1,5 +1,7 @@
 # User stories — StreamPulse
 
+> 🇬🇧 **English version: [en/user-stories.md](en/user-stories.md)**
+
 > Version : 1.2.0 — dernière révision : 2026-08-19
 
 Export des user stories du projet, jusqu'ici visibles uniquement dans Linear. Un système


### PR DESCRIPTION
## Résumé

Traduit en anglais et ajoute dans `docs/en/` les six documents suivants, en complément des cinq déjà bilingues (`README.md`, `architecture.md`, `infrastructure.md`/`operations.md`, `securite.md`/`security.md`, index des ADR) :

**Obligatoire (Ce3.6.2 — documentation technique bilingue)**
- `docs/user-stories.md` → `docs/en/user-stories.md`
- `docs/database.md` → `docs/en/database.md`

**Recommandé, chacun comblant un trou sur un sous-critère précis**
- `docs/diagrammes.md` → `docs/en/diagrams.md` — Ce3.6.1 nomme explicitement les diagrammes UML/BPMN standardisés
- `docs/plan-formation.md` → `docs/en/training-plan.md` — Ce3.6.5 porte spécifiquement sur le plan de formation
- `docs/accessibilite.md` → `docs/en/accessibility.md` — Ce3.6.4 porte sur la documentation d'accessibilité
- `docs/manuel-utilisateur.md` → `docs/en/user-manual.md` — Ce3.6.4 également ; un lecteur anglophone n'avait jusqu'ici aucun manuel

Aucun des quatre documents recommandés ne s'est avéré disproportionné en taille — tous les six ont été traduits intégralement.

**Non traduits, comme demandé** : `cahier-de-recette.md` (hors périmètre Ce3.6, relève de C3.2), `rgpd.md`, `cgu.md`, `politique-confidentialite.md` (non nommés par un sous-critère Ce3.6).

## Conventions suivies

- Structure Markdown préservée à l'identique (vérifié : nombre de titres `#`/`##`/`###` strictement identique entre chaque source et sa traduction).
- Identifiants techniques, routes API, noms de tables/colonnes non traduits.
- Liens croisés vers un autre document `docs/` : vers la version anglaise quand elle existe, vers le fichier français sinon — même traitement que les 5 documents déjà bilingues.
- Anglais britannique (orthographe et vocabulaire), pour rester cohérent avec les 5 documents existants (`summarised`, `licence`, `favourites`, etc.).
- Chaque fichier français traduit reçoit désormais le renvoi réciproque `🇬🇧 English version: […]` en tête de document — convention déjà appliquée à `architecture.md`, `securite.md` et `infrastructure.md`, maintenant étendue aux six nouveaux.

## Mises à jour de cohérence (hors périmètre strict mais nécessaires)

- `docs/README.md` (§ Périmètre bilingue) et `docs/en/README.md` : les six documents étaient explicitement listés comme « français uniquement, et pourquoi » (manuel utilisateur, plan de formation, déclaration d'accessibilité, user stories) — ces tableaux sont mis à jour pour refléter le nouveau périmètre. `cahier-de-recette.md` reste seul dans la ligne « français uniquement » désormais que les user stories en sont retirées.
- `docs/en/architecture.md` : le renvoi vers `accessibilite.md` § 6 pointe maintenant vers `accessibility.md`, devenu disponible.
- `docs/accessibilite.md` § 6, point 3 (« la documentation n'existe qu'en français ») : la traduction anglaise de ce point a été adaptée plutôt que traduite mot à mot, pour ne pas être auto-contradictoire (le fichier anglais qui affirmerait n'exister qu'en français). Elle renvoie maintenant vers la déclaration de périmètre bilingue de `docs/README.md`. Le fichier français source n'a pas été modifié sur ce point — seule sa traduction anglaise reflète l'état actuel.
- `docs/plan-formation.md` § 3 contient un schéma en caractères de dessin de boîtes ; sa traduction anglaise le rend en Mermaid, par la même logique d'accessibilité qui a déjà motivé la conversion dans `architecture.md` (un lecteur d'écran vocalise l'ASCII art caractère par caractère). Le fichier français source n'a pas été touché.

## Organisation des commits

1. `docs: traduire les user stories et le schéma de base de données en anglais` — les deux documents obligatoires.
2. `docs: traduire les diagrammes, le plan de formation, l'accessibilité et le manuel utilisateur en anglais` — les quatre documents recommandés, plus les mises à jour de cohérence ci-dessus (qui touchent aux six documents ensemble).